### PR TITLE
fix: 페이지 이동 팝업 동작 수정

### DIFF
--- a/web/src/pages/Viewer.module.css
+++ b/web/src/pages/Viewer.module.css
@@ -634,3 +634,17 @@
   color: #4db8d9;
   margin-top: 4px;
 }
+
+/* === 설정 오버레이 (페이지 점프 등) === */
+.settingsOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 150; /* 헤더(10)보다 높고 점프 모달(200)보다 낮게 */
+}

--- a/web/src/pages/Viewer.tsx
+++ b/web/src/pages/Viewer.tsx
@@ -1297,7 +1297,7 @@ export function ViewerPage() {
       {/* 페이지 점프 모달 */}
       {showPageJump && (
         <div
-          className="settings-overlay"
+          className={styles.settingsOverlay}
           onClick={() => setShowPageJump(false)}
         >
           <div


### PR DESCRIPTION
팝업이 떳을 때 입력 값이 없는 경우 팝업이 꺼지지 않음 현상 해결, 아무데나 클릭하면 됨