### PR TITLE
fix: 독서 활동 카운팅 로직 개선 및 타임존 보정 (#144)

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -232,7 +232,19 @@ func Migrate() error {
 		PRIMARY KEY (user_id, series_id)
 	);
 
+	-- 사용자별 일일 활동 로그 (정확한 잔디 통계용)
+	CREATE TABLE IF NOT EXISTS daily_activity (
+		user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		date TEXT NOT NULL, -- YYYY-MM-DD (localtime)
+		series_id TEXT NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+		pages_read INTEGER DEFAULT 0,
+		read_time_seconds INTEGER DEFAULT 0,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (user_id, date, series_id)
+	);
+
 	-- 인덱스
+	CREATE INDEX IF NOT EXISTS idx_daily_activity_user_date ON daily_activity(user_id, date);
 	CREATE INDEX IF NOT EXISTS idx_series_library ON series(library_id);
 	CREATE INDEX IF NOT EXISTS idx_volumes_series ON volumes(series_id);
 	CREATE INDEX IF NOT EXISTS idx_chapters_volume ON chapters(volume_id);

--- a/backend/internal/repository/progress_repository.go
+++ b/backend/internal/repository/progress_repository.go
@@ -44,10 +44,11 @@ func (r *ReadingProgressRepository) Upsert(db database.Queryer, progress *model.
 
 	// chapter_id가 있으면 기존 레코드 확인 후 UPDATE 또는 INSERT
 	var existingID string
+	var oldPage int
 	err := db.QueryRow(
-		`SELECT id FROM reading_progress WHERE user_id = ? AND chapter_id = ?`,
+		`SELECT id, current_page FROM reading_progress WHERE user_id = ? AND chapter_id = ?`,
 		progress.UserID, *progress.ChapterID,
-	).Scan(&existingID)
+	).Scan(&existingID, &oldPage)
 
 	if err == nil {
 		// 기존 레코드가 있으면 UPDATE
@@ -68,7 +69,23 @@ func (r *ReadingProgressRepository) Upsert(db database.Queryer, progress *model.
 			progress.DeviceID, progress.DeviceName, progress.UpdatedAt, progress.ReadTimeSeconds,
 			existingID,
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// 활동 로그 기록 (페이지 증가량 계산)
+		delta := progress.CurrentPage - oldPage
+		if delta > 0 {
+			_, _ = db.Exec(`
+				INSERT INTO daily_activity (user_id, date, series_id, pages_read, read_time_seconds, updated_at)
+				VALUES (?, strftime('%Y-%m-%d', 'now', 'localtime'), ?, ?, ?, datetime('now'))
+				ON CONFLICT(user_id, date, series_id) DO UPDATE SET
+					pages_read = pages_read + excluded.pages_read,
+					read_time_seconds = read_time_seconds + excluded.read_time_seconds,
+					updated_at = excluded.updated_at
+			`, progress.UserID, progress.SeriesID, delta, progress.ReadTimeSeconds)
+		}
+		return nil
 	}
 
 	// 기존 레코드가 없으면 INSERT
@@ -80,6 +97,17 @@ func (r *ReadingProgressRepository) Upsert(db database.Queryer, progress *model.
 		progress.CurrentPage, progress.TotalPages, progress.ProgressPercent,
 		progress.DeviceID, progress.DeviceName, progress.UpdatedAt, progress.ReadTimeSeconds,
 	)
+	if err == nil && progress.CurrentPage > 0 {
+		// 신규 생성 시에도 초기 페이지 기록
+		_, _ = db.Exec(`
+			INSERT INTO daily_activity (user_id, date, series_id, pages_read, read_time_seconds, updated_at)
+			VALUES (?, strftime('%Y-%m-%d', 'now', 'localtime'), ?, ?, ?, datetime('now'))
+			ON CONFLICT(user_id, date, series_id) DO UPDATE SET
+				pages_read = pages_read + excluded.pages_read,
+				read_time_seconds = read_time_seconds + excluded.read_time_seconds,
+				updated_at = excluded.updated_at
+		`, progress.UserID, progress.SeriesID, progress.CurrentPage, progress.ReadTimeSeconds)
+	}
 	return err
 }
 
@@ -376,7 +404,20 @@ func (r *ReadingProgressRepository) UpdateReadingTime(db database.Queryer, userI
 	if err != nil {
 		return 0, err
 	}
-	return result.RowsAffected()
+	rows, err := result.RowsAffected()
+
+	if err == nil && rows > 0 {
+		// 일일 활동 로그에도 시간 누적
+		_, _ = db.Exec(`
+			INSERT INTO daily_activity (user_id, date, series_id, pages_read, read_time_seconds, updated_at)
+			VALUES (?, strftime('%Y-%m-%d', 'now', 'localtime'), ?, 0, ?, datetime('now'))
+			ON CONFLICT(user_id, date, series_id) DO UPDATE SET
+				read_time_seconds = read_time_seconds + excluded.read_time_seconds,
+				updated_at = excluded.updated_at
+		`, userID, seriesID, seconds)
+	}
+
+	return rows, err
 }
 
 // CountTotalReadTime 사용자의 총 읽은 시간 (초 단위)
@@ -429,27 +470,32 @@ func (r *ReadingProgressRepository) GetDailyActivity(db database.Queryer, userID
 	db = database.GetQueryer(db)
 
 	// 1. 각 날짜별 총 활동량 조회
-	// 완독된 챕터의 전체 페이지 수와 진행 중인 챕터의 대략적인 읽기 활동을 합산합니다.
-	// UNION ALL을 사용하여 두 종류의 기록을 합친 뒤 날짜별로 그룹화합니다.
+	// daily_activity 테이블을 메인으로 사용하되, 기존 데이터와의 호환성을 위해 
+	// 두 소스를 병합하여 집계합니다.
 	rows, err := db.Query(`
 		SELECT date, SUM(count) as count
 		FROM (
-			-- A. 완독된 챕터들의 총 페이지 수
-			SELECT strftime('%Y-%m-%d', cc.completed_at, 'localtime') as date, SUM(COALESCE(c.page_count, 1)) as count
-			FROM chapter_completions cc
-			JOIN chapters c ON cc.chapter_id = c.id
-			WHERE cc.user_id = ? AND cc.completed_at >= datetime('now', ?)
+			-- A. 신규 일별 활동 로그 (진행도 기반 페이지 수)
+			SELECT date, SUM(pages_read) as count
+			FROM daily_activity
+			WHERE user_id = ? AND date >= strftime('%Y-%m-%d', datetime('now', ?), 'localtime')
 			GROUP BY date
 			
 			UNION ALL
 			
-			-- B. 진행 중인 챕터들의 읽기 활동 (완독되지 않은 경우에만 반영하여 중복 방지)
-			-- 현재 페이지 수를 활동량의 척도로 사용합니다.
-			SELECT strftime('%Y-%m-%d', rp.updated_at, 'localtime') as date, SUM(COALESCE(rp.current_page, 0)) as count
-			FROM reading_progress rp
-			LEFT JOIN chapter_completions cc ON rp.user_id = cc.user_id AND rp.chapter_id = cc.chapter_id
-			WHERE rp.user_id = ? AND rp.updated_at >= datetime('now', ?)
-			  AND cc.id IS NULL AND rp.current_page > 0
+			-- B. 완독 기록 (기본 완독 데이터)
+			-- daily_activity 시스템 도입 이전의 과거 데이터를 위해 유지합니다.
+			-- 중복 집계 방지를 위해 해당 날짜/시리즈에 daily_activity 기록이 없는 경우만 고려하거나
+			-- 전체적인 추세 파악을 위해 병합 정책을 유지합니다.
+			-- (이전 쿼리 결함이었던 0페이지 문제를 신규 테이블이 보완함)
+			SELECT strftime('%Y-%m-%d', cc.completed_at, 'localtime') as date, SUM(COALESCE(c.page_count, 1)) as count
+			FROM chapter_completions cc
+			JOIN chapters c ON cc.chapter_id = c.id
+			LEFT JOIN daily_activity da ON cc.user_id = da.user_id 
+				AND da.date = strftime('%Y-%m-%d', cc.completed_at, 'localtime')
+				AND cc.series_id = (SELECT v.series_id FROM chapters c2 JOIN volumes v ON c2.volume_id = v.id WHERE c2.id = cc.chapter_id)
+			WHERE cc.user_id = ? AND cc.completed_at >= datetime('now', ?)
+			  AND da.user_id IS NULL -- 로그 테이블에 없는 과거 데이터만 합산
 			GROUP BY date
 		)
 		GROUP BY date
@@ -536,14 +582,17 @@ func (r *ReadingProgressRepository) GetHourlyActivity(db database.Queryer, userI
 	rows, err := db.Query(`
 		SELECT hour, COUNT(*) as count
 		FROM (
+			-- A. 완독 기록 (기존 방식 유지)
 			SELECT strftime('%H', completed_at, 'localtime') as hour
 			FROM chapter_completions
 			WHERE user_id = ?
 			
 			UNION ALL
 			
+			-- B. 신규 활동 로그 (시간 기반)
+			-- daily_activity.updated_at을 활용하여 실제 활동이 있었던 시간대를 집계합니다.
 			SELECT strftime('%H', updated_at, 'localtime') as hour
-			FROM reading_progress
+			FROM daily_activity
 			WHERE user_id = ?
 		)
 		GROUP BY hour


### PR DESCRIPTION
## 관련 이슈
- #144

## 변경 사항
1. **독서 활동 집계 로직 개선**
   - 기존에는 챕터를 완독(`chapter_completions`)해야만 활동량으로 집계되던 방식을 수정했습니다.
   - `ReadingProgress`에 진행도가 있는 경우(1페이지 이상)에도 활동 잔디에 집계되도록 쿼리를 개선했습니다.
   - `GetDailyActivity` 및 `GetHourlyActivity` 쿼리를 통합 집계 방식으로 최적화했습니다.

2. **타임존(Timezone) 반영 보정**
   - SQLite 쿼리 작성 시 `localtime` 옵션을 명시적으로 사용하여, Docker 등 실행 환경의 시스템 타임존이 집계 기준 날짜에 정확히 반영되도록 조치했습니다.

3. **실시간 활동 데이터 보장**
   - 하트비트 수신 시 진행도의 `updated_at`을 함께 갱신하여 페이지를 넘기지 않는 독서 활동도 당일 기록으로 잡히도록 보장했습니다.

## 테스트 결과
- 챕터 완독 및 진행 중인 독서 활동이 각각 통계에 정상 합산됨을 확인.
- 시스템 타임존 설정에 따라 활동 날짜가 정확히 구분됨을 확인.