### PR TITLE
fix: 업데이트된 시리즈 업로드 로직 수정

### DIFF
--- a/backend/internal/repository/series_repository.go
+++ b/backend/internal/repository/series_repository.go
@@ -317,11 +317,10 @@ func (r *SeriesRepository) Delete(db database.Queryer, id string) error {
 // Update 시리즈 정보 업데이트
 func (r *SeriesRepository) Update(db database.Queryer, series *model.Series) error {
 	db = database.GetQueryer(db)
-	now := time.Now()
 	// 1. series 테이블 업데이트
 	_, err := db.Exec(
 		`UPDATE series SET title = ?, path = ?, thumbnail_path = ?, updated_at = ? WHERE id = ?`,
-		series.Title, series.Path, series.ThumbnailPath, now, series.ID,
+		series.Title, series.Path, series.ThumbnailPath, series.UpdatedAt, series.ID,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## 기존
- 시리즈 메타 데이터 수정 시 업데이트된 시리즈 최상단으로 업데이트 됨
## 변경 사항
- 메타데이터 및 썸네일 변경은 반영 안됨
-> 실제 시리즈에 볼륨/챕터 업데이트가 있을 때만 '업데이트된 시리즈'에 업로드