### PR TITLE
feat(opds): implement OPDS v1.2 catalog with API key authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ temp/
 # Docker (로컬 볼륨)
 # =============
 docker-data/
+books/
+config/
 
 # =============
 # Antigravity AI Agent (로컬 전용)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -91,6 +91,7 @@ func main() {
 	systemHandler := handler.NewSystemHandler(settingRepo) // 추가
 	statsHandler := handler.NewStatsHandler(progressRepo, completionRepo)
 	sseHandler := handler.NewSSEHandler(hub)
+	opdsHandler := handler.NewOPDSHandler(seriesRepo, libraryRepo, volumeRepo, chapterRepo, userRepo, authService, cfg)
 
 
 	// 미들웨어 초기화
@@ -149,6 +150,23 @@ func main() {
 	// === SSE 스트림 라우트 ===
 	v1.Get("/sse", authMiddleware.Protected(), sseHandler.Handle)
 
+	// === OPDS 라우트 (Basic Auth) ===
+	opds := v1.Group("/opds", opdsHandler.BasicAuthMiddleware)
+	opds.Get("", opdsHandler.Catalog)
+	opds.Get("/library/:id", opdsHandler.LibrarySeries)
+	opds.Get("/series/:id", opdsHandler.SeriesVolumes)
+
+	// OPDS 전용 콘텐츠 라우트 (Basic Auth/API Key 인증 하에 서빙)
+	opds.Get("/series/:id/thumbnail", func(c *fiber.Ctx) error {
+		c.Locals("type", "series")
+		return imageHandler.GetThumbnail(c)
+	})
+	opds.Get("/volumes/:id/thumbnail", func(c *fiber.Ctx) error {
+		c.Locals("type", "volumes")
+		return imageHandler.GetThumbnail(c)
+	})
+	opds.Get("/download/volumes/:id", downloadHandler.DownloadVolume)
+
 	// === 인증 필요 라우트 ===
 	protected := v1.Group("", authMiddleware.Protected())
 
@@ -159,6 +177,11 @@ func main() {
 	users.Delete("/:id", userHandler.Delete)
 	users.Put("/:id", userHandler.Update)
 	users.Put("/:id/libraries", userHandler.UpdateLibraries)
+	
+	// OPDS API Key (자신의 정보)
+	users.Get("/me/opds-key", userHandler.GetMyOPDSKey)
+	users.Post("/me/opds-key/regenerate", userHandler.RegenerateMyOPDSKey)
+
 	users.Get("/sessions", authMiddleware.MasterOnly(), authHandler.ListAllSessions)
 	users.Delete("/:userId/sessions/:sessionId", authMiddleware.MasterOnly(), authHandler.RevokeSessionByAdmin)
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -323,7 +323,24 @@ func Migrate() error {
 	// 18. 사용자별 시리즈 설정에 터치 스와이프 방향 추가
 	migrateSwipeDirection()
 
+	// 19. 사용자 OPDS API Key 컬럼 추가
+	migrateUserOPDSKey()
+
 	return nil
+}
+
+// migrateUserOPDSKey users 테이블에 opds_key 컬럼 추가
+func migrateUserOPDSKey() {
+	if !columnExists("users", "opds_key") {
+		_, err := DB.Exec(`ALTER TABLE users ADD COLUMN opds_key TEXT DEFAULT ''`)
+		if err != nil {
+			fmt.Printf("Migration error (users.opds_key): %v\n", err)
+		} else {
+			fmt.Println("Migrated users table: added opds_key column.")
+		}
+	}
+	// 인덱스 추가 (조회 성능 향상)
+	_, _ = DB.Exec(`CREATE INDEX IF NOT EXISTS idx_users_opds_key ON users(opds_key)`)
 }
 
 // migrateSessions 세션 테이블 생성 (기기별 로그인 관리)

--- a/backend/internal/handler/opds_handler.go
+++ b/backend/internal/handler/opds_handler.go
@@ -1,0 +1,328 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/aha-hyeong/kumiho/backend/internal/config"
+	"github.com/aha-hyeong/kumiho/backend/internal/model"
+	"github.com/aha-hyeong/kumiho/backend/internal/repository"
+	"github.com/aha-hyeong/kumiho/backend/internal/service"
+)
+
+type OPDSHandler struct {
+	seriesRepo  *repository.SeriesRepository
+	libraryRepo *repository.LibraryRepository
+	volumeRepo  *repository.VolumeRepository
+	chapterRepo *repository.ChapterRepository
+	userRepo    *repository.UserRepository
+	authService *service.AuthService
+	config      *config.Config
+}
+
+func NewOPDSHandler(
+	seriesRepo *repository.SeriesRepository,
+	libraryRepo *repository.LibraryRepository,
+	volumeRepo *repository.VolumeRepository,
+	chapterRepo *repository.ChapterRepository,
+	userRepo *repository.UserRepository,
+	authService *service.AuthService,
+	cfg *config.Config,
+) *OPDSHandler {
+	return &OPDSHandler{
+		seriesRepo:  seriesRepo,
+		libraryRepo: libraryRepo,
+		volumeRepo:  volumeRepo,
+		chapterRepo: chapterRepo,
+		userRepo:    userRepo,
+		authService: authService,
+		config:      cfg,
+	}
+}
+
+// BasicAuthMiddleware OPDS 전용 Basic Auth 미들웨어
+func (h *OPDSHandler) BasicAuthMiddleware(c *fiber.Ctx) error {
+	// 1. URL 파라미터 또는 헤더에서 API Key 확인 (Kavita 방식)
+	apiKey := c.Query("key")
+	if apiKey == "" {
+		apiKey = c.Get("X-OPDS-API-KEY")
+	}
+
+	if apiKey != "" {
+		// API Key로 사용자 조회
+		user, err := h.userRepo.FindByOPDSKey(nil, apiKey)
+		if err != nil {
+			return h.sendError(c, http.StatusInternalServerError, "failed to verify api key")
+		}
+		if user != nil {
+			// 컨텍스트에 사용자 정보 저장
+			c.Locals("userID", user.ID)
+			c.Locals("role", user.Role)
+			return c.Next()
+		}
+		// 유효하지 않은 키인 경우 계속해서 Basic Auth 시도 (또는 에러 반환)
+	}
+
+	// 2. 표준 HTTP Basic Auth 확인
+	auth := c.Get("Authorization")
+	if auth == "" {
+		c.Set("WWW-Authenticate", `Basic realm="Kumiho OPDS"`)
+		return c.SendStatus(http.StatusUnauthorized)
+	}
+
+	parts := strings.Split(auth, " ")
+	if len(parts) != 2 || parts[0] != "Basic" {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "invalid auth header"})
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "failed to decode auth"})
+	}
+
+	pair := strings.SplitN(string(payload), ":", 2)
+	if len(pair) != 2 {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "invalid auth format"})
+	}
+
+	username, password := pair[0], pair[1]
+
+	// AuthService를 통한 사용자 검증
+	tokenResp, err := h.authService.Login(&service.LoginRequest{
+		Username: username,
+		Password: password,
+	}, nil)
+
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "invalid credentials"})
+	}
+
+	// 컨텍스트에 사용자 정보 저장
+	c.Locals("userID", tokenResp.User.ID)
+	c.Locals("role", tokenResp.User.Role)
+
+	return c.Next()
+}
+
+// Catalog 최상위 카탈로그 (라이브러리 목록)
+// GET /api/v1/opds
+func (h *OPDSHandler) Catalog(c *fiber.Ctx) error {
+	userID, ok := c.Locals("userID").(string)
+	if !ok {
+		return h.sendError(c, http.StatusUnauthorized, "unauthorized")
+	}
+	
+	libraries, err := h.libraryRepo.FindAll(nil)
+	if err != nil {
+		return h.sendError(c, http.StatusInternalServerError, "failed to fetch libraries")
+	}
+
+	allowedIDs, err := h.authService.GetAllowedLibraryIDs(userID)
+	if err != nil {
+		allowedIDs = []string{}
+	}
+
+	role, ok := c.Locals("role").(model.Role)
+	if !ok {
+		role = model.RoleUser
+	}
+
+	feed := h.newFeed("Kumiho OPDS Catalog", h.baseURL(c, "/api/v1/opds"))
+	
+	for _, lib := range libraries {
+		// 권한 확인
+		if role != model.RoleMaster && lib.Type != "SYSTEM" {
+			allowed := false
+			for _, aid := range allowedIDs {
+				if aid == lib.ID {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				continue
+			}
+		}
+
+		entry := model.Entry{
+			ID:      fmt.Sprintf("urn:kumiho:library:%s", lib.ID),
+			Title:   lib.Name,
+			Updated: lib.UpdatedAt,
+			Links: []model.Link{
+				{
+					Rel:  "subsection",
+					Type: "application/atom+xml;profile=opds-catalog;kind=navigation",
+					Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/library/%s", lib.ID)),
+				},
+			},
+		}
+		feed.Entries = append(feed.Entries, entry)
+	}
+
+	return h.sendXML(c, feed)
+}
+
+// LibrarySeries 라이브러리 내 시리즈 목록
+// GET /api/v1/opds/library/:id
+func (h *OPDSHandler) LibrarySeries(c *fiber.Ctx) error {
+	libraryID := c.Params("id")
+	userID, ok := c.Locals("userID").(string)
+	if !ok {
+		return h.sendError(c, http.StatusUnauthorized, "unauthorized")
+	}
+
+	seriesList, err := h.seriesRepo.FindByLibraryID(nil, libraryID, userID)
+	if err != nil {
+		return h.sendError(c, http.StatusInternalServerError, "failed to fetch series")
+	}
+
+	lib, _ := h.libraryRepo.FindByID(nil, libraryID)
+	title := "Series List"
+	if lib != nil {
+		title = lib.Name
+	}
+
+	feed := h.newFeed(title, h.baseURL(c, fmt.Sprintf("/api/v1/opds/library/%s", libraryID)))
+	feed.Links = append(feed.Links, model.Link{
+		Rel:  "up",
+		Type: "application/atom+xml;profile=opds-catalog;kind=navigation",
+		Href: h.baseURL(c, "/api/v1/opds"),
+	})
+
+	for _, s := range seriesList {
+		entry := model.Entry{
+			ID:      fmt.Sprintf("urn:kumiho:series:%s", s.ID),
+			Title:   s.Title,
+			Updated: s.UpdatedAt,
+			Summary: s.Description,
+			Links: []model.Link{
+				{
+					Rel:  "subsection",
+					Type: "application/atom+xml;profile=opds-catalog;kind=navigation",
+					Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/series/%s", s.ID)),
+				},
+			},
+		}
+
+		if s.ThumbnailPath != nil && *s.ThumbnailPath != "" {
+			entry.Links = append(entry.Links, model.Link{
+				Rel:  "http://opds-spec.org/image",
+				Type: "image/jpeg",
+				Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/series/%s/thumbnail", s.ID)),
+			})
+			entry.Links = append(entry.Links, model.Link{
+				Rel:  "http://opds-spec.org/image/thumbnail",
+				Type: "image/jpeg",
+				Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/series/%s/thumbnail", s.ID)),
+			})
+		}
+
+		feed.Entries = append(feed.Entries, entry)
+	}
+
+	return h.sendXML(c, feed)
+}
+
+// SeriesVolumes 시리즈 내 볼륨 목록
+// GET /api/v1/opds/series/:id
+func (h *OPDSHandler) SeriesVolumes(c *fiber.Ctx) error {
+	seriesID := c.Params("id")
+	userID, ok := c.Locals("userID").(string)
+	if !ok {
+		return h.sendError(c, http.StatusUnauthorized, "unauthorized")
+	}
+
+	series, _ := h.seriesRepo.FindByID(nil, seriesID, userID)
+	if series == nil {
+		return h.sendError(c, http.StatusNotFound, "series not found")
+	}
+
+	volumes, err := h.volumeRepo.FindBySeriesID(nil, seriesID)
+	if err != nil {
+		return h.sendError(c, http.StatusInternalServerError, "failed to fetch volumes")
+	}
+
+	feed := h.newFeed(series.Title, h.baseURL(c, fmt.Sprintf("/api/v1/opds/series/%s", seriesID)))
+	feed.Links = append(feed.Links, model.Link{
+		Rel:  "up",
+		Type: "application/atom+xml;profile=opds-catalog;kind=navigation",
+		Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/library/%s", series.LibraryID)),
+	})
+
+	for _, v := range volumes {
+		entry := model.Entry{
+			ID:      fmt.Sprintf("urn:kumiho:volume:%s", v.ID),
+			Title:   v.Title,
+			Updated: v.UpdatedAt,
+			Summary: v.Description,
+			Links: []model.Link{
+				{
+					Rel:  "http://opds-spec.org/acquisition",
+					Type: "application/zip", // 만화책은 보통 zip/cbz 형태 다운로드 지원 시
+					Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/download/volumes/%s", v.ID)),
+				},
+			},
+		}
+
+		if v.ThumbnailPath != nil && *v.ThumbnailPath != "" {
+			entry.Links = append(entry.Links, model.Link{
+				Rel:  "http://opds-spec.org/image",
+				Type: "image/jpeg",
+				Href: h.baseURL(c, fmt.Sprintf("/api/v1/opds/volumes/%s/thumbnail", v.ID)),
+			})
+		}
+
+		feed.Entries = append(feed.Entries, entry)
+	}
+
+	return h.sendXML(c, feed)
+}
+
+// Helper methods
+
+func (h *OPDSHandler) newFeed(title, href string) model.Feed {
+	return model.Feed{
+		ID:      href,
+		Title:   title,
+		Updated: time.Now(),
+		Links: []model.Link{
+			{Rel: "self", Type: "application/atom+xml;profile=opds-catalog;kind=navigation", Href: href},
+			{Rel: "start", Type: "application/atom+xml;profile=opds-catalog;kind=navigation", Href: h.baseURL(nil, "/api/v1/opds")},
+		},
+	}
+}
+
+func (h *OPDSHandler) baseURL(c *fiber.Ctx, path string) string {
+	// 기본 도메인 설정이 있으면 사용, 없으면 요청 헤더에서 추출
+	host := ""
+	if c != nil {
+		host = c.Hostname()
+		protocol := "http"
+		if c.Secure() {
+			protocol = "https"
+		}
+		// 포트가 있으면 포함 (localhost:3000 등)
+		return fmt.Sprintf("%s://%s%s", protocol, host, path)
+	}
+	return path
+}
+
+func (h *OPDSHandler) sendXML(c *fiber.Ctx, feed model.Feed) error {
+	output, err := xml.MarshalIndent(feed, "", "  ")
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).SendString(err.Error())
+	}
+
+	c.Set("Content-Type", "application/atom+xml; charset=utf-8")
+	return c.SendString(xml.Header + string(output))
+}
+
+func (h *OPDSHandler) sendError(c *fiber.Ctx, code int, message string) error {
+	return c.Status(code).JSON(fiber.Map{"error": message})
+}

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -299,3 +299,29 @@ func (h *UserHandler) UpdateLibraries(c *fiber.Ctx) error {
 		"message": "user libraries updated",
 	})
 }
+
+// GetMyOPDSKey 자신의 OPDS API Key 조회
+// GET /api/v1/users/me/opds-key
+func (h *UserHandler) GetMyOPDSKey(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	key, err := h.authService.GetOPDSKey(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to get opds key",
+		})
+	}
+	return c.JSON(fiber.Map{"opds_key": key})
+}
+
+// RegenerateMyOPDSKey 자신의 OPDS API Key 재발급
+// POST /api/v1/users/me/opds-key/regenerate
+func (h *UserHandler) RegenerateMyOPDSKey(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	key, err := h.authService.RegenerateOPDSKey(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to regenerate opds key",
+		})
+	}
+	return c.JSON(fiber.Map{"opds_key": key})
+}

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -24,15 +24,12 @@ func (m *AuthMiddleware) Protected() fiber.Handler {
 
 		// 1. Authorization 헤더 확인 (모바일 앱 등)
 		authHeader := c.Get("Authorization")
-		if authHeader != "" {
+		if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
 			// Bearer 토큰 추출
 			parts := strings.Split(authHeader, " ")
-			if len(parts) != 2 || parts[0] != "Bearer" {
-				return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-					"error": "invalid authorization header format",
-				})
+			if len(parts) == 2 {
+				tokenString = parts[1]
 			}
-			tokenString = parts[1]
 		}
 
 		// 2. 헤더에 없으면 쿠키 확인 (웹 클라이언트)

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -20,6 +20,7 @@ type User struct {
 	PasswordHash string    `json:"-"`
 	Role         Role      `json:"role"`
 	CanDownload  bool      `json:"can_download" db:"can_download"` // 다운로드 권한
+	OPDSKey      string    `json:"opds_key" db:"opds_key"`         // OPDS API Key
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }

--- a/backend/internal/model/opds.go
+++ b/backend/internal/model/opds.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+// OPDS XML 네임스페이스 상수
+const (
+	AtomNamespace = "http://www.w3.org/2005/Atom"
+	OPDSNamespace = "http://opds-spec.org/2010/catalog"
+)
+
+// Feed OPDS 최상위 피드
+type Feed struct {
+	XMLName xml.Name `xml:"http://www.w3.org/2005/Atom feed"`
+	ID      string   `xml:"id"`
+	Title   string   `xml:"title"`
+	Updated time.Time `xml:"updated"`
+	Author  *Author  `xml:"author,omitempty"`
+	Links   []Link   `xml:"link"`
+	Entries []Entry  `xml:"entry"`
+}
+
+// Author 저자 정보
+type Author struct {
+	Name string `xml:"name"`
+	URI  string `xml:"uri,omitempty"`
+}
+
+// Link 피드 및 엔트리 링크
+type Link struct {
+	Rel  string `xml:"rel,attr"`
+	Type string `xml:"type,attr,omitempty"`
+	Href string `xml:"href,attr"`
+	Title string `xml:"title,attr,omitempty"`
+}
+
+// Entry 개별 엔트리 (시리즈, 권, 챕터 등)
+type Entry struct {
+	ID        string    `xml:"id"`
+	Title     string    `xml:"title"`
+	Updated   time.Time `xml:"updated"`
+	Content   *Content  `xml:"content,omitempty"`
+	Links     []Link    `xml:"link"`
+	Summary   string    `xml:"summary,omitempty"`
+	Author    *Author   `xml:"author,omitempty"`
+}
+
+// Content 엔트리 내용
+type Content struct {
+	Type string `xml:"type,attr"`
+	Body string `xml:",chardata"`
+}

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -25,9 +25,9 @@ func (r *UserRepository) Create(q database.Queryer, user *model.User) error {
 	user.UpdatedAt = now
 
 	_, err := q.Exec(
-		`INSERT INTO users (id, username, nickname, password_hash, role, can_download, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		user.ID, user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.CreatedAt, user.UpdatedAt,
+		`INSERT INTO users (id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.ID, user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.OPDSKey, user.CreatedAt, user.UpdatedAt,
 	)
 	return err
 }
@@ -37,10 +37,10 @@ func (r *UserRepository) FindByUsername(q database.Queryer, username string) (*m
 	q = database.GetQueryer(q)
 	user := &model.User{}
 	err := q.QueryRow(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
 		 FROM users WHERE username = ?`,
 		username,
-	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt)
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -56,10 +56,10 @@ func (r *UserRepository) FindByID(q database.Queryer, id string) (*model.User, e
 	q = database.GetQueryer(q)
 	user := &model.User{}
 	err := q.QueryRow(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
 		 FROM users WHERE id = ?`,
 		id,
-	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt)
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -82,7 +82,7 @@ func (r *UserRepository) Count(q database.Queryer) (int, error) {
 func (r *UserRepository) FindAll(q database.Queryer) ([]model.User, error) {
 	q = database.GetQueryer(q)
 	rows, err := q.Query(
-		`SELECT id, username, nickname, password_hash, role, can_download, created_at, updated_at FROM users ORDER BY created_at`,
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at FROM users ORDER BY created_at`,
 	)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (r *UserRepository) FindAll(q database.Queryer) ([]model.User, error) {
 	var users []model.User
 	for rows.Next() {
 		var user model.User
-		if err := rows.Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.CreatedAt, &user.UpdatedAt); err != nil {
+		if err := rows.Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt); err != nil {
 			return nil, err
 		}
 		users = append(users, user)
@@ -112,8 +112,8 @@ func (r *UserRepository) Update(q database.Queryer, user *model.User) error {
 	q = database.GetQueryer(q)
 	user.UpdatedAt = time.Now()
 	_, err := q.Exec(
-		`UPDATE users SET username = ?, nickname = ?, password_hash = ?, role = ?, can_download = ?, updated_at = ? WHERE id = ?`,
-		user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.UpdatedAt, user.ID,
+		`UPDATE users SET username = ?, nickname = ?, password_hash = ?, role = ?, can_download = ?, opds_key = ?, updated_at = ? WHERE id = ?`,
+		user.Username, user.Nickname, user.PasswordHash, user.Role, user.CanDownload, user.OPDSKey, user.UpdatedAt, user.ID,
 	)
 	return err
 }
@@ -177,4 +177,23 @@ func (r *UserRepository) GetAllowedLibraryIDs(q database.Queryer, userID string)
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// FindByOPDSKey opds_key로 사용자 조회
+func (r *UserRepository) FindByOPDSKey(q database.Queryer, key string) (*model.User, error) {
+	q = database.GetQueryer(q)
+	user := &model.User{}
+	err := q.QueryRow(
+		`SELECT id, username, nickname, password_hash, role, can_download, opds_key, created_at, updated_at
+		 FROM users WHERE opds_key = ? AND opds_key != ''`,
+		key,
+	).Scan(&user.ID, &user.Username, &user.Nickname, &user.PasswordHash, &user.Role, &user.CanDownload, &user.OPDSKey, &user.CreatedAt, &user.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/aha-hyeong/kumiho/backend/internal/config"
@@ -465,6 +466,39 @@ func (s *AuthService) ChangePassword(userID, oldPassword, newPassword string) er
 // SetUserLibraries 사용자의 접근 가능 라이브러리 설정 (관리자용)
 func (s *AuthService) SetUserLibraries(userID string, libraryIDs []string) error {
 	return s.userRepo.SetUserLibraries(nil, userID, libraryIDs)
+}
+
+// GetOPDSKey 사용자의 OPDS API Key 조회
+func (s *AuthService) GetOPDSKey(userID string) (string, error) {
+	user, err := s.userRepo.FindByID(nil, userID)
+	if err != nil {
+		return "", err
+	}
+	if user == nil {
+		return "", ErrUserNotFound
+	}
+	return user.OPDSKey, nil
+}
+
+// RegenerateOPDSKey 사용자의 OPDS API Key 재발급
+func (s *AuthService) RegenerateOPDSKey(userID string) (string, error) {
+	user, err := s.userRepo.FindByID(nil, userID)
+	if err != nil {
+		return "", err
+	}
+	if user == nil {
+		return "", ErrUserNotFound
+	}
+
+	// 새로운 랜덤 키 생성
+	newKey := uuid.New().String()
+	user.OPDSKey = newKey
+
+	if err := s.userRepo.Update(nil, user); err != nil {
+		return "", err
+	}
+
+	return newKey, nil
 }
 
 // GetAllowedLibraryIDs 사용자의 접근 가능 라이브러리 ID 목록 조회

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -97,6 +97,8 @@ export const authAPI = {
   me: () => api.get("/auth/me"),
   updateProfile: (data: { nickname: string }) => api.put("/auth/me", data),
   changePassword: (data: { old_password: string; new_password: string }) => api.put("/auth/me/password", data),
+  getOPDSKey: () => api.get<{ opds_key: string }>("/users/me/opds-key"),
+  regenerateOPDSKey: () => api.post<{ opds_key: string }>("/users/me/opds-key/regenerate"),
 };
 
 // Users API (Master only)

--- a/web/src/components/settings/OPDSTab.module.css
+++ b/web/src/components/settings/OPDSTab.module.css
@@ -1,0 +1,152 @@
+.section {
+  margin-top: 1.5rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #e2e8f0;
+  margin-bottom: 0.5rem;
+}
+
+.inputGroup {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  color: #a0aec0;
+  font-size: 0.9rem;
+  outline: none;
+  font-family: monospace;
+}
+
+.iconButton {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem;
+  color: #a0aec0;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.successIcon {
+  color: #48bb78;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #718096;
+  margin-top: 0.5rem;
+}
+
+.dangerZone {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: rgba(245, 101, 101, 0.05);
+  border: 1px solid rgba(245, 101, 101, 0.1);
+  border-radius: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+}
+
+.dangerInfo h4 {
+  color: #feb2b2;
+  margin: 0 0 0.25rem 0;
+  font-size: 1rem;
+}
+
+.dangerInfo p {
+  color: #718096;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.dangerButton {
+  background: #c53030;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.dangerButton:hover:not(:disabled) {
+  background: #cc4747;
+}
+
+.dangerButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 3rem;
+  color: #718096;
+}
+
+.errorBanner {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: rgba(245, 101, 101, 0.1);
+  border-radius: 8px;
+  color: #feb2b2;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 768px) {
+  .dangerZone {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+}

--- a/web/src/components/settings/OPDSTab.tsx
+++ b/web/src/components/settings/OPDSTab.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Copy, RefreshCw, Check, AlertCircle, Rss } from "lucide-react";
+import { authAPI } from "../../api/client";
+import { AlertModal } from "../modals/AlertModal";
+import commonStyles from "./SettingsComponents.module.css";
+import styles from "./OPDSTab.module.css";
+
+export function OPDSTab() {
+  const { t } = useTranslation();
+  const [opdsKey, setOpdsKey] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fetchOPDSKey = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const response = await authAPI.getOPDSKey();
+      setOpdsKey(response.data.opds_key);
+      setError(null);
+    } catch (err) {
+      console.error("Failed to fetch OPDS key:", err);
+      setError(t("settings.opds.fetch_error"));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchOPDSKey();
+  }, [fetchOPDSKey]);
+
+  const handleRegenerate = async () => {
+    try {
+      setIsRegenerating(true);
+      const response = await authAPI.regenerateOPDSKey();
+      setOpdsKey(response.data.opds_key);
+      setError(null);
+      setIsModalOpen(false);
+    } catch (err) {
+      console.error("Failed to regenerate OPDS key:", err);
+      alert(t("settings.opds.regenerate_error"));
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
+  const getOpdsBaseUrl = () => {
+    const origin = window.location.origin;
+    // 개발 환경(5173 포트)인 경우 백엔드 포트(9999)로 교체
+    if (origin.includes(":5173")) {
+      return origin.replace(":5173", ":9999");
+    }
+    return origin;
+  };
+
+  const handleCopy = () => {
+    const url = `${getOpdsBaseUrl()}/api/v1/opds?key=${opdsKey}`;
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return <div className={styles.loading}>{t("common.loading")}</div>;
+  }
+
+  const displayUrl = opdsKey ? `${getOpdsBaseUrl()}/api/v1/opds?key=${opdsKey}` : t("settings.opds.no_key");
+
+  return (
+    <div className={commonStyles.tabContent}>
+      <div className={commonStyles.tabHeader}>
+        <h2>{t("settings.opds.title")}</h2>
+        <p className={commonStyles.tabDescription}>{t("settings.opds.description")}</p>
+      </div>
+
+      <div className={commonStyles.settingsSections}>
+        <section className={commonStyles.settingsSection}>
+          <div className={commonStyles.sectionTitle}>
+            <Rss size={18} />
+            <h3>{t("settings.opds.url_label")}</h3>
+          </div>
+
+          <div className={styles.section}>
+            <div className={styles.inputGroup}>
+              <input
+                type="text"
+                className={styles.input}
+                value={displayUrl}
+                readOnly
+              />
+              <button
+                className={styles.iconButton}
+                onClick={handleCopy}
+                disabled={!opdsKey}
+                title={t("common.copy")}
+              >
+                {copied ? (
+                  <Check
+                    size={18}
+                    className={styles.successIcon}
+                  />
+                ) : (
+                  <Copy size={18} />
+                )}
+              </button>
+            </div>
+            <p className={styles.hint}>{t("settings.opds.url_hint")}</p>
+          </div>
+        </section>
+
+        <section className={commonStyles.settingsSection}>
+          <div className={styles.dangerZone}>
+            <div className={styles.dangerInfo}>
+              <h4>{t("settings.opds.regenerate_title")}</h4>
+              <p>{t("settings.opds.regenerate_description")}</p>
+            </div>
+            <button
+              className={styles.dangerButton}
+              onClick={() => setIsModalOpen(true)}
+              disabled={isRegenerating}
+            >
+              <RefreshCw
+                size={18}
+                className={isRegenerating ? styles.spinning : ""}
+              />
+              {t("settings.opds.regenerate_btn")}
+            </button>
+          </div>
+        </section>
+      </div>
+
+      <AlertModal
+        isOpen={isModalOpen}
+        type="warning"
+        title={t("settings.opds.regenerate_title")}
+        message={t("settings.opds.regenerate_confirm")}
+        confirmText={t("settings.opds.regenerate_btn")}
+        showCancel={true}
+        onConfirm={handleRegenerate}
+        onCancel={() => setIsModalOpen(false)}
+      />
+
+      {error && (
+        <div className={styles.errorBanner}>
+          <AlertCircle size={18} />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -76,7 +76,8 @@
       "users": "Users",
       "system": "System",
       "account": "Account",
-      "statistics": "Statistics"
+      "statistics": "Statistics",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "My Statistics",
@@ -413,6 +414,19 @@
         "deleted": "User deleted.",
         "delete_failed": "Failed to delete user."
       }
+    },
+    "opds": {
+      "title": "OPDS Settings",
+      "description": "OPDS API Key allows you to connect to your library from external apps (Kavita, Chunky, Moon+ Reader, etc.) without entering your username and password.",
+      "url_label": "My OPDS URL",
+      "url_hint": "Use this URL as the catalog address in your OPDS client app.",
+      "no_key": "No key generated. Please click the regenerate button.",
+      "regenerate_title": "Regenerate API Key",
+      "regenerate_description": "The existing API Key will be invalidated immediately, and access from all currently connected apps will be blocked.",
+      "regenerate_btn": "Generate New API Key",
+      "regenerate_confirm": "Are you sure you want to regenerate the API Key?\nAll currently connected OPDS apps will be disconnected.",
+      "fetch_error": "Failed to load API Key.",
+      "regenerate_error": "Failed to regenerate API Key."
     }
   },
   "home": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -76,7 +76,8 @@
       "users": "ユーザー管理",
       "system": "システム",
       "account": "アカウント",
-      "statistics": "統計"
+      "statistics": "統計",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "マイ統計",
@@ -410,6 +411,19 @@
         "deleted": "ユーザーが削除されました。",
         "delete_failed": "ユーザーの削除に失敗しました。"
       }
+    },
+    "opds": {
+      "title": "OPDS設定",
+      "description": "OPDS API Keyを使用すると、ユーザーIDとパスワードを入力することなく、外部アプリ（Kavita、Chunky、Moon+ Readerなど）からライブラリに接続できます。",
+      "url_label": "マイ OPDS URL",
+      "url_hint": "このURLをOPDSクライアントアプリのカタログアドレスとして使用してください。",
+      "no_key": "キーが生成されていません。再発行ボタンを押してください。",
+      "regenerate_title": "API Keyの再発行",
+      "regenerate_description": "既存のAPI Keyは即座に無効化され、現在接続されているすべてのアプリのアクセスが遮断されます。",
+      "regenerate_btn": "新しいAPI Keyを作成",
+      "regenerate_confirm": "API Keyを再発行しますか？\n既存のすべてのOPDSアプリとの接続が切断されます。",
+      "fetch_error": "API Keyの取得に失敗しました。",
+      "regenerate_error": "API Keyの再発行に失敗しました。"
     }
   },
   "home": {

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -76,7 +76,8 @@
       "users": "사용자 관리",
       "system": "시스템",
       "account": "내 계정",
-      "statistics": "통계"
+      "statistics": "통계",
+      "opds": "OPDS"
     },
     "statistics": {
       "title": "내 통계",
@@ -413,6 +414,19 @@
         "deleted": "사용자가 삭제되었습니다.",
         "delete_failed": "사용자 삭제에 실패했습니다."
       }
+    },
+    "opds": {
+      "title": "OPDS 설정",
+      "description": "OPDS API Key를 사용하면 아이디와 비밀번호 입력 없이 외부 앱(Kavita, Chunky, Moon+ Reader 등)에서 라이브러리에 연결할 수 있습니다.",
+      "url_label": "내 OPDS URL",
+      "url_hint": "이 URL을 OPDS 클라이언트 앱의 카탈로그 주소로 사용하세요.",
+      "no_key": "키가 생성되지 않았습니다. 재발급 버튼을 눌러주세요.",
+      "regenerate_title": "API Key 재발급",
+      "regenerate_description": "기존 API Key는 즉시 무효화되며 현재 연결된 모든 앱의 접근이 차단됩니다.",
+      "regenerate_btn": "새 API Key 생성",
+      "regenerate_confirm": "API Key를 재발급하시겠습니까?\n기존에 연결된 모든 OPDS 앱의 연결이 끊어지게 됩니다.",
+      "fetch_error": "API Key를 불러오는데 실패했습니다.",
+      "regenerate_error": "API Key 재발급에 실패했습니다."
     }
   },
   "home": {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, Users, Server, User, Settings, Monitor, BarChart3 } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+import { Library, Users, Server, User, Settings, Monitor, BarChart3, Rss } from "lucide-react";
 import { Header } from "../components/headers/Header";
 import { Sidebar } from "../components/Sidebar";
 import { SubHeader } from "../components/headers/SubHeader";
@@ -12,10 +13,11 @@ import { UsersTab } from "../components/settings/UsersTab";
 import { SystemTab } from "../components/settings/SystemTab";
 import { AccountTab } from "../components/settings/AccountTab";
 import { StatisticsTab } from "../components/settings/StatisticsTab";
+import { OPDSTab } from "../components/settings/OPDSTab";
 import styles from "./Settings.module.css";
 
 // 설정 탭 타입
-type SettingsTab = "general" | "statistics" | "viewer" | "libraries" | "users" | "system" | "account";
+type SettingsTab = "general" | "statistics" | "viewer" | "libraries" | "users" | "system" | "account" | "opds";
 
 // 탭 정보
 const TABS: { id: SettingsTab; label: string; icon: typeof Library; adminOnly?: boolean }[] = [
@@ -26,13 +28,22 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Library; adminOnly?: 
   { id: "users", label: "settings.tabs.users", icon: Users, adminOnly: true },
   { id: "system", label: "settings.tabs.system", icon: Server, adminOnly: true },
   { id: "account", label: "settings.tabs.account", icon: User },
+  { id: "opds", label: "settings.tabs.opds", icon: Rss },
 ];
 
 export function SettingsPage() {
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const user = useAuthStore((state) => state.user);
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  // URL 파라미터에서 현재 탭 계산 (Source of Truth를 URL로 일원화)
+  const tabParam = searchParams.get("tab") as SettingsTab;
+  const activeTab = tabParam && TABS.some((t) => t.id === tabParam) ? tabParam : "general";
+
+  const setActiveTab = (tab: SettingsTab) => {
+    setSearchParams({ tab });
+  };
 
   // 사용자 역할에 따른 탭 필터링
   const availableTabs = TABS.filter((tab) => !tab.adminOnly || user?.role === "MASTER");
@@ -54,6 +65,8 @@ export function SettingsPage() {
         return <SystemTab />;
       case "account":
         return <AccountTab />;
+      case "opds":
+        return <OPDSTab />;
       default:
         return null;
     }


### PR DESCRIPTION
## 개요

OPDS v1.2 표준을 구현하여 외부 리더 앱(Moon+ Reader, Chunky, Panels 등)에서 Kumiho 라이브러리에 접근 가능하도록 합니다.

## 변경 사항

### Backend
- **OPDS Handler** (`opds_handler.go`): OPDS v1.2 카탈로그 피드 (라이브러리 → 시리즈 → 볼륨)
- **인증**: API Key (URL 쿼리/헤더) + HTTP Basic Auth 이중 지원
- **OPDS 전용 콘텐츠 라우트**: 썸네일/다운로드를 OPDS 인증 그룹 내에서 서빙 (JWT 불필요)
- **DB 마이그레이션**: `users` 테이블에 `opds_key` 필드 추가
- **API 엔드포인트**: `GET /users/me/opds-key`, `POST /users/me/opds-key/regenerate`

### Frontend
- **OPDSTab 컴포넌트**: OPDS URL 표시, 복사, API Key 재발급 UI
- **Settings 개선**: URL 파라미터 기반 탭 유지 (새로고침 대응)
- **커스텀 AlertModal**: Key 재발급 시 확인 모달
- **i18n**: ko, en, ja 번역 추가

### 인프라
- `.gitignore`: Docker 볼륨 디렉토리 (`books/`, `config/`) 추가

## 알려진 문제 (추후 이 브랜치에서 작업 필요)

> ⚠️ **이 PR은 머지하지 않고, 아래 문제들을 해결한 뒤 머지할 예정입니다.**

### 1. OPDS MIME 타입 수정 필요
- 현재 볼륨 다운로드 링크의 MIME 타입이 `application/zip`으로 설정되어 있음
- Moon+ Reader 등에서 책을 "열기"가 아닌 "다운로드"로 인식함
- 파일 확장자에 따라 올바른 MIME 타입을 반환하도록 수정 필요:
  - `.cbz` → `application/vnd.comicbook+zip`
  - `.epub` → `application/epub+zip`
  - `.pdf` → `application/pdf`
  - 폴더(이미지) → CBZ 스트리밍

### 2. OPDS v2.0 (JSON) 지원 고려
- 현재 OPDS v1.2 (XML) 전용 구현
- 최신 앱 호환성을 위해 OPDS v2.0 JSON 포맷 병행 지원 검토

### 3. 전용 Mihon 확장 앱 개발 검토
- Kotlin 기반 Mihon 전용 소스 앱 제작 검토
- 양방향 트래킹, 세션 관리 등 고급 기능 구현 가능

## 테스트

- [x] OPDS 카탈로그 브라우저 접속 확인 (Basic Auth)
- [x] Moon+ Reader 연동 테스트 (카탈로그/라이브러리 표시 성공)
- [x] API Key 생성/재발급/복사 동작 확인
- [x] 백엔드 빌드 통과
- [x] 프론트엔드 빌드 통과
- [x] golangci-lint 통과
- [x] eslint 통과