### PR TITLE
fix: 스캔 성능 최적화 (Lazy Analysis) 및 증분 스캔 구현 (v0.2.3)

### DIFF
--- a/backend/internal/handler/image_handler.go
+++ b/backend/internal/handler/image_handler.go
@@ -133,6 +133,15 @@ func (h *ImageHandler) GetPageImage(c *fiber.Ctx) error {
 		})
 	}
 
+	// Lazy Analysis: DB에 저장된 크기가 0이면 업데이트
+	if page.Width == 0 || page.Height == 0 {
+		if cfg, _, err := image.DecodeConfig(bytes.NewReader(imageData)); err == nil {
+			page.Width = cfg.Width
+			page.Height = cfg.Height
+			_ = h.pageRepo.Update(nil, page) // 비동기 에러 무시 (다음 요청 때 다시 시도)
+		}
+	}
+
 	// 리사이즈 요청이 있는 경우
 	if width > 0 {
 		if resized, rErr := h.resizeImage(imageData, width); rErr == nil {

--- a/backend/internal/repository/page_repository.go
+++ b/backend/internal/repository/page_repository.go
@@ -88,3 +88,13 @@ func (r *PageRepository) DeleteByChapterID(db database.Queryer, chapterID string
 	_, err := db.Exec(`DELETE FROM pages WHERE chapter_id = ?`, chapterID)
 	return err
 }
+
+// Update 페이지 정보 업데이트
+func (r *PageRepository) Update(db database.Queryer, page *model.Page) error {
+	db = database.GetQueryer(db)
+	_, err := db.Exec(
+		`UPDATE pages SET width = ?, height = ? WHERE id = ?`,
+		page.Width, page.Height, page.ID,
+	)
+	return err
+}

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -1279,7 +1279,6 @@ func (s *Scanner) analyzeImages(basePath string, imageFiles []string, perf scanP
 	pages := make([]scannedPage, len(imageFiles))
 
 
-
 	for i, imgFile := range imageFiles {
 		// Lazy Analysis: Scan 단계에서는 크기를 측정하지 않음
 		pages[i] = scannedPage{


### PR DESCRIPTION
## 변경 사항

### 1. 성능 개선 (Lazy Analysis & Optimization)
- **지연 분석 (Lazy Analysis) 도입**: 스캔 단계에서는 이미지 크기를 `0`으로 저장하여 I/O를 최소화하고, 실제 크기 측정은 **이미지 열람 시점**으로 지연시켰습니다. 스캔 속도가 비약적으로 향상되었습니다.
- **HDD 최적화**: 터보 모드의 동시성 설정을 `Series: 2, Volume: 4, Image: 16`으로 조정하여 HDD/SSD 환경 모두를 고려했습니다.
- **시스템 콜 최적화**: `os.Stat` 대신 `entry.Info()`를 사용하여 불필요한 시스템 콜을 제거했습니다.

### 2. 증분 스캔 (Incremental Scan)
- **변경 감지**: 파일의 수정 시간(ModTime)이 DB와 동일하면 분석을 건너뛰도록 구현했습니다.
- **Producer-Consumer 최적화**: Consumer 단계의 중복 ModTime 체크 로직을 제거하여 로직을 단순화했습니다.

### 3. 기타 수정
- **버전 업데이트**: `v0.2.3`으로 버전 범프.
- **코드 정리**: PR 피드백을 반영하여 중복 코드 및 미사용 변수를 제거했습니다.