### PR TITLE
fix: 오디오북 썸네일 fallback 및 볼륨 썸네일 권한 검사 보강

### DIFF
--- a/backend/internal/handler/image_handler.go
+++ b/backend/internal/handler/image_handler.go
@@ -1472,10 +1472,6 @@ func (h *ImageHandler) findFirstAvailableChapterRecursively(volumeID string) (*m
 				return &ch, &pages[0], archivePath, true
 			}
 
-			// 오디오북 챕터는 페이지가 없을 수 있으므로 마지막 fallback으로 반환
-			if ch.HasAudio {
-				return &ch, nil, "", true
-			}
 		}
 	}
 
@@ -1486,6 +1482,15 @@ func (h *ImageHandler) findFirstAvailableChapterRecursively(volumeID string) (*m
 			ch, pg, arch, found := h.findFirstAvailableChapterRecursively(subVol.ID)
 			if found {
 				return ch, pg, arch, true
+			}
+		}
+	}
+
+	// 3. 하위 볼륨에서도 못 찾은 경우, 오디오북 챕터를 마지막 fallback으로 반환
+	if len(chapters) > 0 {
+		for i := range chapters {
+			if chapters[i].HasAudio {
+				return &chapters[i], nil, "", true
 			}
 		}
 	}

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -397,7 +397,8 @@ export function SeriesCard({
   const showMetaExtensionBadge = shouldShowExtensionBadge && extensionBadgePlacement === "meta" && !!extensionBadge;
   const showThumbnailExtensionBadge =
     shouldShowExtensionBadge && extensionBadgePlacement === "thumbnail" && !!extensionBadge;
-  const isAudioLayout = isAudiobook;
+  const hasAudio = "has_audio" in item && item.has_audio;
+  const isAudioLayout = isAudiobook || hasAudio;
   const showOverlayProgress =
     progressStyle === "overlay" && displayProgress !== null && (displayProgress > 0 || forceShowProgress);
   const thumbnailSrc = useMemo(() => {


### PR DESCRIPTION
## Summary
- 오디오북 전용 썸네일 fallback 조건 정리 및 재귀 탐색 우선순위 보강
- 볼륨 썸네일 권한 검사와 지연 조회 적용
- SeriesCard 썸네일 fallback 로직 개선 및 테스트 추가

## Test plan
- [ ] 오디오북 시리즈에서 썸네일이 정상 표시되는지 확인
- [ ] 볼륨 썸네일 fallback 경로가 올바르게 동작하는지 확인
- [ ] 권한 없는 썸네일 접근 시 적절히 처리되는지 확인