### PR TITLE
fix: Access Token 만료 후 자동 갱신 실패로 인한 로그아웃 문제 수정

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -33,9 +33,11 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // auth 관련 요청이면 인터셉터 처리 skip (무한 루프 방지)
-    const isAuthRequest = originalRequest.url?.includes("/api/v1/auth/") || originalRequest.url?.startsWith("/auth/");
-    if (isAuthRequest) {
+    // 인증 흐름 자체의 요청은 인터셉터 처리 skip (무한 루프 방지)
+    // /auth/me, /auth/sessions 등은 skip하지 않아 Access Token 만료 후 자동 갱신 가능
+    const skipRefreshPaths = ["/auth/login", "/auth/register", "/auth/refresh", "/auth/logout", "/auth/setup"];
+    const shouldSkipRefresh = skipRefreshPaths.some((path) => originalRequest.url?.endsWith(path));
+    if (shouldSkipRefresh) {
       return Promise.reject(error);
     }
 


### PR DESCRIPTION
## 문제

Access Token(1시간) 만료 후 새로고침 또는 앱 재진입 시 자동 로그아웃이 발생하는 문제.

### 원인

`client.ts`의 응답 인터셉터에서 401 에러 발생 시, `/auth/` 경로 하위 요청 전체를 refresh skip 대상으로 처리하고 있었음.

```typescript
const isAuthRequest = originalRequest.url?.includes("/api/v1/auth/") || originalRequest.url?.startsWith("/auth/");
```

이로 인해 `checkAuth()` → `/auth/me` 요청이 401을 받아도 refresh token 갱신 시도 없이 바로 로그아웃 처리됨.

Refresh Token(7일)은 정상적으로 유효했으나 **사용 기회를 받지 못하는 상태**였음.

### 동작 차이

| 상황 | Access Token 유효 | Access Token 만료 (수정 전) | Access Token 만료 (수정 후) |
|------|:---:|:---:|:---:|
| 페이지 내 API 요청 | ✅ | ✅ 자동 갱신 | ✅ 자동 갱신 |
| 새로고침 / 앱 재진입 | ✅ | ❌ 로그아웃 | ✅ 자동 갱신 |

## 변경 사항

### `web/src/api/client.ts`

- `isAuthRequest` 전체 경로 매칭을 **`skipRefreshPaths` 화이트리스트 방식**으로 변경
- refresh skip 대상: `/auth/login`, `/auth/register`, `/auth/refresh`, `/auth/logout`, `/auth/setup`
- `/auth/me`, `/auth/sessions` 등 인증이 필요한 엔드포인트에서 401 발생 시 자동 갱신 수행

```diff
- const isAuthRequest = originalRequest.url?.includes("/api/v1/auth/") || originalRequest.url?.startsWith("/auth/");
- if (isAuthRequest) {
+ const skipRefreshPaths = ["/auth/login", "/auth/register", "/auth/refresh", "/auth/logout", "/auth/setup"];
+ const shouldSkipRefresh = skipRefreshPaths.some((path) => originalRequest.url?.endsWith(path));
+ if (shouldSkipRefresh) {
```

무한 루프 방지는 `/auth/refresh` 자체가 skip 목록에 포함되어 있어 기존과 동일하게 보장됨.