### PR TITLE
fix: 썸네일 변경 안됨 문제 수정

### DIFF
--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -893,6 +893,7 @@ func (h *SeriesHandler) UploadThumbnail(c *fiber.Ctx) error {
 
 	// DB 업데이트
 	series.ThumbnailPath = &path
+	series.UpdatedAt = time.Now()
 	if err := h.seriesRepo.Update(nil, series); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update series thumbnail path",
@@ -1024,6 +1025,7 @@ func (h *SeriesHandler) DownloadThumbnail(c *fiber.Ctx) error {
 
 	// DB 업데이트
 	series.ThumbnailPath = &path
+	series.UpdatedAt = time.Now()
 	if err := h.seriesRepo.Update(nil, series); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update series thumbnail path",
@@ -1076,6 +1078,7 @@ func (h *SeriesHandler) DeleteThumbnail(c *fiber.Ctx) error {
 	// DB 업데이트 (ThumbnailPath = nil, ThumbnailURL = nil)
 	series.ThumbnailPath = nil
 	series.ThumbnailURL = nil
+	series.UpdatedAt = time.Now()
 
 	if upErr := h.seriesRepo.Update(nil, series); upErr != nil {
 		fmt.Printf("[DEBUG] Failed to update series in DB: %v\n", upErr)


### PR DESCRIPTION
fix: 썸네일 변경 안됨 문제 수정

## 변경 사항
- 시리즈 썸네일 업로드 시 `series.updated_at`을 현재 시각으로 갱신하도록 수정했습니다.
- 시리즈 썸네일 URL 변경 시 `series.updated_at`을 현재 시각으로 갱신하도록 수정했습니다.
- 시리즈 썸네일 초기화 시 `series.updated_at`을 현재 시각으로 갱신하도록 수정했습니다.
- 썸네일 변경 후 `thumbnail_url`의 캐시 버스터가 바뀌지 않아 이전 이미지가 계속 보이던 문제를 해결했습니다.

## 테스트
- [x] `cd backend && go test ./...`
- [x] `cd backend && golangci-lint run ./...`

## 관련 이슈
Closes #283