### PR TITLE
fix: 스캔 로직 개선 및 UI 버그 수정

### DIFF
--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -280,7 +280,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context, library *model.Library) (resu
 				// 초기 진행 상태 업데이트 (시리즈 시작)
 				updateProgress(entry.Name())
 
-				seriesResult, err := s.processSeries(ctx, library.ID, path, entry.Name(), existingMap, updateProgress)
+				seriesResult, err := s.processSeries(ctx, library.ID, path, entry.Name(), existingMap, excludePatterns, updateProgress)
 				if err != nil {
 					errChan <- err
 					return
@@ -785,7 +785,7 @@ func (s *Scanner) processArchiveAsSeries(ctx context.Context, libraryID, archive
 }
 
 // processSeries 시리즈 처리 (생성 또는 업데이트 후 스캔)
-func (s *Scanner) processSeries(ctx context.Context, libraryID, seriesPath, title string, existingMap map[string]*model.Series, onProgress func(string)) (*ScanResult, error) {
+func (s *Scanner) processSeries(ctx context.Context, libraryID, seriesPath, title string, existingMap map[string]*model.Series, excludePatterns []string, onProgress func(string)) (*ScanResult, error) {
 	var series *model.Series
 
 	// 폴더 수정 시간 확인
@@ -831,11 +831,11 @@ func (s *Scanner) processSeries(ctx context.Context, libraryID, seriesPath, titl
 		}
 	}
 
-	return s.scanSeriesContent(ctx, series, onProgress)
+	return s.scanSeriesContent(ctx, series, excludePatterns, onProgress)
 }
 
 // scanSeriesContent 시리즈 내용 스캔 (볼륨, 챕터) - Incremental Scan 적용
-func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, onProgress func(string)) (*ScanResult, error) {
+func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, excludePatterns []string, onProgress func(string)) (*ScanResult, error) {
 	result := &ScanResult{}
 	seriesPath := series.Path
 
@@ -863,7 +863,7 @@ func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, o
 		entryMap[entry.Name()] = entry
 	}
 	natsort.Sort(names)
-
+	
 	// 처리된 Path 추적 (삭제 대상 식별용)
 	processedPaths := make(map[string]bool)
 
@@ -886,6 +886,11 @@ func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, o
 
 			entry := entryMap[n]
 			entryPath := filepath.Join(seriesPath, n)
+
+			// 제외 패던 확인
+			if isExcluded(n, excludePatterns) {
+				return
+			}
 
 			mu.Lock()
 			processedPaths[entryPath] = true
@@ -935,7 +940,7 @@ func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, o
 				}
 
 				if entry.IsDir() {
-					volResult, err := s.scanVolume(ctx, tx, series.ID, entryPath, n, idx+1)
+					volResult, err := s.scanVolume(ctx, tx, series.ID, entryPath, n, idx+1, excludePatterns)
 					if err != nil {
 						return err
 					}
@@ -990,7 +995,7 @@ func (s *Scanner) scanSeriesContent(ctx context.Context, series *model.Series, o
 }
 
 // scanVolume 폴더 볼륨 스캔
-func (s *Scanner) scanVolume(ctx context.Context, db database.Queryer, seriesID, volumePath, title string, volumeNum int) (*ScanResult, error) {
+func (s *Scanner) scanVolume(ctx context.Context, db database.Queryer, seriesID, volumePath, title string, volumeNum int, excludePatterns []string) (*ScanResult, error) {
 	result := &ScanResult{}
 
 	// 볼륨 번호 추출 시도 (준비중)
@@ -1017,6 +1022,11 @@ func (s *Scanner) scanVolume(ctx context.Context, db database.Queryer, seriesID,
 	var subDirs []string
 
 	for _, entry := range entries {
+		// 제외 패턴 확인
+		if isExcluded(entry.Name(), excludePatterns) {
+			continue
+		}
+
 		if entry.IsDir() {
 			subDirs = append(subDirs, entry.Name())
 		} else if isImage(entry.Name()) {
@@ -1119,7 +1129,7 @@ func (s *Scanner) scanArchiveAsVolume(ctx context.Context, db database.Queryer, 
 	}
 
 	resultChan := make(chan dimensionResult, len(imageFiles))
-	workerChan := make(chan int, 8) // 아카이브 내 작업도 병렬로 수행 (CPU 및 I/O 활용)
+	workerChan := make(chan int, 16) // 아카이브 내 작업도 병렬로 수행 (CPU 및 I/O 활용) - 16으로 상향
 
 	var wg sync.WaitGroup
 	for i, imgPath := range imageFiles {
@@ -1201,7 +1211,7 @@ func (s *Scanner) scanImagesAsChapter(db database.Queryer, volumeID, basePath, t
 	}
 
 	resultChan := make(chan dimensionResult, len(imageFiles))
-	workerChan := make(chan int, 8) // 최대 8개 병렬 I/O 작업
+	workerChan := make(chan int, 16) // 최대 16개 병렬 I/O 작업 - 성능 향상을 위해 상향
 
 	var wg sync.WaitGroup
 	for i, imgFile := range imageFiles {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -37,7 +37,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     if (scanningIds.has(libraryId)) return;
 
     setScanningIds((prev) => new Set(prev).add(libraryId));
-    setStatus({ type: "info", message: "스캔을 시작했습니다." });
+    setStatus(null); // 이전 메시지 제거
+    setTimeout(() => {
+      setStatus({ type: "info", message: "스캔을 시작했습니다." });
+    }, 0);
 
     // 스캔 진행바 폴링 시작
     startPolling();
@@ -46,7 +49,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       await libraryAPI.scan(libraryId);
       await fetchLibraries();
       triggerRefresh();
-      setStatus({ type: "success", message: "스캔이 완료되었습니다." });
+      setStatus(null); // 이전 메시지 확실히 제거
+      setTimeout(() => {
+        setStatus({ type: "success", message: "스캔이 완료되었습니다." });
+      }, 0);
     } catch (error: unknown) {
       console.error("Scan failed:", error);
       const err = error as { response?: { status?: number } };

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -56,12 +56,18 @@ export function LibraryPage() {
   const handleScan = async () => {
     if (!id) return;
     setIsScanning(true);
-    setStatus({ type: "info", message: "스캔을 시작했습니다." });
+    setStatus(null); // 이전 메시지 제거
+    setTimeout(() => {
+      setStatus({ type: "info", message: "스캔을 시작했습니다." });
+    }, 0);
     try {
       await libraryAPI.scan(id);
       await loadData();
       triggerRefresh();
-      setStatus({ type: "success", message: "스캔이 완료되었습니다." });
+      setStatus(null); // 이전 메시지 제거
+      setTimeout(() => {
+        setStatus({ type: "success", message: "스캔이 완료되었습니다." });
+      }, 0);
     } catch (error: unknown) {
       console.error("Scan failed:", error);
       const err = error as { response?: { status?: number } };


### PR DESCRIPTION
## 개요
개인 호스팅 미디어 서버 Kumiho의 라이브러리 스캔 로직을 개선하고, 사용자 인터페이스상의 사소한 버그를 수정했습니다.

## 주요 변경 사항

### 1. 백엔드 스캔 로직 개선 및 성능 향상
- **제외 패턴 필터링 강화**: 기존 라이브러리 루트 레벨에서만 작동하던 제외 패턴(@eaDir, #recycle 등) 필터링을 시리즈(Series) 및 볼륨(Volume) 폴더 스캔 단계까지 확장 적용했습니다. 이를 통해 NAS 환경에서 불필요한 시스템 디렉토리가 볼륨으로 오인되는 문제를 해결했습니다.
- **이미지 분석 병렬성 상향**: 이미지 크기 정보를 추출하는 병렬 처리 수(worker pool size)를 기존 8에서 16으로 상향 조정했습니다. 이는 대량의 이미지 파일이 포함된 라이브러리 스캔 시 전체 스캔 속도를 유의미하게 향상시킵니다.
- **코드 구조 개선**: 스캔 단계별로 제외 패턴 리스트를 하위 함수에 명시적으로 전달하도록 구조를 변경하여 로직의 일관성을 확보했습니다.

### 2. 프론트엔드 UI 버그 수정
- **스캔 토스트 메시지 잔상 해결**: 사이드바(Sidebar) 및 라이브러리(Library) 페이지에서 스캔 실행 또는 완료 시 표시되는 토스트 메시지가 사라지지 않거나 여러 번 클릭 시 중복되는 현상을 수정했습니다.
- **상태 처리 최적화**: setStatus 호출 전 이전 상태를 명시적으로 초기화(null)하고 setTimeout을 활용한 비동기 업데이트를 통해 React 상태 갱신 충돌을 방지했습니다.

## 테스트 결과
- golangci-lint를 통한 코드 품질 검증 완료.
- 유닛 레벨에서 제외 패턴 매칭 로직이 정상 작동함을 확인.
- 실제 UI 환경에서 스캔 토스트 메시지가 3초 후 정상적으로 소멸됨을 확인.