### PR TITLE
fix: 라이브러리 목차 스크롤 동기화 개선

### DIFF
--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.15.0-beta.2"
+const Version = "v0.15.0-beta.3"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.15.0-beta.2",
+  "version": "0.15.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.15.0-beta.2",
+      "version": "0.15.0-beta.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.15.0-beta.2",
+  "version": "0.15.0-beta.3",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/src/pages/Library.module.css
+++ b/web/src/pages/Library.module.css
@@ -45,6 +45,8 @@
   right: 18px;
   width: 56px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   max-height: calc(100vh - 196px);
   padding: 12px 8px;
   border: 1px solid rgba(109, 213, 240, 0.18);
@@ -60,33 +62,52 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  flex: 1;
+  min-height: 0;
   gap: 8px;
-  max-height: calc(100vh - 222px);
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 0;
   padding-top: 2px;
   padding-bottom: 2px;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(109, 213, 240, 0.42) transparent;
+  scrollbar-width: none;
+  scrollbar-color: transparent transparent;
 }
 
 .seriesIndexScrollArea::-webkit-scrollbar {
-  width: 6px;
+  width: 0;
 }
 
 .seriesIndexScrollArea::-webkit-scrollbar-track {
-  margin: 4px 0;
   background: transparent;
 }
 
 .seriesIndexScrollArea::-webkit-scrollbar-thumb {
-  border-radius: 999px;
-  background: rgba(109, 213, 240, 0.42);
+  background: transparent;
 }
 
-.seriesIndexScrollArea::-webkit-scrollbar-thumb:hover {
-  background: rgba(109, 213, 240, 0.58);
+.seriesIndexScrollbar {
+  position: absolute;
+  top: 12px;
+  right: 4px;
+  bottom: 12px;
+  width: 3px;
+  border-radius: 999px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.24s ease;
+}
+
+.seriesIndexScrollbarVisible {
+  opacity: 1;
+}
+
+.seriesIndexScrollbarThumb {
+  width: 100%;
+  border-radius: inherit;
+  background: rgba(109, 213, 240, 0.48);
+  box-shadow: 0 0 10px rgba(109, 213, 240, 0.24);
+  transition: transform 0.12s ease, height 0.12s ease;
 }
 
 .seriesIndexButton {
@@ -302,20 +323,21 @@
     top: 182px;
     right: 8px;
     width: 40px;
-    max-height: calc(100vh - 210px);
     padding: 10px 4px;
     border-radius: 14px;
   }
 
+  .seriesIndexScrollbar {
+    top: 10px;
+    right: 3px;
+    bottom: 10px;
+    width: 2px;
+  }
+
   .seriesIndexScrollArea {
-    max-height: calc(100vh - 232px);
     gap: 6px;
     padding-top: 1px;
     padding-bottom: 1px;
-  }
-
-  .seriesIndexScrollArea::-webkit-scrollbar {
-    width: 5px;
   }
 
   .seriesIndexButton {
@@ -347,12 +369,7 @@
     top: 176px;
     right: 6px;
     width: 36px;
-    max-height: calc(100vh - 208px);
     padding: 9px 3px;
-  }
-
-  .seriesIndexScrollArea {
-    max-height: calc(100vh - 226px);
   }
 
   .seriesIndexButton {

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { ReactNode } from "react";
+import type { Series } from "../types/series";
+import { LibraryPage } from "./Library";
+import styles from "./Library.module.css";
+
+const { mocks, libraryStoreState, authStoreState } = vi.hoisted(() => {
+  const libraryGetMock = vi.fn();
+  const libraryGetSeriesMock = vi.fn();
+  const libraryScanMock = vi.fn();
+  const fetchLibrariesMock = vi.fn();
+  const triggerRefreshMock = vi.fn();
+
+  return {
+    mocks: {
+      libraryGetMock,
+      libraryGetSeriesMock,
+      libraryScanMock,
+      fetchLibrariesMock,
+      triggerRefreshMock,
+    },
+    libraryStoreState: {
+      libraries: [{ id: "library-1", scan_status: "IDLE" }],
+      refreshKey: 0,
+      fetchLibraries: fetchLibrariesMock,
+      triggerRefresh: triggerRefreshMock,
+    },
+    authStoreState: {
+      user: {
+        id: "user-1",
+        username: "master",
+        nickname: "구미호",
+        role: "MASTER",
+        can_download: true,
+        created_at: "2026-04-10T00:00:00Z",
+        updated_at: "2026-04-10T00:00:00Z",
+      },
+    },
+  };
+});
+
+type LibraryStoreState = typeof libraryStoreState;
+type AuthStoreState = typeof authStoreState;
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+
+  private callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe = vi.fn();
+  disconnect = vi.fn();
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === "home.library.series_index_nav") {
+        return "series index";
+      }
+      if (key === "home.library.series_index_jump") {
+        return `jump ${String(options?.key ?? "")}`;
+      }
+      return key;
+    },
+  }),
+  Trans: ({ i18nKey, count }: { i18nKey?: string; count?: number; components?: Record<string, ReactNode> }) => (
+    <span>
+      {i18nKey}
+      {typeof count === "number" ? ` ${count}` : ""}
+    </span>
+  ),
+}));
+
+vi.mock("../api/client", () => ({
+  libraryAPI: {
+    get: (...args: unknown[]) => mocks.libraryGetMock(...args),
+    getSeries: (...args: unknown[]) => mocks.libraryGetSeriesMock(...args),
+    scan: (...args: unknown[]) => mocks.libraryScanMock(...args),
+  },
+}));
+
+vi.mock("../stores/libraryStore", () => ({
+  useLibraryStore: (selector?: (state: LibraryStoreState) => unknown) =>
+    selector ? selector(libraryStoreState) : libraryStoreState,
+}));
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: (selector?: (state: AuthStoreState) => unknown) =>
+    selector ? selector(authStoreState) : authStoreState,
+}));
+
+vi.mock("../components/headers/Header", () => ({
+  Header: () => <div data-testid="header" />,
+}));
+
+vi.mock("../components/headers/SubHeader", () => ({
+  SubHeader: ({ title, rightContent }: { title: ReactNode; rightContent?: ReactNode }) => (
+    <header>
+      <div>{title}</div>
+      {rightContent}
+    </header>
+  ),
+}));
+
+vi.mock("../components/Sidebar", () => ({
+  Sidebar: () => null,
+}));
+
+vi.mock("../components/SeriesCard", () => ({
+  SeriesCard: ({ item }: { item: Series }) => (
+    <article data-testid="series-card">
+      {item.title}
+    </article>
+  ),
+}));
+
+vi.mock("../components/common/Toast", () => ({
+  Toast: () => null,
+}));
+
+vi.mock("../components/common/LoadingSpinner", () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner" />,
+}));
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+const createRect = (overrides: Partial<DOMRect> = {}): DOMRect => ({
+  x: overrides.x ?? 0,
+  y: overrides.y ?? overrides.top ?? 0,
+  width: overrides.width ?? 0,
+  height: overrides.height ?? 0,
+  top: overrides.top ?? 0,
+  right: overrides.right ?? 0,
+  bottom: overrides.bottom ?? 0,
+  left: overrides.left ?? 0,
+  toJSON: () => ({}),
+});
+
+const setElementScrollMetrics = (
+  element: HTMLElement,
+  metrics: { clientHeight: number; scrollHeight: number; scrollTop?: number },
+) => {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop ?? 0,
+  });
+};
+
+const seriesFixture: Series[] = [
+  {
+    id: "series-a",
+    library_id: "library-1",
+    title: "Alpha",
+    path: "/library/Alpha",
+    created_at: "2026-04-10T00:00:00Z",
+    updated_at: "2026-04-10T00:00:00Z",
+  },
+  {
+    id: "series-b",
+    library_id: "library-1",
+    title: "Beta",
+    path: "/library/Beta",
+    created_at: "2026-04-10T00:00:00Z",
+    updated_at: "2026-04-10T00:00:00Z",
+  },
+  {
+    id: "series-c",
+    library_id: "library-1",
+    title: "Cat",
+    path: "/library/Cat",
+    created_at: "2026-04-10T00:00:00Z",
+    updated_at: "2026-04-10T00:00:00Z",
+  },
+];
+
+const renderLibraryPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/libraries/library-1"]}>
+      <Routes>
+        <Route
+          path="/libraries/:id"
+          element={<LibraryPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("LibraryPage series index", () => {
+  let defaultRectSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockResizeObserver.instances = [];
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+    defaultRectSpy = vi.spyOn(window.HTMLElement.prototype, "getBoundingClientRect");
+    defaultRectSpy.mockReturnValue(createRect({ top: 999, bottom: 1019, height: 20 }));
+
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window.HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    mocks.fetchLibrariesMock.mockResolvedValue(undefined);
+    mocks.libraryGetMock.mockResolvedValue({
+      data: {
+        id: "library-1",
+        name: "테스트",
+        paths: ["/library"],
+        default_view_mode: "single",
+        default_read_direction: "left-to-right",
+        default_page_transition: "slide",
+        default_epub_render_mode: "flow",
+        default_epub_theme: "dark",
+        default_epub_spread: "auto",
+        default_epub_wheel_direction: "vertical",
+        default_epub_keyboard_direction: "default",
+        default_epub_click_direction: "default",
+        sort_order: 0,
+        scan_status: "IDLE",
+        last_scan_result: "",
+        type: "LOCAL",
+      },
+    });
+    mocks.libraryGetSeriesMock.mockResolvedValue({
+      data: {
+        series: seriesFixture,
+      },
+    });
+  });
+
+  afterEach(() => {
+    defaultRectSpy.mockRestore();
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it("활성 목차 항목이 스크롤 영역 중앙에 오도록 이동한다", async () => {
+    renderLibraryPage();
+
+    const targetButton = await screen.findByRole("button", { name: "jump C" });
+    const nav = screen.getByRole("navigation", { name: "series index" });
+    const scrollArea = nav.firstElementChild as HTMLElement;
+    const scrollToMock = vi.fn();
+
+    setElementScrollMetrics(scrollArea, { clientHeight: 100, scrollHeight: 300 });
+    Object.defineProperty(scrollArea, "getBoundingClientRect", {
+      configurable: true,
+      value: vi.fn(() => createRect({ top: 100, bottom: 200, height: 100 })),
+    });
+    Object.defineProperty(targetButton, "getBoundingClientRect", {
+      configurable: true,
+      value: vi.fn(() => createRect({ top: 180, bottom: 200, height: 20 })),
+    });
+    Object.defineProperty(scrollArea, "scrollTo", {
+      configurable: true,
+      value: scrollToMock,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "jump A" })).toHaveAttribute("aria-current", "location");
+    });
+    scrollToMock.mockClear();
+
+    fireEvent.click(targetButton);
+
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({
+        top: 40,
+        behavior: "auto",
+      });
+    });
+  });
+
+  it("목차 스크롤바는 사용자 조작에서만 표시된다", async () => {
+    renderLibraryPage();
+
+    await screen.findByRole("button", { name: "jump C" });
+    const nav = screen.getByRole("navigation", { name: "series index" });
+    const scrollArea = nav.firstElementChild as HTMLElement;
+
+    setElementScrollMetrics(scrollArea, { clientHeight: 100, scrollHeight: 300 });
+    MockResizeObserver.instances[0]?.trigger();
+
+    await waitFor(() => {
+      expect(nav.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseEnter(scrollArea);
+    expect(nav.querySelector('[aria-hidden="true"]')).not.toHaveClass(styles.seriesIndexScrollbarVisible);
+
+    fireEvent.wheel(scrollArea);
+
+    await waitFor(() => {
+      expect(nav.querySelector('[aria-hidden="true"]')).toHaveClass(styles.seriesIndexScrollbarVisible);
+    });
+  });
+});

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -134,6 +134,11 @@ vi.mock("../components/common/LoadingSpinner", () => ({
 }));
 
 const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  "scrollIntoView",
+);
+const originalScrollToDescriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "scrollTo");
 
 const createRect = (overrides: Partial<DOMRect> = {}): DOMRect => ({
   x: overrides.x ?? 0,
@@ -256,6 +261,16 @@ describe("LibraryPage series index", () => {
   afterEach(() => {
     defaultRectSpy.mockRestore();
     globalThis.ResizeObserver = originalResizeObserver;
+    if (originalScrollIntoViewDescriptor) {
+      Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
+    } else {
+      Reflect.deleteProperty(window.HTMLElement.prototype, "scrollIntoView");
+    }
+    if (originalScrollToDescriptor) {
+      Object.defineProperty(window.HTMLElement.prototype, "scrollTo", originalScrollToDescriptor);
+    } else {
+      Reflect.deleteProperty(window.HTMLElement.prototype, "scrollTo");
+    }
   });
 
   it("활성 목차 항목이 스크롤 영역 중앙에 오도록 이동한다", async () => {

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -61,6 +61,7 @@ export function LibraryPage() {
   const indexInteractionTimeoutRef = useRef<number | null>(null);
   const syncingIndexScrollRef = useRef(false);
   const syncingIndexScrollFrameRef = useRef<number | null>(null);
+  const indexScrollbarFrameRef = useRef<number | null>(null);
   const seriesGridRef = useRef<HTMLDivElement | null>(null);
   const seriesIndexRef = useRef<HTMLElement | null>(null);
   const seriesIndexScrollAreaRef = useRef<HTMLDivElement | null>(null);
@@ -243,6 +244,17 @@ export function LibraryPage() {
     });
   }, []);
 
+  const scheduleIndexScrollbarThumbUpdate = useCallback(() => {
+    if (indexScrollbarFrameRef.current !== null) {
+      return;
+    }
+
+    indexScrollbarFrameRef.current = window.requestAnimationFrame(() => {
+      indexScrollbarFrameRef.current = null;
+      updateIndexScrollbarThumb();
+    });
+  }, [updateIndexScrollbarThumb]);
+
   const scrollToGroup = (groupKey: string) => {
     setActiveGroupKey(groupKey);
     scrollingToGroupRef.current = groupKey;
@@ -361,17 +373,21 @@ export function LibraryPage() {
     }
 
     updateIndexScrollbarThumb();
-    const resizeObserver = new ResizeObserver(updateIndexScrollbarThumb);
+    const resizeObserver = new ResizeObserver(scheduleIndexScrollbarThumbUpdate);
     resizeObserver.observe(scrollArea);
 
     return () => {
       resizeObserver.disconnect();
+      if (indexScrollbarFrameRef.current !== null) {
+        window.cancelAnimationFrame(indexScrollbarFrameRef.current);
+        indexScrollbarFrameRef.current = null;
+      }
       if (syncingIndexScrollFrameRef.current !== null) {
         window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
         syncingIndexScrollFrameRef.current = null;
       }
     };
-  }, [groupedSeriesList, indexPosition, updateIndexScrollbarThumb]);
+  }, [groupedSeriesList, indexPosition, scheduleIndexScrollbarThumbUpdate, updateIndexScrollbarThumb]);
 
   useEffect(() => {
     if (groupedSeriesList.length === 0) {
@@ -561,7 +577,7 @@ export function LibraryPage() {
                   ref={seriesIndexScrollAreaRef}
                   className={styles.seriesIndexScrollArea}
                   onScroll={() => {
-                    updateIndexScrollbarThumb();
+                    scheduleIndexScrollbarThumbUpdate();
                     if (!syncingIndexScrollRef.current) {
                       showIndexScrollbar();
                     }

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -587,10 +587,12 @@ export function LibraryPage() {
                   ref={seriesIndexScrollAreaRef}
                   className={styles.seriesIndexScrollArea}
                   onScroll={() => {
-                    scheduleIndexScrollbarThumbUpdate();
-                    if (!syncingIndexScrollRef.current) {
-                      showIndexScrollbar();
+                    if (syncingIndexScrollRef.current) {
+                      return;
                     }
+
+                    scheduleIndexScrollbarThumbUpdate();
+                    showIndexScrollbar();
                   }}
                   onWheel={showIndexScrollbar}
                   onTouchStart={showIndexScrollbar}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -29,6 +29,7 @@ const INDEX_TOP_RETRY_DELAY_MS = 100;
 const INDEX_SCROLL_LOCK_MS = 600;
 const GRID_MIN_VISIBLE_TOP_PX = 92; // 카드 그리드 top이 이 값 이상일 때만 유효한 측정으로 본다.
 const INDEX_BOTTOM_VIEWPORT_GAP_PX = 24;
+const INDEX_MIN_HEIGHT_PX = 160;
 const INDEX_SCROLLBAR_VISIBILITY_MS = 900;
 const INDEX_SCROLLBAR_MIN_THUMB_PX = 28;
 
@@ -382,11 +383,23 @@ export function LibraryPage() {
     }
 
     updateIndexScrollbarThumb();
-    const resizeObserver = new ResizeObserver(scheduleIndexScrollbarThumbUpdate);
-    resizeObserver.observe(scrollArea);
+    let resizeObserver: ResizeObserver | null = null;
+    const handleWindowResize = () => {
+      scheduleIndexScrollbarThumbUpdate();
+    };
+
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(scheduleIndexScrollbarThumbUpdate);
+      resizeObserver.observe(scrollArea);
+    } else {
+      window.addEventListener("resize", handleWindowResize);
+    }
 
     return () => {
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
+      if (resizeObserver === null) {
+        window.removeEventListener("resize", handleWindowResize);
+      }
       if (indexScrollbarFrameRef.current !== null) {
         window.cancelAnimationFrame(indexScrollbarFrameRef.current);
         indexScrollbarFrameRef.current = null;
@@ -426,7 +439,10 @@ export function LibraryPage() {
           return current ?? null;
         }
 
-        const nextMaxHeight = Math.max(160, window.innerHeight - resolvedTop - INDEX_BOTTOM_VIEWPORT_GAP_PX);
+        const nextMaxHeight = Math.max(
+          INDEX_MIN_HEIGHT_PX,
+          window.innerHeight - resolvedTop - INDEX_BOTTOM_VIEWPORT_GAP_PX,
+        );
 
         if (
           current &&

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -28,6 +28,9 @@ const HEADER_SCROLL_THRESHOLD_PX = 184; // 헤더 높이(172px)와 시각적 여
 const INDEX_TOP_RETRY_DELAY_MS = 100;
 const INDEX_SCROLL_LOCK_MS = 600;
 const GRID_MIN_VISIBLE_TOP_PX = 92; // 카드 그리드 top이 이 값 이상일 때만 유효한 측정으로 본다.
+const INDEX_BOTTOM_VIEWPORT_GAP_PX = 24;
+const INDEX_SCROLLBAR_VISIBILITY_MS = 900;
+const INDEX_SCROLLBAR_MIN_THUMB_PX = 28;
 
 export function LibraryPage() {
   const { id } = useParams<{ id: string }>();
@@ -45,14 +48,22 @@ export function LibraryPage() {
   const [isScanning, setIsScanning] = useState(false);
   const [status, setStatus] = useState<{ type: "success" | "error" | "info"; message: string } | null>(null);
   const [activeGroupKey, setActiveGroupKey] = useState<string | null>(null);
-  const [indexPosition, setIndexPosition] = useState<{ top: number; right: number } | null>(null);
+  const [indexPosition, setIndexPosition] = useState<{ top: number; right: number; maxHeight: number } | null>(null);
+  const [isIndexInteracting, setIsIndexInteracting] = useState(false);
+  const [hasIndexOverflow, setHasIndexOverflow] = useState(false);
+  const [indexScrollbarThumb, setIndexScrollbarThumb] = useState<{ top: number; height: number } | null>(null);
   const loadSequenceRef = useRef(0);
   const lastFetchedIdRef = useRef<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const indexButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const scrollingToGroupRef = useRef<string | null>(null);
   const scrollReleaseTimeoutRef = useRef<number | null>(null);
+  const indexInteractionTimeoutRef = useRef<number | null>(null);
+  const syncingIndexScrollRef = useRef(false);
+  const syncingIndexScrollFrameRef = useRef<number | null>(null);
   const seriesGridRef = useRef<HTMLDivElement | null>(null);
   const seriesIndexRef = useRef<HTMLElement | null>(null);
+  const seriesIndexScrollAreaRef = useRef<HTMLDivElement | null>(null);
 
   const user = useAuthStore((state) => state.user);
 
@@ -182,9 +193,60 @@ export function LibraryPage() {
     }
   };
 
+  const showIndexScrollbar = useCallback(() => {
+    if (!hasIndexOverflow) {
+      return;
+    }
+
+    setIsIndexInteracting(true);
+    if (indexInteractionTimeoutRef.current !== null) {
+      window.clearTimeout(indexInteractionTimeoutRef.current);
+    }
+    indexInteractionTimeoutRef.current = window.setTimeout(() => {
+      setIsIndexInteracting(false);
+      indexInteractionTimeoutRef.current = null;
+    }, INDEX_SCROLLBAR_VISIBILITY_MS);
+  }, [hasIndexOverflow]);
+
+  const updateIndexScrollbarThumb = useCallback(() => {
+    const scrollArea = seriesIndexScrollAreaRef.current;
+    if (!scrollArea) {
+      setIndexScrollbarThumb(null);
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollArea;
+    const nextHasOverflow = scrollHeight > clientHeight + 1;
+    setHasIndexOverflow((current) => (current === nextHasOverflow ? current : nextHasOverflow));
+
+    if (!nextHasOverflow) {
+      setIndexScrollbarThumb(null);
+      setIsIndexInteracting(false);
+      return;
+    }
+
+    const thumbHeight = Math.max(INDEX_SCROLLBAR_MIN_THUMB_PX, (clientHeight / scrollHeight) * clientHeight);
+    const maxThumbTop = Math.max(0, clientHeight - thumbHeight);
+    const maxScrollTop = Math.max(1, scrollHeight - clientHeight);
+    const thumbTop = (scrollTop / maxScrollTop) * maxThumbTop;
+
+    setIndexScrollbarThumb((current) => {
+      if (
+        current &&
+        Math.abs(current.top - thumbTop) < 0.5 &&
+        Math.abs(current.height - thumbHeight) < 0.5
+      ) {
+        return current;
+      }
+
+      return { top: thumbTop, height: thumbHeight };
+    });
+  }, []);
+
   const scrollToGroup = (groupKey: string) => {
     setActiveGroupKey(groupKey);
     scrollingToGroupRef.current = groupKey;
+    showIndexScrollbar();
     if (scrollReleaseTimeoutRef.current !== null) {
       window.clearTimeout(scrollReleaseTimeoutRef.current);
     }
@@ -253,10 +315,63 @@ export function LibraryPage() {
         window.clearTimeout(scrollReleaseTimeoutRef.current);
         scrollReleaseTimeoutRef.current = null;
       }
+      if (indexInteractionTimeoutRef.current !== null) {
+        window.clearTimeout(indexInteractionTimeoutRef.current);
+        indexInteractionTimeoutRef.current = null;
+      }
       window.removeEventListener("scroll", scheduleActiveGroupUpdate);
       window.removeEventListener("resize", scheduleActiveGroupUpdate);
     };
   }, [groupedSeriesList]);
+
+  useEffect(() => {
+    if (!activeGroupKey) return;
+
+    const scrollArea = seriesIndexScrollAreaRef.current;
+    const activeButton = indexButtonRefs.current[activeGroupKey];
+    if (!scrollArea || !activeButton) return;
+
+    syncingIndexScrollRef.current = true;
+    const scrollAreaRect = scrollArea.getBoundingClientRect();
+    const activeButtonRect = activeButton.getBoundingClientRect();
+    const buttonCenterInScrollArea =
+      activeButtonRect.top - scrollAreaRect.top + scrollArea.scrollTop + activeButtonRect.height / 2;
+    const targetScrollTop =
+      buttonCenterInScrollArea - scrollArea.clientHeight / 2;
+    scrollArea.scrollTo({
+      top: Math.max(0, targetScrollTop),
+      behavior: "auto",
+    });
+    if (syncingIndexScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
+    }
+    syncingIndexScrollFrameRef.current = window.requestAnimationFrame(() => {
+      updateIndexScrollbarThumb();
+      syncingIndexScrollRef.current = false;
+      syncingIndexScrollFrameRef.current = null;
+    });
+  }, [activeGroupKey, updateIndexScrollbarThumb]);
+
+  useEffect(() => {
+    const scrollArea = seriesIndexScrollAreaRef.current;
+    if (!scrollArea) {
+      setHasIndexOverflow(false);
+      setIndexScrollbarThumb(null);
+      return;
+    }
+
+    updateIndexScrollbarThumb();
+    const resizeObserver = new ResizeObserver(updateIndexScrollbarThumb);
+    resizeObserver.observe(scrollArea);
+
+    return () => {
+      resizeObserver.disconnect();
+      if (syncingIndexScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
+        syncingIndexScrollFrameRef.current = null;
+      }
+    };
+  }, [groupedSeriesList, indexPosition, updateIndexScrollbarThumb]);
 
   useEffect(() => {
     if (groupedSeriesList.length === 0) {
@@ -285,15 +400,18 @@ export function LibraryPage() {
           return current ?? null;
         }
 
+        const nextMaxHeight = Math.max(160, window.innerHeight - resolvedTop - INDEX_BOTTOM_VIEWPORT_GAP_PX);
+
         if (
           current &&
           Math.abs(current.right - centeredRight) < 0.5 &&
-          Math.abs(current.top - resolvedTop) < 0.5
+          Math.abs(current.top - resolvedTop) < 0.5 &&
+          Math.abs(current.maxHeight - nextMaxHeight) < 0.5
         ) {
           return current;
         }
 
-        return { top: resolvedTop, right: centeredRight };
+        return { top: resolvedTop, right: centeredRight, maxHeight: nextMaxHeight };
       });
     };
 
@@ -434,13 +552,31 @@ export function LibraryPage() {
                     ? {
                         top: `${indexPosition.top}px`,
                         right: `${indexPosition.right}px`,
+                        maxHeight: `${indexPosition.maxHeight}px`,
                       }
                     : undefined
                 }
               >
-                <div className={styles.seriesIndexScrollArea}>
+                <div
+                  ref={seriesIndexScrollAreaRef}
+                  className={styles.seriesIndexScrollArea}
+                  onScroll={() => {
+                    updateIndexScrollbarThumb();
+                    if (!syncingIndexScrollRef.current) {
+                      showIndexScrollbar();
+                    }
+                  }}
+                  onMouseEnter={showIndexScrollbar}
+                  onWheel={showIndexScrollbar}
+                  onTouchStart={showIndexScrollbar}
+                  onPointerDown={showIndexScrollbar}
+                  onFocus={showIndexScrollbar}
+                >
                   {groupedSeriesList.map((group) => (
                     <button
+                      ref={(node) => {
+                        indexButtonRefs.current[group.key] = node;
+                      }}
                       key={group.key}
                       type="button"
                       className={`${styles.seriesIndexButton} ${activeGroupKey === group.key ? styles.seriesIndexButtonActive : ""}`}
@@ -452,6 +588,20 @@ export function LibraryPage() {
                     </button>
                   ))}
                 </div>
+                {hasIndexOverflow && indexScrollbarThumb && (
+                  <div
+                    className={`${styles.seriesIndexScrollbar} ${isIndexInteracting ? styles.seriesIndexScrollbarVisible : ""}`}
+                    aria-hidden="true"
+                  >
+                    <div
+                      className={styles.seriesIndexScrollbarThumb}
+                      style={{
+                        height: `${indexScrollbarThumb.height}px`,
+                        transform: `translateY(${indexScrollbarThumb.top}px)`,
+                      }}
+                    />
+                  </div>
+                )}
               </nav>
 
               <div

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -330,6 +330,7 @@ export function LibraryPage() {
       if (indexInteractionTimeoutRef.current !== null) {
         window.clearTimeout(indexInteractionTimeoutRef.current);
         indexInteractionTimeoutRef.current = null;
+        setIsIndexInteracting(false);
       }
       window.removeEventListener("scroll", scheduleActiveGroupUpdate);
       window.removeEventListener("resize", scheduleActiveGroupUpdate);
@@ -362,6 +363,14 @@ export function LibraryPage() {
       syncingIndexScrollRef.current = false;
       syncingIndexScrollFrameRef.current = null;
     });
+
+    return () => {
+      if (syncingIndexScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
+        syncingIndexScrollFrameRef.current = null;
+      }
+      syncingIndexScrollRef.current = false;
+    };
   }, [activeGroupKey, updateIndexScrollbarThumb]);
 
   useEffect(() => {
@@ -385,6 +394,7 @@ export function LibraryPage() {
       if (syncingIndexScrollFrameRef.current !== null) {
         window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
         syncingIndexScrollFrameRef.current = null;
+        syncingIndexScrollRef.current = false;
       }
     };
   }, [groupedSeriesList, indexPosition, scheduleIndexScrollbarThumbUpdate, updateIndexScrollbarThumb]);
@@ -582,7 +592,6 @@ export function LibraryPage() {
                       showIndexScrollbar();
                     }
                   }}
-                  onMouseEnter={showIndexScrollbar}
                   onWheel={showIndexScrollbar}
                   onTouchStart={showIndexScrollbar}
                   onPointerDown={showIndexScrollbar}


### PR DESCRIPTION
## 변경 사항
- 라이브러리 우측 목차 active 항목 자동 중앙 동기화
- 긴 목차에서 하단 잘림 방지용 동적 높이 계산 추가
- 네이티브 스크롤바 대신 overlay thumb 사용으로 중앙 정렬 유지
- 직접 목차 조작 시에만 overlay scrollbar 표시
- 모바일/데스크톱 목차 레일 크기 유지

## 테스트
- [x] npm run lint
- [x] npm run build
- [x] npm test -- --run

## 관련 이슈
없음