### PR TITLE
fix: 백엔드, 완독 처리 로직 추가

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	// Fiber 앱 생성
 	app := fiber.New(fiber.Config{
-		AppName:   "Kumiho API v0.5.4",
+		AppName:   "Kumiho API v0.5.5",
 		BodyLimit: 50 * 1024 * 1024, // 50MB
 		ErrorHandler: func(c *fiber.Ctx, err error) error {
 			code := fiber.StatusInternalServerError

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -419,6 +419,9 @@ func (h *ProgressHandler) SyncProgress(c *fiber.Ctx) error {
 
 			// 완독 상태 해제 체크
 			h.removeCompletionIfIncomplete(userID, item.VolumeID, item.CurrentPage, item.TotalPages)
+
+			// 자동 완독 처리 (마지막 챕터의 마지막 페이지 도달 시)
+			h.markCompleteIfLastPage(userID, item.VolumeID, item.ChapterID, item.CurrentPage, item.TotalPages)
 		}
 	}
 
@@ -905,40 +908,57 @@ func (h *ProgressHandler) removeCompletionIfIncomplete(userID string, volumeID *
 
 // markCompleteIfLastPage 마지막 챕터의 마지막 페이지에 도달한 경우 볼륨 완독 처리
 func (h *ProgressHandler) markCompleteIfLastPage(userID string, volumeID, chapterID *string, currentPage, totalPages int) {
-	if volumeID == nil || chapterID == nil || totalPages <= 0 {
+	if volumeID == nil || chapterID == nil {
 		return
 	}
 
-	// 마지막 페이지인지 확인
-	if currentPage < totalPages {
-		// 마지막 페이지가 아니면 무시
-		return
-	}
-
-	// 챕터 정보 조회 (ChapterNumber 확인용)
+	// 챕터 정보 조회 (PageCount, ChapterNumber, VolumeID 확인용)
 	chapter, err := h.chapterRepo.FindByID(nil, *chapterID)
 	if err != nil || chapter == nil {
 		return
 	}
 
+	// 서버에 저장된 PageCount를 우선 사용하고, 없는 경우 클라이언트 요청값(totalPages)으로 fallback
+	lastPage := totalPages
+	if chapter.PageCount > 0 {
+		lastPage = chapter.PageCount
+	}
+
+	// 유효한 마지막 페이지 정보가 없으면 종료
+	if lastPage <= 0 {
+		return
+	}
+
+	// 마지막 페이지인지 확인
+	if currentPage < lastPage {
+		// 마지막 페이지가 아니면 무시
+		return
+	}
+
+	// 요청된 VolumeID와 실제 챕터의 VolumeID 일치 여부 확인 (잘못된 요청 방지)
+	// 클라이언트가 잘못된 VolumeID를 보냈을 경우엔 실제 챕터의 VolumeID를 기준으로 처리하거나 무시할 수 있음
+	// 여기서는 안전하게 실제 챕터 정보의 VolumeID를 사용
+	targetVolumeID := chapter.VolumeID
+	if *volumeID != targetVolumeID {
+		log.Printf("Warning: VolumeID mismatch in markCompleteIfLastPage. Request: %s, Actual: %s", *volumeID, targetVolumeID)
+	}
+
 	// 볼륨의 마지막 챕터인지 확인
-	isLast, err := h.chapterRepo.IsLastChapter(nil, *volumeID, chapter.ChapterNumber)
+	isLast, err := h.chapterRepo.IsLastChapter(nil, targetVolumeID, chapter.ChapterNumber)
 	if err != nil || !isLast {
 		return
 	}
 
 	// 이미 완료된 상태인지 확인 (중복 호출 방지)
-	isCompleted, _ := h.completionRepo.IsCompleted(nil, userID, *volumeID)
+	isCompleted, _ := h.completionRepo.IsCompleted(nil, userID, targetVolumeID)
 	if isCompleted {
 		return
 	}
 
 	// 완독 처리
-	// Note: 여기서는 볼륨 완료 상태(volume_completions)만 기록합니다.
-	// 모든 챕터 진행도를 100%로 강제 업데이트하는 로직은 포함하지 않습니다 (진행도 보존).
-	if _, err := h.completionRepo.MarkComplete(nil, userID, *volumeID); err != nil {
-		log.Printf("Failed to auto-mark completion for volume %s: %v", *volumeID, err)
+	if _, err := h.completionRepo.MarkComplete(nil, userID, targetVolumeID); err != nil {
+		log.Printf("Failed to auto-mark completion for volume %s: %v", targetVolumeID, err)
 	} else {
-		log.Printf("Auto-marked volume %s as complete for user %s", *volumeID, userID)
+		log.Printf("Auto-marked volume %s as complete for user %s", targetVolumeID, userID)
 	}
 }

--- a/backend/internal/handler/system_handler.go
+++ b/backend/internal/handler/system_handler.go
@@ -30,7 +30,7 @@ type VersionInfo struct {
 	NeedsUpdate    bool   `json:"needs_update"`
 }
 
-const CurrentVersion = "v0.5.4"
+const CurrentVersion = "v0.5.5"
 const GithubRepo = "aha-hyeong/kumiho"
 
 func NewSystemHandler(settingRepo repository.SettingRepository) *SystemHandler {

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -138,13 +138,19 @@ func (r *ChapterRepository) CountBySeriesID(db database.Queryer, seriesID string
 // IsLastChapter 해당 챕터가 볼륨의 마지막 챕터인지 확인
 func (r *ChapterRepository) IsLastChapter(db database.Queryer, volumeID string, chapterNumber int) (bool, error) {
 	db = database.GetQueryer(db)
-	var count int
+	var dummy int
 	err := db.QueryRow(
-		`SELECT COUNT(*) FROM chapters WHERE volume_id = ? AND chapter_number > ?`,
+		`SELECT 1 FROM chapters WHERE volume_id = ? AND chapter_number > ? LIMIT 1`,
 		volumeID, chapterNumber,
-	).Scan(&count)
+	).Scan(&dummy)
+
+	if err == sql.ErrNoRows {
+		// 이후 챕터가 없으므로 마지막 챕터
+		return true, nil
+	}
 	if err != nil {
 		return false, err
 	}
-	return count == 0, nil
+	// 이후 챕터가 존재하므로 마지막 챕터가 아님
+	return false, nil
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 기존 
- 백엔드에 완독 처리 로직이 없어 프론트에서 API 호출 실패시 완독 처리가 정상적으로 안됨
## 변경 사항
- 추가해서 잘됨 개굿


