### PR TITLE
fix: auth input Trim 수정

### DIFF
--- a/web/src/components/settings/UsersTab.tsx
+++ b/web/src/components/settings/UsersTab.tsx
@@ -202,14 +202,14 @@ export function UsersTab() {
                     type="text"
                     placeholder={t("settings.users.create.id_placeholder")}
                     value={newUser.username}
-                    onChange={(e) => setNewUser({ ...newUser, username: e.target.value })}
+                    onChange={(e) => setNewUser({ ...newUser, username: e.target.value.trim() })}
                     className={commonStyles.settingsInput}
                   />
                   <input
                     type="text"
                     placeholder={t("settings.users.create.nickname_placeholder")}
                     value={newUser.nickname}
-                    onChange={(e) => setNewUser({ ...newUser, nickname: e.target.value })}
+                    onChange={(e) => setNewUser({ ...newUser, nickname: e.target.value.trim() })}
                     className={commonStyles.settingsInput}
                   />
                   <input

--- a/web/src/pages/Auth.tsx
+++ b/web/src/pages/Auth.tsx
@@ -54,7 +54,7 @@ export function LoginPage() {
               type="text"
               id="username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => setUsername(e.target.value.trim())}
               placeholder={t("auth.form.id")}
               required
             />
@@ -152,7 +152,7 @@ export function RegisterPage() {
               type="text"
               id="username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => setUsername(e.target.value.trim())}
               placeholder={t("auth.form.id")}
               required
             />
@@ -164,7 +164,7 @@ export function RegisterPage() {
               type="text"
               id="nickname"
               value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
+              onChange={(e) => setNickname(e.target.value.trim())}
               placeholder="구미호"
               required
             />


### PR DESCRIPTION
## 기존
id, 닉네임, 비밀번호에 스페이스바 입력 가능
## 변경 후
비밀번호를 제외한 나머지 입력창은 스페이스바 입력 불가능
비밀번호는 문장으로 사용 가능
