### PR TITLE
feat: 볼륨/챕터 단위 읽기 진행도 연동 및 볼륨 상세 페이지 UI 개선

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -139,6 +139,7 @@ func main() {
 	volumes := protected.Group("/volumes")
 	volumes.Get("/:id", seriesHandler.GetVolume)
 	volumes.Get("/:volumeId/chapters", seriesHandler.ListChapters)
+	volumes.Get("/:volumeId/progress", progressHandler.GetVolumeProgress)
 	volumes.Get("/:id/thumbnail", func(c *fiber.Ctx) error {
 		c.Locals("type", "volumes")
 		return imageHandler.GetThumbnail(c)

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -161,5 +161,57 @@ func Migrate() error {
 		DB.Exec(query)
 	}
 
+	// 마이그레이션: reading_progress 테이블 UNIQUE 제약조건 변경 (user_id, series_id) → (user_id, chapter_id)
+	// SQLite에서는 ALTER TABLE로 UNIQUE 변경 불가하므로 새 테이블 생성 후 데이터 이전
+	migrateReadingProgress()
+
 	return nil
+}
+
+// migrateReadingProgress reading_progress 테이블 UNIQUE 제약조건 마이그레이션
+// (user_id, series_id) → (user_id, chapter_id)로 변경하여 챕터별 진행도 저장 가능하게 함
+func migrateReadingProgress() {
+	// 이미 마이그레이션 되었는지 확인 (새 테이블이 있거나 기존 테이블에 새 인덱스가 있으면 skip)
+	var count int
+	err := DB.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_progress_chapter'`).Scan(&count)
+	if err == nil && count > 0 {
+		return // 이미 마이그레이션 완료
+	}
+
+	// 새 테이블 생성
+	_, err = DB.Exec(`
+		CREATE TABLE IF NOT EXISTS reading_progress_new (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			series_id TEXT NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+			volume_id TEXT REFERENCES volumes(id) ON DELETE SET NULL,
+			chapter_id TEXT NOT NULL REFERENCES chapters(id) ON DELETE CASCADE,
+			current_page INTEGER NOT NULL DEFAULT 0,
+			total_pages INTEGER NOT NULL DEFAULT 0,
+			progress_percent REAL DEFAULT 0.0,
+			device_id TEXT,
+			device_name TEXT,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(user_id, chapter_id)
+		)
+	`)
+	if err != nil {
+		// 이미 존재하면 무시
+		return
+	}
+
+	// 기존 데이터 이전 (chapter_id가 있는 것만)
+	DB.Exec(`
+		INSERT OR IGNORE INTO reading_progress_new 
+		SELECT * FROM reading_progress WHERE chapter_id IS NOT NULL
+	`)
+
+	// 기존 테이블 삭제 및 이름 변경
+	DB.Exec(`DROP TABLE IF EXISTS reading_progress`)
+	DB.Exec(`ALTER TABLE reading_progress_new RENAME TO reading_progress`)
+
+	// 인덱스 생성
+	DB.Exec(`CREATE INDEX IF NOT EXISTS idx_progress_user ON reading_progress(user_id)`)
+	DB.Exec(`CREATE INDEX IF NOT EXISTS idx_progress_series ON reading_progress(series_id)`)
+	DB.Exec(`CREATE INDEX IF NOT EXISTS idx_progress_chapter ON reading_progress(chapter_id)`)
 }

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -69,6 +69,28 @@ func (h *ProgressHandler) GetProgress(c *fiber.Ctx) error {
 	})
 }
 
+// GetVolumeProgress 볼륨 내 모든 챕터 읽기 진행도 조회
+// GET /api/v1/volumes/:volumeId/progress
+func (h *ProgressHandler) GetVolumeProgress(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	volumeID := c.Params("volumeId")
+
+	progressList, err := h.progressRepo.FindByUserAndVolume(userID, volumeID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to fetch progress",
+		})
+	}
+
+	if progressList == nil {
+		progressList = []model.ReadingProgress{}
+	}
+
+	return c.JSON(fiber.Map{
+		"progress_list": progressList,
+	})
+}
+
 // UpdateProgress 읽기 진행도 업데이트
 // PATCH /api/v1/series/:seriesId/progress
 func (h *ProgressHandler) UpdateProgress(c *fiber.Ctx) error {

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -504,6 +504,17 @@ func (h *SeriesHandler) GetVolume(c *fiber.Ctx) error {
 		})
 	}
 
+	// 썸네일 URL 설정
+	if volume.ThumbnailPath == nil || *volume.ThumbnailPath == "" {
+		pageID, err := h.volumeRepo.GetFirstPageID(volume.ID)
+		if err == nil && pageID != "" {
+			url := fmt.Sprintf("/api/v1/pages/%s/image?width=400", pageID)
+			volume.ThumbnailURL = &url
+		}
+	} else {
+		// 커스텀 썸네일이 있는 경우 (필요시 구현)
+	}
+
 	return c.JSON(volume)
 }
 
@@ -521,6 +532,16 @@ func (h *SeriesHandler) ListChapters(c *fiber.Ctx) error {
 
 	if chapters == nil {
 		chapters = []model.Chapter{}
+	}
+
+	// 썸네일 URL 설정
+	for i := range chapters {
+		// 챕터는 보통 별도 썸네일 파일이 없으므로 항상 첫 페이지를 썸네일로 사용
+		pageID, err := h.chapterRepo.GetFirstPageID(chapters[i].ID)
+		if err == nil && pageID != "" {
+			url := fmt.Sprintf("/api/v1/pages/%s/image?width=400", pageID)
+			chapters[i].ThumbnailURL = &url
+		}
 	}
 
 	return c.JSON(fiber.Map{

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -71,6 +71,7 @@ type Chapter struct {
 	ChapterNumber int       `json:"chapter_number"`
 	Path          string    `json:"path"`
 	PageCount     int       `json:"page_count"`
+	ThumbnailURL  *string   `json:"thumbnail_url,omitempty" db:"-"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 }

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/aha-hyeong/kumiho/backend/internal/database"
@@ -87,4 +88,21 @@ func (r *ChapterRepository) UpdatePageCount(id string, pageCount int) error {
 		pageCount, time.Now(), id,
 	)
 	return err
+}
+
+// GetFirstPageID 챕터의 첫 번째 페이지 ID 조회 (썸네일용)
+func (r *ChapterRepository) GetFirstPageID(chapterID string) (string, error) {
+	var pageID string
+	err := database.DB.QueryRow(
+		`SELECT id FROM pages WHERE chapter_id = ? ORDER BY page_number LIMIT 1`,
+		chapterID,
+	).Scan(&pageID)
+
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return pageID, nil
 }

--- a/backend/internal/repository/progress_repository.go
+++ b/backend/internal/repository/progress_repository.go
@@ -15,13 +15,18 @@ func NewReadingProgressRepository() *ReadingProgressRepository {
 	return &ReadingProgressRepository{}
 }
 
-// Upsert 읽기 진행도 생성 또는 업데이트
+// Upsert 읽기 진행도 생성 또는 업데이트 (챕터별)
 func (r *ReadingProgressRepository) Upsert(progress *model.ReadingProgress) error {
 	now := time.Now()
 	progress.UpdatedAt = now
 
-	// 기존 진행도 조회
-	existing, err := r.FindByUserAndSeries(progress.UserID, progress.SeriesID)
+	// chapter_id가 없으면 에러
+	if progress.ChapterID == nil || *progress.ChapterID == "" {
+		return nil // 챕터 ID 없으면 저장하지 않음
+	}
+
+	// 기존 진행도 조회 (챕터별)
+	existing, err := r.FindByUserAndChapter(progress.UserID, *progress.ChapterID)
 	if err != nil {
 		return err
 	}
@@ -42,10 +47,10 @@ func (r *ReadingProgressRepository) Upsert(progress *model.ReadingProgress) erro
 		progress.ID = existing.ID
 		_, err = database.DB.Exec(
 			`UPDATE reading_progress SET 
-			 volume_id = ?, chapter_id = ?, current_page = ?, total_pages = ?, 
+			 volume_id = ?, current_page = ?, total_pages = ?, 
 			 progress_percent = ?, device_id = ?, device_name = ?, updated_at = ?
 			 WHERE id = ?`,
-			progress.VolumeID, progress.ChapterID, progress.CurrentPage, progress.TotalPages,
+			progress.VolumeID, progress.CurrentPage, progress.TotalPages,
 			progress.ProgressPercent, progress.DeviceID, progress.DeviceName, progress.UpdatedAt,
 			progress.ID,
 		)
@@ -53,15 +58,17 @@ func (r *ReadingProgressRepository) Upsert(progress *model.ReadingProgress) erro
 	return err
 }
 
-// FindByUserAndSeries 사용자와 시리즈로 진행도 조회
+// FindByUserAndSeries 사용자와 시리즈의 가장 최근 진행도 조회
 func (r *ReadingProgressRepository) FindByUserAndSeries(userID, seriesID string) (*model.ReadingProgress, error) {
 	var p model.ReadingProgress
 	var volumeID, chapterID, deviceID, deviceName sql.NullString
 
+	// 시리즈 내 가장 최근 읽은 챕터 진행도 반환
 	err := database.DB.QueryRow(
 		`SELECT id, user_id, series_id, volume_id, chapter_id, current_page, total_pages, 
 		 progress_percent, device_id, device_name, updated_at
-		 FROM reading_progress WHERE user_id = ? AND series_id = ?`,
+		 FROM reading_progress WHERE user_id = ? AND series_id = ?
+		 ORDER BY updated_at DESC LIMIT 1`,
 		userID, seriesID,
 	).Scan(&p.ID, &p.UserID, &p.SeriesID, &volumeID, &chapterID,
 		&p.CurrentPage, &p.TotalPages, &p.ProgressPercent, &deviceID, &deviceName, &p.UpdatedAt)
@@ -78,6 +85,42 @@ func (r *ReadingProgressRepository) FindByUserAndSeries(userID, seriesID string)
 	}
 	if chapterID.Valid {
 		p.ChapterID = &chapterID.String
+	}
+	if deviceID.Valid {
+		p.DeviceID = &deviceID.String
+	}
+	if deviceName.Valid {
+		p.DeviceName = &deviceName.String
+	}
+
+	return &p, nil
+}
+
+// FindByUserAndChapter 사용자와 챕터로 진행도 조회
+func (r *ReadingProgressRepository) FindByUserAndChapter(userID, chapterID string) (*model.ReadingProgress, error) {
+	var p model.ReadingProgress
+	var volumeID, chapterIDNull, deviceID, deviceName sql.NullString
+
+	err := database.DB.QueryRow(
+		`SELECT id, user_id, series_id, volume_id, chapter_id, current_page, total_pages, 
+		 progress_percent, device_id, device_name, updated_at
+		 FROM reading_progress WHERE user_id = ? AND chapter_id = ?`,
+		userID, chapterID,
+	).Scan(&p.ID, &p.UserID, &p.SeriesID, &volumeID, &chapterIDNull,
+		&p.CurrentPage, &p.TotalPages, &p.ProgressPercent, &deviceID, &deviceName, &p.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if volumeID.Valid {
+		p.VolumeID = &volumeID.String
+	}
+	if chapterIDNull.Valid {
+		p.ChapterID = &chapterIDNull.String
 	}
 	if deviceID.Valid {
 		p.DeviceID = &deviceID.String
@@ -179,4 +222,49 @@ func (r *ReadingProgressRepository) FindRecentByUser(userID string, limit int) (
 func (r *ReadingProgressRepository) Delete(id string) error {
 	_, err := database.DB.Exec(`DELETE FROM reading_progress WHERE id = ?`, id)
 	return err
+}
+
+// FindByUserAndVolume 사용자와 볼륨의 모든 챕터 진행도 조회
+func (r *ReadingProgressRepository) FindByUserAndVolume(userID, volumeID string) ([]model.ReadingProgress, error) {
+	rows, err := database.DB.Query(
+		`SELECT rp.id, rp.user_id, rp.series_id, rp.volume_id, rp.chapter_id, rp.current_page, 
+		 rp.total_pages, rp.progress_percent, rp.device_id, rp.device_name, rp.updated_at
+		 FROM reading_progress rp
+		 LEFT JOIN chapters c ON rp.chapter_id = c.id
+		 WHERE rp.user_id = ? AND (rp.volume_id = ? OR c.volume_id = ?)
+		 ORDER BY c.chapter_number ASC`,
+		userID, volumeID, volumeID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var progressList []model.ReadingProgress
+	for rows.Next() {
+		var p model.ReadingProgress
+		var volID, chapID, devID, devName sql.NullString
+
+		if err := rows.Scan(&p.ID, &p.UserID, &p.SeriesID, &volID, &chapID,
+			&p.CurrentPage, &p.TotalPages, &p.ProgressPercent, &devID, &devName, &p.UpdatedAt); err != nil {
+			return nil, err
+		}
+
+		if volID.Valid {
+			p.VolumeID = &volID.String
+		}
+		if chapID.Valid {
+			p.ChapterID = &chapID.String
+		}
+		if devID.Valid {
+			p.DeviceID = &devID.String
+		}
+		if devName.Valid {
+			p.DeviceName = &devName.String
+		}
+
+		progressList = append(progressList, p)
+	}
+
+	return progressList, nil
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage, RegisterPage } from "./pages/Auth";
 import { HomePage } from "./pages/Home";
 import { LibraryPage } from "./pages/Library";
 import { SeriesPage } from "./pages/Series";
+import { VolumePage } from "./pages/Volume";
 import { ViewerPage } from "./pages/Viewer";
 import { api } from "./api/client";
 import "./App.css";
@@ -191,6 +192,14 @@ function App() {
           element={
             <ProtectedRoute>
               <SeriesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/volumes/:volumeId"
+          element={
+            <ProtectedRoute>
+              <VolumePage />
             </ProtectedRoute>
           }
         />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -111,6 +111,7 @@ export const seriesAPI = {
 export const volumeAPI = {
   get: (id: string) => api.get(`/volumes/${id}`),
   getChapters: (volumeId: string) => api.get(`/volumes/${volumeId}/chapters`),
+  getProgress: (volumeId: string) => api.get(`/volumes/${volumeId}/progress`),
 };
 
 // Chapter API

--- a/web/src/components/SeriesInfoCard.css
+++ b/web/src/components/SeriesInfoCard.css
@@ -151,6 +151,7 @@
   background: rgba(0, 0, 0, 0.2);
   padding: 1rem;
   border-radius: 12px;
+  width: 350px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;

--- a/web/src/pages/Series.css
+++ b/web/src/pages/Series.css
@@ -16,6 +16,7 @@
 
 .sub-header-left {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 1rem;
 }

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -3,10 +3,10 @@ import { useParams, Link, useNavigate } from "react-router-dom";
 import { BookOpen, ArrowLeft, Folder, Play } from "lucide-react";
 import { Header } from "../components/Header";
 import { Sidebar } from "../components/Sidebar";
-import { api, volumeAPI } from "../api/client";
+import { api } from "../api/client";
 import "./Series.css";
 
-import type { Series, Volume, Library, ReadingProgress, Chapter } from "../types/series";
+import type { Series, Volume, Library, ReadingProgress } from "../types/series";
 import { SeriesInfoCard } from "../components/SeriesInfoCard";
 import { AlertModal, type AlertType } from "../components/AlertModal";
 
@@ -18,7 +18,7 @@ export function SeriesPage() {
   const [library, setLibrary] = useState<Library | null>(null);
   const [progress, setProgress] = useState<ReadingProgress | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
-  const [openingVolumeId, setOpeningVolumeId] = useState<string | null>(null);
+  // openingVolumeId 제거
 
   // 사이드바 상태
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -42,28 +42,10 @@ export function SeriesPage() {
     setAlertModal((prev) => ({ ...prev, isOpen: false }));
   };
 
-  // 볼륨 클릭 시 첫 번째 챕터로 뷰어 이동
-  const handleVolumeClick = async (volume: Volume, e: React.MouseEvent) => {
+  // 볼륨 클릭 시 볼륨 상세 페이지로 이동
+  const handleVolumeClick = (volume: Volume, e: React.MouseEvent) => {
     e.preventDefault();
-    setOpeningVolumeId(volume.id);
-
-    try {
-      const res = await volumeAPI.getChapters(volume.id);
-      const chapters: Chapter[] = res.data.chapters || [];
-
-      if (chapters.length > 0) {
-        // 챕터 번호순 정렬 후 첫 번째 챕터로 이동
-        const sortedChapters = [...chapters].sort((a, b) => a.chapter_number - b.chapter_number);
-        navigate(`/viewer/${sortedChapters[0].id}`);
-      } else {
-        showAlert("읽을 수 있는 챕터가 없습니다.", "warning");
-      }
-    } catch (error) {
-      console.error("챕터 로드 실패:", error);
-      showAlert("챕터를 불러올 수 없습니다.", "error");
-    } finally {
-      setOpeningVolumeId(null);
-    }
+    navigate(`/volumes/${volume.id}`);
   };
 
   useEffect(() => {
@@ -207,7 +189,7 @@ export function SeriesPage() {
             {volumes.map((volume) => (
               <div
                 key={volume.id}
-                className={`volume-card ${openingVolumeId === volume.id ? "loading" : ""}`}
+                className="volume-card"
                 onClick={(e) => handleVolumeClick(volume, e)}
                 role="button"
                 tabIndex={0}
@@ -231,14 +213,10 @@ export function SeriesPage() {
                   )}
                   {/* 재생 오버레이 */}
                   <div className="volume-play-overlay">
-                    {openingVolumeId === volume.id ? (
-                      <div className="loading-spinner small" />
-                    ) : (
-                      <Play
-                        size={32}
-                        fill="white"
-                      />
-                    )}
+                    <Play
+                      size={32}
+                      fill="white"
+                    />
                   </div>
                 </div>
                 <div className="volume-info">

--- a/web/src/pages/Volume.css
+++ b/web/src/pages/Volume.css
@@ -1,0 +1,225 @@
+/* Volume Page Styles */
+
+.sub-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sub-header-left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+}
+
+.back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.back-button:hover {
+  color: var(--text-primary);
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.breadcrumb-link:hover {
+  color: var(--primary-color);
+}
+
+.breadcrumb-current {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* SeriesInfoCard Override or Specifics */
+/* .series-info-card 스타일은 import된 CSS를 사용하되, 여기서 위치 조정 등 필요하면 추가 */
+
+.volume-main {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.chapter-count {
+  font-size: 1rem;
+  color: var(--text-primary);
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.chapter-count strong {
+  color: var(--primary-color);
+}
+
+.chapter-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chapter-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem;
+  background: var(--bg-primary);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.chapter-item:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
+  transform: translateY(-1px);
+}
+
+.chapter-item.current {
+  border-color: var(--primary-color);
+  background: rgba(102, 126, 234, 0.05);
+}
+
+.chapter-item.loading {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+/* 챕터 썸네일 */
+.chapter-thumbnail-wrapper {
+  width: 80px;
+  height: 60px; /* 가로형 썸네일 비율 */
+  background-color: var(--card-bg);
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  position: relative;
+}
+
+/* 세로형 썸네일 대응을 위해 object-fit: cover 사용 */
+.chapter-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chapter-thumbnail-placeholder {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+.chapter-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.chapter-number {
+  font-weight: 600;
+  color: var(--primary-color);
+  font-size: 0.9rem;
+}
+
+.chapter-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.chapter-pages {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.chapter-status {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-left: 1rem;
+}
+
+.complete-icon {
+  color: #10b981;
+}
+
+.progress-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--bg-tertiary); /* 눈에 덜 띄게 변경 */
+  color: var(--text-secondary);
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+
+.play-icon {
+  color: var(--text-muted);
+  transition: color 0.2s;
+  opacity: 0; /* 기본적으로 숨김 */
+}
+
+.chapter-item:hover .play-icon {
+  opacity: 1;
+  color: var(--primary-color);
+}
+
+.loading-spinner.small {
+  width: 18px;
+  height: 18px;
+  border-width: 2px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-muted);
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .chapter-item {
+    align-items: flex-start;
+  }
+
+  .chapter-thumbnail-wrapper {
+    width: 60px;
+    height: 45px;
+  }
+
+  .chapter-info {
+    justify-content: center;
+  }
+
+  .chapter-title {
+    font-size: 0.95rem;
+  }
+}

--- a/web/src/pages/Volume.tsx
+++ b/web/src/pages/Volume.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useState } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { BookOpen, ArrowLeft, Folder, Play, CheckCircle } from "lucide-react";
+import { Header } from "../components/Header";
+import { Sidebar } from "../components/Sidebar";
+import { api, volumeAPI } from "../api/client";
+import "../components/SeriesInfoCard.css"; // SeriesInfoCard 스타일 재사용
+import "./Volume.css";
+
+import type { Series, Volume, Chapter, ReadingProgress } from "../types/series";
+import { AlertModal, type AlertType } from "../components/AlertModal";
+
+export function VolumePage() {
+  const { volumeId } = useParams<{ volumeId: string }>();
+  const navigate = useNavigate();
+  const [volume, setVolume] = useState<Volume | null>(null);
+  const [series, setSeries] = useState<Series | null>(null);
+  const [chapters, setChapters] = useState<Chapter[]>([]);
+  // 챕터 ID를 키로 하는 진행도 맵
+  const [progressMap, setProgressMap] = useState<Record<string, ReadingProgress>>({});
+  // 이 볼륨의 마지막 진행도 (이어보기용)
+  const [lastProgress, setLastProgress] = useState<ReadingProgress | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [openingChapterId, setOpeningChapterId] = useState<string | null>(null);
+
+  // 사이드바 상태
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // 알림 모달 상태
+  const [alertModal, setAlertModal] = useState<{
+    isOpen: boolean;
+    type: AlertType;
+    message: string;
+  }>({
+    isOpen: false,
+    type: "info",
+    message: "",
+  });
+
+  const showAlert = (message: string, type: AlertType = "info") => {
+    setAlertModal({ isOpen: true, type, message });
+  };
+
+  const closeAlert = () => {
+    setAlertModal((prev) => ({ ...prev, isOpen: false }));
+  };
+
+  // 챕터 클릭 시 뷰어로 이동
+  const handleChapterClick = (chapter: Chapter, e: React.MouseEvent) => {
+    e.preventDefault();
+    setOpeningChapterId(chapter.id);
+
+    // 해당 챕터의 진행도 확인
+    const chapterProgress = progressMap[chapter.id];
+
+    if (chapterProgress && chapterProgress.current_page > 0) {
+      // 100% 완료가 아니면 이어서 읽기
+      if (chapterProgress.progress_percent < 100) {
+        navigate(`/viewer/${chapter.id}?page=${chapterProgress.current_page}`);
+        return;
+      }
+    }
+
+    // 새로 시작
+    navigate(`/viewer/${chapter.id}`);
+  };
+
+  useEffect(() => {
+    if (volumeId) loadData();
+  }, [volumeId]);
+
+  const loadData = async () => {
+    try {
+      // 볼륨 정보
+      const volumeRes = await volumeAPI.get(volumeId!);
+      setVolume(volumeRes.data);
+
+      // 시리즈 정보
+      if (volumeRes.data.series_id) {
+        const seriesRes = await api.get(`/series/${volumeRes.data.series_id}`);
+        setSeries(seriesRes.data);
+      }
+
+      // 읽기 진행도 (볼륨 내 모든 챕터)
+      try {
+        const progressRes = await volumeAPI.getProgress(volumeId!);
+        const list: ReadingProgress[] = progressRes.data.progress_list || [];
+
+        // 맵으로 변환
+        const map: Record<string, ReadingProgress> = {};
+
+        // 가장 최근 읽은 기록 찾기
+        let latest: ReadingProgress | undefined = undefined;
+        let latestTime = 0;
+
+        list.forEach((p) => {
+          if (p.chapter_id) {
+            map[p.chapter_id] = p;
+
+            // 최근 기록 갱신
+            const time = new Date(p.updated_at).getTime();
+            if (time > latestTime) {
+              latestTime = time;
+              latest = p;
+            }
+          }
+        });
+
+        setProgressMap(map);
+        setLastProgress(latest);
+      } catch (err) {
+        console.warn("진행도 로드 실패:", err);
+      }
+
+      // 챕터 목록
+      const chaptersRes = await volumeAPI.getChapters(volumeId!);
+      const chapterList = chaptersRes.data.chapters || [];
+      // 챕터 번호순 정렬
+      setChapters(chapterList.sort((a: Chapter, b: Chapter) => a.chapter_number - b.chapter_number));
+    } catch (error) {
+      console.error("Failed to load volume:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="page-container">
+        <Header />
+        <div className="loading-container">
+          <div className="loading-spinner" />
+          <p>로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!volume) {
+    return (
+      <div className="page-container">
+        <Header />
+        <div className="error-container">
+          <p>볼륨을 찾을 수 없습니다</p>
+          <Link
+            to="/"
+            className="back-link"
+          >
+            홈으로
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // 이어보기 또는 첫 챕터 읽기
+  const handlePlay = () => {
+    // 가장 최근 읽은 챕터가 있으면 거기로
+    if (lastProgress && lastProgress.chapter_id) {
+      navigate(`/viewer/${lastProgress.chapter_id}?page=${lastProgress.current_page}`);
+      return;
+    }
+
+    // 진행도가 없으면 첫 챕터 읽기
+    if (chapters.length > 0) {
+      navigate(`/viewer/${chapters[0].id}`);
+    } else {
+      showAlert("읽을 수 있는 챕터가 없습니다.", "warning");
+    }
+  };
+
+  // 썸네일 URL
+  const getThumbnailUrl = () => {
+    // series가 없으면 volume.thumbnail_url만 사용, series가 있으면 우선순위 고려
+    // 하지만 VolumePage에서는 Volume의 썸네일이 우선되어야 함.
+    // 만약 Volume 썸네일이 없으면 Series 썸네일?
+    // 볼륨별 커버가 없는 경우 시리즈 커버를 쓰는게 맞나?
+    // 사용자는 "각 볼륨에 맞춰서" 라고 했으므로, 최대한 볼륨 썸네일을 써야 함.
+    // Backend가 populate 해줌.
+    const url = volume.thumbnail_url || series?.thumbnail_url;
+    if (!url) return null;
+    const token = localStorage.getItem("access_token");
+    if (!token) return url;
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}token=${token}`;
+  };
+
+  return (
+    <div className={`page-container page-with-sidebar ${sidebarOpen ? "sidebar-open" : ""}`}>
+      <Header onMenuClick={() => setSidebarOpen(true)} />
+      <Sidebar
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+        refreshKey={0}
+        onAddLibrary={() => showAlert("라이브러리 페이지에서만 추가할 수 있습니다.", "info")}
+      />
+
+      {/* 서브 헤더 (page-content-wrapper 밖으로 이동하여 Series 페이지와 위치 통일) */}
+      <div className="sub-header">
+        <div className="sub-header-left">
+          <Link
+            to={series ? `/series/${series.id}` : "/"}
+            className="back-button"
+          >
+            <ArrowLeft size={16} /> 뒤로
+          </Link>
+          <div className="breadcrumb">
+            {series && (
+              <>
+                <Link
+                  to={`/series/${series.id}`}
+                  className="breadcrumb-link"
+                >
+                  <Folder size={14} /> {series.title}
+                </Link>
+                <span className="breadcrumb-separator">/</span>
+              </>
+            )}
+            <span className="breadcrumb-current">{volume.title}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="page-content-wrapper"
+        style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 2rem 2rem 2rem" }}
+      >
+        {/* 볼륨 정보 헤더 (SeriesInfoCard 스타일) */}
+        <div
+          className="series-info-card"
+          style={{ marginBottom: "3rem" }}
+        >
+          {/* 배경 블러 이미지 (Card 내부로 이동) */}
+          <div className="series-backdrop">
+            {getThumbnailUrl() && (
+              <img
+                src={getThumbnailUrl()!}
+                alt=""
+                className="series-backdrop-image"
+              />
+            )}
+          </div>
+
+          <div className="series-thumbnail-container">
+            {getThumbnailUrl() ? (
+              <img
+                src={getThumbnailUrl()!}
+                alt={volume.title}
+                className="series-thumbnail"
+              />
+            ) : (
+              <div className="series-thumbnail-placeholder">
+                <BookOpen size={48} />
+              </div>
+            )}
+            <div className="series-status-badge status-ONGOING">{volume.volume_number}권</div>
+          </div>
+
+          <div className="series-content">
+            <div className="series-header">
+              <h1>{volume.title}</h1>
+              <div className="series-meta">
+                <span>{chapters.length}화</span>
+                {series?.authors && <span>• {series.authors}</span>}
+              </div>
+            </div>
+
+            <div className="series-progress-section">
+              <div className="progress-labels">
+                <span>
+                  {(() => {
+                    const readCount = Object.values(progressMap).filter(
+                      (p) => p.progress_percent > 95 || p.total_pages - p.current_page <= 1
+                    ).length;
+                    return readCount > 0 ? `${readCount} / ${chapters.length}화 읽음` : "읽지 않음";
+                  })()}
+                </span>
+              </div>
+              <div className="progress-bar-bg">
+                <div
+                  className="progress-bar-fill"
+                  style={{
+                    width: `${
+                      (Object.values(progressMap).filter((p) => p.progress_percent > 95).length /
+                        Math.max(1, chapters.length)) *
+                      100
+                    }%`,
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="series-actions">
+              <button
+                className="btn-action btn-primary"
+                onClick={handlePlay}
+              >
+                <Play
+                  size={20}
+                  fill="currentColor"
+                />
+                {lastProgress ? "이어보기" : "읽기 시작"}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* 챕터 목록 */}
+        <main className="volume-main">
+          <div className="chapter-count">
+            총 <strong>{chapters.length}</strong>화
+          </div>
+
+          {chapters.length === 0 ? (
+            <div className="empty-state">
+              <p>스캔된 챕터가 없습니다</p>
+            </div>
+          ) : (
+            <div className="chapter-list">
+              {chapters.map((chapter) => {
+                const chapterProgress = progressMap[chapter.id];
+                const isCurrentChapter = lastProgress?.chapter_id === chapter.id;
+                const isComplete = chapterProgress && chapterProgress.progress_percent >= 100;
+
+                // 챕터 썸네일 URL
+                const getChapterThumb = () => {
+                  // chapter.thumbnail_url은 backend에서 채워줌
+                  if (!chapter.thumbnail_url) return null;
+                  const token = localStorage.getItem("access_token");
+                  if (!token) return chapter.thumbnail_url;
+                  const separator = chapter.thumbnail_url.includes("?") ? "&" : "?";
+                  return `${chapter.thumbnail_url}${separator}token=${token}`;
+                };
+
+                return (
+                  <div
+                    key={chapter.id}
+                    className={`chapter-item ${openingChapterId === chapter.id ? "loading" : ""} ${
+                      isCurrentChapter ? "current" : ""
+                    }`}
+                    onClick={(e) => handleChapterClick(chapter, e)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) =>
+                      e.key === "Enter" && handleChapterClick(chapter, e as unknown as React.MouseEvent)
+                    }
+                  >
+                    <div className="chapter-thumbnail-wrapper">
+                      {getChapterThumb() ? (
+                        <img
+                          src={getChapterThumb()!}
+                          alt=""
+                          className="chapter-thumbnail"
+                        />
+                      ) : (
+                        <div className="chapter-thumbnail-placeholder">
+                          <BookOpen size={20} />
+                        </div>
+                      )}
+                    </div>
+                    <div className="chapter-info">
+                      <span className="chapter-number">{chapter.chapter_number}화</span>
+                      <span className="chapter-title">{chapter.title}</span>
+                      <span className="chapter-pages">{chapter.page_count}p</span>
+                    </div>
+                    <div className="chapter-status">
+                      {isComplete && (
+                        <CheckCircle
+                          size={18}
+                          className="complete-icon"
+                        />
+                      )}
+                      {chapterProgress && !isComplete && (
+                        <span className="progress-badge">
+                          {chapterProgress.current_page}/{chapterProgress.total_pages}
+                        </span>
+                      )}
+                      {openingChapterId === chapter.id ? (
+                        <div className="loading-spinner small" />
+                      ) : (
+                        <Play
+                          size={18}
+                          className="play-icon"
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </main>
+      </div>
+
+      <AlertModal
+        isOpen={alertModal.isOpen}
+        type={alertModal.type}
+        message={alertModal.message}
+        onConfirm={closeAlert}
+      />
+    </div>
+  );
+}

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -30,7 +30,9 @@ export interface Chapter {
   chapter_number: number;
   path: string;
   page_count: number;
+  thumbnail_url?: string;
   created_at: string;
+  updated_at: string;
 }
 
 export interface Page {


### PR DESCRIPTION
### PR 개요
볼륨 및 챕터 단위 세밀한 읽기 진행도 관리 기능 통합 및 볼륨 상세 페이지 UI 개선

### 주요 변경 사항

#### Backend
- **진행도 API 확장**: 특정 볼륨 내 모든 챕터의 진행 기록 조회 엔드포인트 추가 (`/api/v1/volumes/:volumeId/progress`)
- **동적 썸네일 제공**: 볼륨 및 챕터 목록 조회 시 첫 페이지 기반으로 `ThumbnailURL` 자동 계산 반환
- **Repository**: 볼륨 기준 진행도 조회 및 챕터 첫 페이지 ID 조회 메서드 추가
- **Model**: [Chapter](cci:2://file:///home/aha-hyeong/workspace/project/kumiho/web/src/types/series.ts:25:0-35:1) 모델에 `ThumbnailURL` 필드 추가

#### Frontend
- **볼륨 상세 페이지([VolumePage](cci:1://file:///home/aha-hyeong/workspace/project/kumiho/web/src/pages/Volume.tsx:12:0-402:1))**: 시리즈 페이지와 통일된 [SeriesInfoCard](cci:1://file:///home/aha-hyeong/workspace/project/kumiho/web/src/components/SeriesInfoCard.tsx:13:0-201:1) 스타일 헤더 및 레이아웃 적용
- **챕터 썸네일**: 챕터 리스트 각 아이템에 챕터별 첫 페이지 썸네일 적용
- **진행도 시각화**: 챕터별 완료 상태(체크 아이콘) 및 읽은 페이지 수 표시, 볼륨 전체 진행도 바 구현
- **기능 통합**: 볼륨 내 마지막 읽기 지점 또는 첫 챕터로 즉시 이동하는 '이어보기/읽기 시작' 로직 적용
- **타입 정의**: [Chapter](cci:2://file:///home/aha-hyeong/workspace/project/kumiho/web/src/types/series.ts:25:0-35:1) 인터페이스에 `thumbnail_url` 필드 추가 및 컴파일 오류 해결

### 테스트 결과
- 볼륨 상세 페이지 진입 시 챕터별 진행도 및 썸네일 정상 로드 확인
- 챕터 클릭 시 이전 읽기 지점(페이지 번호) 전달 확인
- 상단 서브 헤더(뒤로가기, 브레드크럼) 위치 및 레이아웃 일관성 확인

#19
