### PR TITLE
feat: 스캔 시 시리즈 카드 실시간 추가

### DIFF
--- a/web/src/stores/scanStore.ts
+++ b/web/src/stores/scanStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { libraryAPI } from "../api/client";
+import { useLibraryStore } from "./libraryStore";
 
 // 라이브러리 스캔 상태 타입
 interface LibraryScanStatus {
@@ -71,13 +72,26 @@ export const useScanStore = create<ScanStore>((set, get) => ({
       const wasScanning = get().isScanning;
       const isNowScanning = scanning.length > 0;
 
+      // 이전 스캔 항목들 추출
+      const prevItems = get()
+        .scanningLibraries.map((lib) => lib.currentItem)
+        .join(",");
+      // 현재 스캔 항목들 추출
+      const currentItems = scanning.map((lib) => lib.currentItem).join(",");
+
       set({
         scanningLibraries: scanning,
         isScanning: isNowScanning,
       });
 
-      // 스캔이 완료되면 폴링 중지
+      // 스캔 중인 항목이 변경되었을 때 화면 갱신 트리거
+      if (isNowScanning && prevItems !== currentItems) {
+        useLibraryStore.getState().triggerRefresh();
+      }
+
+      // 스캔이 완료되면 폴링 중지 및 최종 화면 갱신
       if (wasScanning && !isNowScanning) {
+        useLibraryStore.getState().triggerRefresh();
         get().stopPolling();
       }
     } catch (error) {


### PR DESCRIPTION
라이브러리 스캔 시 홈 화면과 라이브러리 페이지에서 시리즈 카드가 실시간으로 업데이트되도록 기능을 개선했습니다.

### 주요 구현 내용
- **실시간 UI 동기화**: scanStore.ts의 폴링 로직을 강화하여, 스캔 중인 항목(currentItem)이 변경될 때마다 전역 상태인 refreshKey를 갱신합니다.
- **Zustand Store 연동**: scanStore에서 libraryStore.getState().triggerRefresh()를 호출하여 다른 컴포넌트들이 최신 데이터를 다시 불러오도록(Re-fetch) 트리거를 제공합니다.
- **최종 정합성 보장**: 스캔이 완료되는 시점에도 마지막으로 한 번 더 UI를 갱신하여 전체 목록이 최신 상태임을 보장합니다.

이 변경으로 인해 사용자는 스캔 진행 상황을 문구뿐만 아니라 실제 카드 리스트가 채워지는 모습으로도 실시간 확인할 수 있습니다.
