### PR TITLE
fix: 단권 및 번호 없는 책의 프롤로그 오인식 문제 수정

### DIFF
--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -2344,8 +2344,8 @@ func parseVolumeNumber(name string) (int, string, bool) {
 		return 0, "volume", true
 	}
 
-	// Pattern 0: Korean "권", "화", "회" (e.g. 01권, 1권, 1화) -> Volume or Chapter
-	// reVolKorean is `(\d+)\s*(권|회|화)` so mKor[1] is number, mKor[2] is unit
+	// Pattern 0: Korean "권", "화", "회", "부" (e.g. 01권, 1권, 1화, 1부) -> Volume or Chapter
+	// reVolKorean is `(\d+)\s*(권|회|화|부)` so mKor[1] is number, mKor[2] is unit ("권"/"부" as volume, "회"/"화" as chapter)
 	mKor := reVolKorean.FindStringSubmatch(name)
 	if len(mKor) > 2 {
 		n, err := strconv.Atoi(mKor[1])


### PR DESCRIPTION
## 구현 내용
- 단권 책이나 파일명에 숫자가 없는 경우 스캐너가 기본값 0(Prologue)을 할당하던 로직 수정
- backend/internal/scanner/scanner.go의 scanSeriesContent 함수 내 볼륨 번호 자동 할당 로직 개선
- 번호 파싱 실패 시, 이전 할당 번호(lastVolNum)가 -1(초기값)인 경우 1번부터 시작하도록 변경하여 단권 책이 '1권'으로 표시되도록 조치
- 명시적으로 '0'이나 'Prologue' 등이 포함된 파일은 기존과 동일하게 0번으로 유지하여 의도된 프롤로그 인식 유지
- 번호 할당 시의 변수 스코프(ok) 문제 해결 및 백엔드 전체 빌드(go build ./...) 검증 완료