### PR TITLE
feat(opds): OPDS v1.2 구현 및 API Key 인증 기능 추가

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -91,6 +91,7 @@ func main() {
 	systemHandler := handler.NewSystemHandler(settingRepo) // 추가
 	statsHandler := handler.NewStatsHandler(progressRepo, completionRepo)
 	sseHandler := handler.NewSSEHandler(hub)
+	opdsHandler := handler.NewOPDSHandler(seriesRepo, libraryRepo, volumeRepo, chapterRepo, userRepo, authService, cfg)
 
 
 	// 미들웨어 초기화
@@ -149,6 +150,12 @@ func main() {
 	// === SSE 스트림 라우트 ===
 	v1.Get("/sse", authMiddleware.Protected(), sseHandler.Handle)
 
+	// === OPDS 라우트 (Basic Auth) ===
+	opds := v1.Group("/opds", opdsHandler.BasicAuthMiddleware)
+	opds.Get("", opdsHandler.Catalog)
+	opds.Get("/library/:id", opdsHandler.LibrarySeries)
+	opds.Get("/series/:id", opdsHandler.SeriesVolumes)
+
 	// === 인증 필요 라우트 ===
 	protected := v1.Group("", authMiddleware.Protected())
 
@@ -159,6 +166,11 @@ func main() {
 	users.Delete("/:id", userHandler.Delete)
 	users.Put("/:id", userHandler.Update)
 	users.Put("/:id/libraries", userHandler.UpdateLibraries)
+	
+	// OPDS API Key (자신의 정보)
+	users.Get("/me/opds-key", userHandler.GetMyOPDSKey)
+	users.Post("/me/opds-key/regenerate", userHandler.RegenerateMyOPDSKey)
+
 	users.Get("/sessions", authMiddleware.MasterOnly(), authHandler.ListAllSessions)
 	users.Delete("/:userId/sessions/:sessionId", authMiddleware.MasterOnly(), authHandler.RevokeSessionByAdmin)
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -323,7 +323,24 @@ func Migrate() error {
 	// 18. 사용자별 시리즈 설정에 터치 스와이프 방향 추가
 	migrateSwipeDirection()
 
+	// 19. 사용자 OPDS API Key 컬럼 추가
+	migrateUserOPDSKey()
+
 	return nil
+}
+
+// migrateUserOPDSKey users 테이블에 opds_key 컬럼 추가
+func migrateUserOPDSKey() {
+	if !columnExists("users", "opds_key") {
+		_, err := DB.Exec(`ALTER TABLE users ADD COLUMN opds_key TEXT DEFAULT ''`)
+		if err != nil {
+			fmt.Printf("Migration error (users.opds_key): %v\n", err)
+		} else {
+			fmt.Println("Migrated users table: added opds_key column.")
+		}
+	}
+	// 인덱스 추가 (조회 성능 향상)
+	_, _ = DB.Exec(`CREATE INDEX IF NOT EXISTS idx_users_opds_key ON users(opds_key)`)
 }
 
 // migrateSessions 세션 테이블 생성 (기기별 로그인 관리)

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -299,3 +299,29 @@ func (h *UserHandler) UpdateLibraries(c *fiber.Ctx) error {
 		"message": "user libraries updated",
 	})
 }
+
+// GetMyOPDSKey 자신의 OPDS API Key 조회
+// GET /api/v1/users/me/opds-key
+func (h *UserHandler) GetMyOPDSKey(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	key, err := h.authService.GetOPDSKey(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to get opds key",
+		})
+	}
+	return c.JSON(fiber.Map{"opds_key": key})
+}
+
+// RegenerateMyOPDSKey 자신의 OPDS API Key 재발급
+// POST /api/v1/users/me/opds-key/regenerate
+func (h *UserHandler) RegenerateMyOPDSKey(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	key, err := h.authService.RegenerateOPDSKey(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to regenerate opds key",
+		})
+	}
+	return c.JSON(fiber.Map{"opds_key": key})
+}

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -24,15 +24,12 @@ func (m *AuthMiddleware) Protected() fiber.Handler {
 
 		// 1. Authorization 헤더 확인 (모바일 앱 등)
 		authHeader := c.Get("Authorization")
-		if authHeader != "" {
+		if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
 			// Bearer 토큰 추출
 			parts := strings.Split(authHeader, " ")
-			if len(parts) != 2 || parts[0] != "Bearer" {
-				return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-					"error": "invalid authorization header format",
-				})
+			if len(parts) == 2 {
+				tokenString = parts[1]
 			}
-			tokenString = parts[1]
 		}
 
 		// 2. 헤더에 없으면 쿠키 확인 (웹 클라이언트)

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -20,6 +20,7 @@ type User struct {
 	PasswordHash string    `json:"-"`
 	Role         Role      `json:"role"`
 	CanDownload  bool      `json:"can_download" db:"can_download"` // 다운로드 권한
+	OPDSKey      string    `json:"opds_key" db:"opds_key"`         // OPDS API Key
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -25,9 +25,9 @@ func (r *UserRepository) Create(q database.Queryer, user *model.User) error {
 	user.UpdatedAt = now
 
 	_, err := q.Exec(
-		`INSERT INTO users (id, username, nickname, password_hash, role, can_download, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		user.ID, user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.CreatedAt, user.UpdatedAt,
+		`INSERT INTO users (id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.ID, user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.OPDSKey, user.CreatedAt, user.UpdatedAt,
 	)
 	return err
 }
@@ -37,10 +37,10 @@ func (r *UserRepository) FindByUsername(q database.Queryer, username string) (*m
 	q = database.GetQueryer(q)
 	user := &model.User{}
 	err := q.QueryRow(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
 		 FROM users WHERE username = ?`,
 		username,
-	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt)
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -56,10 +56,10 @@ func (r *UserRepository) FindByID(q database.Queryer, id string) (*model.User, e
 	q = database.GetQueryer(q)
 	user := &model.User{}
 	err := q.QueryRow(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
 		 FROM users WHERE id = ?`,
 		id,
-	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt)
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -82,7 +82,7 @@ func (r *UserRepository) Count(q database.Queryer) (int, error) {
 func (r *UserRepository) FindAll(q database.Queryer) ([]model.User, error) {
 	q = database.GetQueryer(q)
 	rows, err := q.Query(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at FROM users ORDER BY created_at`,
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at FROM users ORDER BY created_at`,
 	)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (r *UserRepository) FindAll(q database.Queryer) ([]model.User, error) {
 	var users []model.User
 	for rows.Next() {
 		var user model.User
-		if err := rows.Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt); err != nil {
+		if err := rows.Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt); err != nil {
 			return nil, err
 		}
 		users = append(users, user)
@@ -112,8 +112,8 @@ func (r *UserRepository) Update(q database.Queryer, user *model.User) error {
 	q = database.GetQueryer(q)
 	user.UpdatedAt = time.Now()
 	_, err := q.Exec(
-		`UPDATE users SET username = ?, nickname = ?, password_hash = ?, role = ?, can_download = ?, updated_at = ? WHERE id = ?`,
-		user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.UpdatedAt, user.ID,
+		`UPDATE users SET username = ?, nickname = ?, password_hash = ?, role = ?, can_download = ?, opds_key = ?, updated_at = ? WHERE id = ?`,
+		user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.OPDSKey, user.UpdatedAt, user.ID,
 	)
 	return err
 }
@@ -177,4 +177,23 @@ func (r *UserRepository) GetAllowedLibraryIDs(q database.Queryer, userID string)
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// FindByOPDSKey opds_key로 사용자 조회
+func (r *UserRepository) FindByOPDSKey(q database.Queryer, key string) (*model.User, error) {
+	q = database.GetQueryer(q)
+	user := &model.User{}
+	err := q.QueryRow(
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
+		 FROM users WHERE opds_key = ? AND opds_key != ''`,
+		key,
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/aha-hyeong/kumiho/backend/internal/config"
@@ -465,6 +466,39 @@ func (s *AuthService) ChangePassword(userID, oldPassword, newPassword string) er
 // SetUserLibraries 사용자의 접근 가능 라이브러리 설정 (관리자용)
 func (s *AuthService) SetUserLibraries(userID string, libraryIDs []string) error {
 	return s.userRepo.SetUserLibraries(nil, userID, libraryIDs)
+}
+
+// GetOPDSKey 사용자의 OPDS API Key 조회
+func (s *AuthService) GetOPDSKey(userID string) (string, error) {
+	user, err := s.userRepo.FindByID(nil, userID)
+	if err != nil {
+		return "", err
+	}
+	if user == nil {
+		return "", ErrUserNotFound
+	}
+	return user.OPDSKey, nil
+}
+
+// RegenerateOPDSKey 사용자의 OPDS API Key 재발급
+func (s *AuthService) RegenerateOPDSKey(userID string) (string, error) {
+	user, err := s.userRepo.FindByID(nil, userID)
+	if err != nil {
+		return "", err
+	}
+	if user == nil {
+		return "", ErrUserNotFound
+	}
+
+	// 새로운 랜덤 키 생성
+	newKey := uuid.New().String()
+	user.OPDSKey = newKey
+
+	if err := s.userRepo.Update(nil, user); err != nil {
+		return "", err
+	}
+
+	return newKey, nil
 }
 
 // GetAllowedLibraryIDs 사용자의 접근 가능 라이브러리 ID 목록 조회

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -97,6 +97,8 @@ export const authAPI = {
   me: () => api.get("/auth/me"),
   updateProfile: (data: { nickname: string }) => api.put("/auth/me", data),
   changePassword: (data: { old_password: string; new_password: string }) => api.put("/auth/me/password", data),
+  getOPDSKey: () => api.get<{ opds_key: string }>("/users/me/opds-key"),
+  regenerateOPDSKey: () => api.post<{ opds_key: string }>("/users/me/opds-key/regenerate"),
 };
 
 // Users API (Master only)

--- a/web/src/components/settings/OPDSTab.module.css
+++ b/web/src/components/settings/OPDSTab.module.css
@@ -1,0 +1,152 @@
+.section {
+  margin-top: 1.5rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #e2e8f0;
+  margin-bottom: 0.5rem;
+}
+
+.inputGroup {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  color: #a0aec0;
+  font-size: 0.9rem;
+  outline: none;
+  font-family: monospace;
+}
+
+.iconButton {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem;
+  color: #a0aec0;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.successIcon {
+  color: #48bb78;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #718096;
+  margin-top: 0.5rem;
+}
+
+.dangerZone {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: rgba(245, 101, 101, 0.05);
+  border: 1px solid rgba(245, 101, 101, 0.1);
+  border-radius: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+}
+
+.dangerInfo h4 {
+  color: #feb2b2;
+  margin: 0 0 0.25rem 0;
+  font-size: 1rem;
+}
+
+.dangerInfo p {
+  color: #718096;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.dangerButton {
+  background: #c53030;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.dangerButton:hover:not(:disabled) {
+  background: #cc4747;
+}
+
+.dangerButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 3rem;
+  color: #718096;
+}
+
+.errorBanner {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: rgba(245, 101, 101, 0.1);
+  border-radius: 8px;
+  color: #feb2b2;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 768px) {
+  .dangerZone {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+}

--- a/web/src/components/settings/OPDSTab.tsx
+++ b/web/src/components/settings/OPDSTab.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Copy, RefreshCw, Check, AlertCircle, Rss } from "lucide-react";
+import { authAPI } from "../../api/client";
+import { AlertModal } from "../modals/AlertModal";
+import commonStyles from "./SettingsComponents.module.css";
+import styles from "./OPDSTab.module.css";
+
+export function OPDSTab() {
+  const { t } = useTranslation();
+  const [opdsKey, setOpdsKey] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fetchOPDSKey = async () => {
+    try {
+      setIsLoading(true);
+      const response = await authAPI.getOPDSKey();
+      setOpdsKey(response.data.opds_key);
+      setError(null);
+    } catch (err) {
+      console.error("Failed to fetch OPDS key:", err);
+      setError(t("settings.opds.fetch_error"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchOPDSKey();
+  }, []);
+
+  const handleRegenerate = async () => {
+    try {
+      setIsRegenerating(true);
+      const response = await authAPI.regenerateOPDSKey();
+      setOpdsKey(response.data.opds_key);
+      setError(null);
+      setIsModalOpen(false);
+    } catch (err) {
+      console.error("Failed to regenerate OPDS key:", err);
+      alert(t("settings.opds.regenerate_error"));
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
+  const handleCopy = () => {
+    const url = `${window.location.origin}/api/v1/opds?key=${opdsKey}`;
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return <div className={styles.loading}>{t("common.loading")}</div>;
+  }
+
+  const displayUrl = opdsKey ? `${window.location.origin}/api/v1/opds?key=${opdsKey}` : t("settings.opds.no_key");
+
+  return (
+    <div className={commonStyles.tabContent}>
+      <div className={commonStyles.tabHeader}>
+        <h2>{t("settings.opds.title")}</h2>
+        <p className={commonStyles.tabDescription}>{t("settings.opds.description")}</p>
+      </div>
+
+      <div className={commonStyles.settingsSections}>
+        <section className={commonStyles.settingsSection}>
+          <div className={commonStyles.sectionTitle}>
+            <Rss size={18} />
+            <h3>{t("settings.opds.url_label")}</h3>
+          </div>
+
+          <div className={styles.section}>
+            <div className={styles.inputGroup}>
+              <input
+                type="text"
+                className={styles.input}
+                value={displayUrl}
+                readOnly
+              />
+              <button
+                className={styles.iconButton}
+                onClick={handleCopy}
+                disabled={!opdsKey}
+                title={t("common.copy")}
+              >
+                {copied ? (
+                  <Check
+                    size={18}
+                    className={styles.successIcon}
+                  />
+                ) : (
+                  <Copy size={18} />
+                )}
+              </button>
+            </div>
+            <p className={styles.hint}>{t("settings.opds.url_hint")}</p>
+          </div>
+        </section>
+
+        <section className={commonStyles.settingsSection}>
+          <div className={styles.dangerZone}>
+            <div className={styles.dangerInfo}>
+              <h4>{t("settings.opds.regenerate_title")}</h4>
+              <p>{t("settings.opds.regenerate_description")}</p>
+            </div>
+            <button
+              className={styles.dangerButton}
+              onClick={() => setIsModalOpen(true)}
+              disabled={isRegenerating}
+            >
+              <RefreshCw
+                size={18}
+                className={isRegenerating ? styles.spinning : ""}
+              />
+              {t("settings.opds.regenerate_btn")}
+            </button>
+          </div>
+        </section>
+      </div>
+
+      <AlertModal
+        isOpen={isModalOpen}
+        type="warning"
+        title={t("settings.opds.regenerate_title")}
+        message={t("settings.opds.regenerate_confirm")}
+        confirmText={t("settings.opds.regenerate_btn")}
+        showCancel={true}
+        onConfirm={handleRegenerate}
+        onCancel={() => setIsModalOpen(false)}
+      />
+
+      {error && (
+        <div className={styles.errorBanner}>
+          <AlertCircle size={18} />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -76,7 +76,8 @@
       "users": "Users",
       "system": "System",
       "account": "Account",
-      "statistics": "Statistics"
+      "statistics": "Statistics",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "My Statistics",
@@ -413,6 +414,19 @@
         "deleted": "User deleted.",
         "delete_failed": "Failed to delete user."
       }
+    },
+    "opds": {
+      "title": "OPDS Settings",
+      "description": "OPDS API Key allows you to connect to your library from external apps (Kavita, Chunky, Moon+ Reader, etc.) without entering your username and password.",
+      "url_label": "My OPDS URL",
+      "url_hint": "Use this URL as the catalog address in your OPDS client app.",
+      "no_key": "No key generated. Please click the regenerate button.",
+      "regenerate_title": "Regenerate API Key",
+      "regenerate_description": "The existing API Key will be invalidated immediately, and access from all currently connected apps will be blocked.",
+      "regenerate_btn": "Generate New API Key",
+      "regenerate_confirm": "Are you sure you want to regenerate the API Key?\nAll currently connected OPDS apps will be disconnected.",
+      "fetch_error": "Failed to load API Key.",
+      "regenerate_error": "Failed to regenerate API Key."
     }
   },
   "home": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -76,7 +76,8 @@
       "users": "ユーザー管理",
       "system": "システム",
       "account": "アカウント",
-      "statistics": "統計"
+      "statistics": "統計",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "マイ統計",
@@ -410,6 +411,19 @@
         "deleted": "ユーザーが削除されました。",
         "delete_failed": "ユーザーの削除に失敗しました。"
       }
+    },
+    "opds": {
+      "title": "OPDS設定",
+      "description": "OPDS API Keyを使用すると、ユーザーIDとパスワードを入力することなく、外部アプリ（Kavita、Chunky、Moon+ Readerなど）からライブラリに接続できます。",
+      "url_label": "マイ OPDS URL",
+      "url_hint": "このURLをOPDSクライアントアプリのカタログアドレスとして使用してください。",
+      "no_key": "キーが生成されていません。再発行ボタンを押してください。",
+      "regenerate_title": "API Keyの再発行",
+      "regenerate_description": "既存のAPI Keyは即座に無効化され、現在接続されているすべてのアプリのアクセスが遮断されます。",
+      "regenerate_btn": "新しいAPI Keyを作成",
+      "regenerate_confirm": "API Keyを再発行しますか？\n既存のすべてのOPDSアプリとの接続が切断されます。",
+      "fetch_error": "API Keyの取得に失敗しました。",
+      "regenerate_error": "API Keyの再発行に失敗しました。"
     }
   },
   "home": {

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -76,7 +76,8 @@
       "users": "사용자 관리",
       "system": "시스템",
       "account": "내 계정",
-      "statistics": "통계"
+      "statistics": "통계",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "내 통계",
@@ -413,6 +414,19 @@
         "deleted": "사용자가 삭제되었습니다.",
         "delete_failed": "사용자 삭제에 실패했습니다."
       }
+    },
+    "opds": {
+      "title": "OPDS 설정",
+      "description": "OPDS API Key를 사용하면 아이디와 비밀번호 입력 없이 외부 앱(Kavita, Chunky, Moon+ Reader 등)에서 라이브러리에 연결할 수 있습니다.",
+      "url_label": "내 OPDS URL",
+      "url_hint": "이 URL을 OPDS 클라이언트 앱의 카탈로그 주소로 사용하세요.",
+      "no_key": "키가 생성되지 않았습니다. 재발급 버튼을 눌러주세요.",
+      "regenerate_title": "API Key 재발급",
+      "regenerate_description": "기존 API Key는 즉시 무효화되며 현재 연결된 모든 앱의 접근이 차단됩니다.",
+      "regenerate_btn": "새 API Key 생성",
+      "regenerate_confirm": "API Key를 재발급하시겠습니까?\n기존에 연결된 모든 OPDS 앱의 연결이 끊어지게 됩니다.",
+      "fetch_error": "API Key를 불러오는데 실패했습니다.",
+      "regenerate_error": "API Key 재발급에 실패했습니다."
     }
   },
   "home": {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, Users, Server, User, Settings, Monitor, BarChart3 } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+import { Library, Users, Server, User, Settings, Monitor, BarChart3, Rss } from "lucide-react";
 import { Header } from "../components/headers/Header";
 import { Sidebar } from "../components/Sidebar";
 import { SubHeader } from "../components/headers/SubHeader";
@@ -12,10 +13,11 @@ import { UsersTab } from "../components/settings/UsersTab";
 import { SystemTab } from "../components/settings/SystemTab";
 import { AccountTab } from "../components/settings/AccountTab";
 import { StatisticsTab } from "../components/settings/StatisticsTab";
+import { OPDSTab } from "../components/settings/OPDSTab";
 import styles from "./Settings.module.css";
 
 // 설정 탭 타입
-type SettingsTab = "general" | "statistics" | "viewer" | "libraries" | "users" | "system" | "account";
+type SettingsTab = "general" | "statistics" | "viewer" | "libraries" | "users" | "system" | "account" | "opds";
 
 // 탭 정보
 const TABS: { id: SettingsTab; label: string; icon: typeof Library; adminOnly?: boolean }[] = [
@@ -26,13 +28,28 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Library; adminOnly?: 
   { id: "users", label: "settings.tabs.users", icon: Users, adminOnly: true },
   { id: "system", label: "settings.tabs.system", icon: Server, adminOnly: true },
   { id: "account", label: "settings.tabs.account", icon: User },
+  { id: "opds", label: "settings.tabs.opds", icon: Rss },
 ];
 
 export function SettingsPage() {
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const user = useAuthStore((state) => state.user);
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [activeTab, setActiveTabState] = useState<SettingsTab>("general");
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  // URL 파라미터와 탭 상태 동기화
+  useEffect(() => {
+    const tabParam = searchParams.get("tab") as SettingsTab;
+    if (tabParam && TABS.some((t) => t.id === tabParam)) {
+      setActiveTabState(tabParam);
+    }
+  }, [searchParams]);
+
+  const setActiveTab = (tab: SettingsTab) => {
+    setActiveTabState(tab);
+    setSearchParams({ tab });
+  };
 
   // 사용자 역할에 따른 탭 필터링
   const availableTabs = TABS.filter((tab) => !tab.adminOnly || user?.role === "MASTER");
@@ -54,6 +71,8 @@ export function SettingsPage() {
         return <SystemTab />;
       case "account":
         return <AccountTab />;
+      case "opds":
+        return <OPDSTab />;
       default:
         return null;
     }


### PR DESCRIPTION
## 구현 내용

### 1. OPDS v1.2 및 API Key 인증
- **API Key 기반 인증**: URL 파라미터(?key=...) 또는 'X-OPDS-API-KEY' 헤더를 통한 인증 기능을 추가했습니다. 기존 Basic Auth와 함께 사용할 수 있습니다.
- **OPDS 피드**: 라이브러리, 시리즈, 권(Volume) 정보를 포함하는 Atom 피드 형식을 구현했습니다.
- **라우팅 수정**: API 엔드포인트 충돌로 인해 발생하던 404 오류를 해결하기 위해 라우팅 구조를 개선했습니다.

### 2. 설정 페이지 UX 개선
- **탭 유지 기능 (Persistence)**: 설정 페이지에서 새로고침 시에도 사용자가 보고 있던 탭이 유지되도록 URL 파라미터(?tab=...) 연동 로직을 추가했습니다.
- **커스텀 확인 모달**: API Key 생성/재발급 시 브라우저 기본 컨펌 창 대신 'AlertModal' 컴포넌트를 적용하여 시각적 확인 절차를 개선했습니다.

### 3. 기타 사항
- 한국어, 영어, 일본어 다국어 번역 지원 추가
- aha-hyeong 테이블에  컬럼 추가를 위한 DB 마이그레이션 적용

## 검증 결과
- **백엔드**: 빌드 및 DB 마이그레이션 정상 작동 확인
- **프론트엔드**: 빌드 성공 및 탭 고정/키 생성 UI 동작 수동 테스트 완료