### PR TITLE
fix: 웹소켓 동시성 문제 및 세션 종료 로직 개선

### DIFF
--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -124,7 +124,7 @@ func (h *Hub) Run() {
 
 		case triggerClient := <-h.forceLogout:
 			// 1. 해당 유저의 세션 맵 확인
-			// 다른 고루틴(Handers)에서 h.clients를 읽거나(RLock), WritePump가 닫힐 때 h.clients를 수정(Lock)할 수 있으므로
+			// 다른 고루틴(Handlers)에서 h.clients를 읽거나(RLock), WritePump가 닫힐 때 h.clients를 수정(Lock)할 수 있으므로
 			// 여기서도 안전하게 RLock을 걸어야 함.
 			h.mu.RLock()
 			if sessions, ok := h.clients[triggerClient.UserID]; ok {


### PR DESCRIPTION
## 구현 내용

1. **WebSocket Ping/Pong 주기 단축**
   - `client.go`: `pongWait`를 60초에서 30초로 단축 (Ping 주기 27초)
   - 배포 환경(NAS 등)의 짧은 네트워크 타임아웃으로 인한 좀비 커넥션 방지

2. **Global Connection 예외 처리**
   - `hub.go`: `Header` 컴포넌트에서 맺는 전역 웹소켓 연결(`source=`)은 강제 로그아웃 대상에서 제외
   - 뷰어 진입 시 설정 페이지 등 다른 페이지의 연결이 끊어지는 문제 해결

3. **Hub 동시성 제어 리팩토링**
   - `hub.go`: `ForceLogout` 로직을 `Mutex` 기반의 동기 호출에서 **채널(`forceLogout`) 기반의 이벤트 루프**로 변경
   - `Register`(핸들러 고루틴)와 `ForceLogout`(허브 고루틴) 간의 Lock 경합 및 잠재적 데드락 제거