### PR TITLE
fix: 운영 환경 클라이언트 IP 감지 및 동시 세션 관리 개선

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -78,21 +78,26 @@ func getClientIP(c *fiber.Ctx) string {
 	directIPStr := c.IP()
 	directIP := net.ParseIP(directIPStr)
 
-	// 직접 연결된 상대가 사설 IP(Private)이거나 루프백(Loopback)인 경우에만 프록시 헤더를 신뢰함
-	// 이는 외부 사용자가 직접 X-Forwarded-For 헤더를 조작하여 보내는 IP 스푸핑을 방지하기 위함임
+	// 직접 연결된 상대가 사설 IP(Private)이거나 루프백(Loopback)인 경우에만 프록시 헤더를 신뢰함.
+	// 이는 외부 사용자가 직접 X-Forwarded-For 헤더를 조작하여 보내는 IP 스푸핑을 방지하기 위함임.
+	// net.ParseIP와 IsPrivate/IsLoopback은 IPv4와 IPv6를 모두 지원함.
 	if directIP != nil && (directIP.IsPrivate() || directIP.IsLoopback()) {
 		// 1. X-Forwarded-For 확인
 		if xff := c.Get("X-Forwarded-For"); xff != "" {
-			ip := strings.TrimSpace(strings.Split(xff, ",")[0])
-			if net.ParseIP(ip) != nil {
-				return ip
+			// 여러 IP가 있을 수 있으므로 첫 번째 IP 추출.
+			// IPv6 주소의 경우 [] 브래킷이 포함될 수 있으므로 정리가 필요할 수 있음.
+			ipStr := strings.TrimSpace(strings.Split(xff, ",")[0])
+			ipStr = strings.Trim(ipStr, "[]")
+			if net.ParseIP(ipStr) != nil {
+				return ipStr
 			}
 		}
 
 		// 2. X-Real-IP 확인
 		if xrip := c.Get("X-Real-IP"); xrip != "" {
-			if net.ParseIP(xrip) != nil {
-				return xrip
+			ipStr := strings.Trim(strings.TrimSpace(xrip), "[]")
+			if net.ParseIP(ipStr) != nil {
+				return ipStr
 			}
 		}
 	}


### PR DESCRIPTION
## 설명
본 PR은 운영 환경(시놀로지 역방향 프록시)에서 뷰어의 동시 접속 세션이 정상적으로 종료되지 않던 문제를 해결하며, 리뷰 피드백을 반영하여 보안성을 더욱 강화했습니다.

### 원인 분석
백엔드 서버가 모든 클라이언트의 IP를 역방향 프록시의 내부 IP(`192.168.0.1`)로 오인하여 다음과 같은 문제가 발생했습니다:
1. **세션 식별 오류**: 서로 다른 기기임에도 브라우저/OS/IP 정보가 동일하게 인식되어 하나의 세션 ID를 공유하게 됨.
2. **강제 종료 로직 무력화**: `ForceLogoutOtherViewerSessions` 기능은 현재 세션 ID와 다른 세션만 종료시키는데, 세션 ID가 중복되면서 종료 대상에서 제외됨.

### 주요 변경 사항 (스마트 프록시 신뢰 도입)
단순히 헤더를 파싱하는 것을 넘어, **보안**과 **사용자 편의성**을 모두 잡기 위해 다음과 같은 로직을 구현했습니다:

1. **자동 보안 검증 (Smart Trust)**:
   - 서버에 직접 연결된 상대의 IP가 **사설 망(Private IP)** 또는 **로컬(Loopback)** 주소일 때만 `X-Forwarded-For` 및 `X-Real-IP` 헤더를 파싱합니다.
   - 이를 통해 외부(공인 IP)에서 직접 접속하며 헤더를 조작하는 **IP 스푸핑 공격**을 원천 차단합니다.
2. **무설정(No-Config) 지원**:
   - 별도의 환경 변수 설정 없이도 시놀로지, Docker 등의 일반적인 역방향 프록시 환경에서 자동으로 실제 IP를 식별합니다.
3. **데이터 검증**:
   - 추출한 IP 주소는 `net.ParseIP()`를 통해 유효성 검사를 거쳐 안전하게 데이터베이스에 기록됩니다.

## 테스트 결과
- **로컬 환경**: `127.0.0.1`이 정상적으로 감지되며, 외부 헤더 조작 시 무시되는 것을 확인했습니다.
- **운영 환경**: 프록시를 거쳐온 실제 외부 클라이언트 IP가 정상적으로 식별되어, 동시 시청 강제 종료 기능이 의도대로 작동함을 확인했습니다.