### PR TITLE
feat: 시스템 업데이트 확인 30분 폴링 추가

### DIFF
--- a/web/src/components/headers/Header.tsx
+++ b/web/src/components/headers/Header.tsx
@@ -67,7 +67,7 @@ export function Header({ onMenuClick }: HeaderProps) {
       }
     });
 
-    // 2. 시스템 업데이트 확인 (MASTER 권한만)
+    // 2. 시스템 업데이트 확인 (MASTER 권한만, 30분 폴링)
     const checkVersion = async () => {
       if (user?.role !== "MASTER") return;
 
@@ -80,8 +80,11 @@ export function Header({ onMenuClick }: HeaderProps) {
     };
     checkVersion();
 
+    const versionInterval = setInterval(checkVersion, 30 * 60 * 1000);
+
     return () => {
       unsubscribe();
+      clearInterval(versionInterval);
     };
   }, [subscribe, user?.role]);
 


### PR DESCRIPTION
## 변경 내용

Header의 **UP 배지**(시스템 업데이트 알림)가 새로고침 없이도 자동으로 표시되도록 개선합니다.

### 기존 동작
- `systemAPI.getVersion()`을 컴포넌트 마운트 시 **1회만** 호출
- 업데이트가 나와도 **새로고침 전까지 UP 배지가 표시되지 않음**

### 변경 후
- 마운트 시 1회 + **30분마다 자동 폴링**으로 업데이트 여부 확인
- MASTER 권한 사용자만 해당
- 컴포넌트 언마운트 시 `clearInterval`로 정리

### 수정 파일
- `web/src/components/headers/Header.tsx`