### PR TITLE
fix(scanner): 서버 재시작 후 잔류 SCANNING 상태 자동 초기화 (v0.15.1)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -74,6 +74,11 @@ func main() {
 	defer fileScanner.StopScheduler()
 	defer fileScanner.StopWatcher()
 
+	// 서버 재시작으로 잔류한 SCANNING 상태 초기화
+	if err := fileScanner.ResetStaleScanStates(); err != nil {
+		log.Printf("Failed to reset stale scan states: %v", err)
+	}
+
 	// 저장된 스캔 설정 로드 및 적용
 	if setting, err := settingRepo.GetByKey(nil, "scan_interval"); err == nil && setting != nil {
 		var interval int

--- a/backend/internal/repository/library_repository.go
+++ b/backend/internal/repository/library_repository.go
@@ -394,7 +394,10 @@ func (r *LibraryRepository) ResetStaleScanStates(db database.Queryer) (int64, er
 	if err != nil {
 		return 0, err
 	}
-	n, _ := result.RowsAffected()
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
 	return n, nil
 }
 

--- a/backend/internal/repository/library_repository.go
+++ b/backend/internal/repository/library_repository.go
@@ -384,14 +384,18 @@ func (r *LibraryRepository) UpdateScanStatus(db database.Queryer, id string, sta
 }
 
 // ResetStaleScanStates 서버 재시작 시 잔류하는 SCANNING 상태를 IDLE로 초기화
-func (r *LibraryRepository) ResetStaleScanStates() error {
-	db := database.GetQueryer(nil)
+func (r *LibraryRepository) ResetStaleScanStates(db database.Queryer) (int64, error) {
+	db = database.GetQueryer(db)
 	now := time.Now()
-	_, err := db.Exec(
-		`UPDATE libraries SET scan_status = 'IDLE', last_scan_result = '서버 재시작으로 스캔이 중단되었습니다.', updated_at = ? WHERE scan_status = 'SCANNING'`,
-		now,
+	result, err := db.Exec(
+		`UPDATE libraries SET scan_status = 'IDLE', last_scan_result = ?, updated_at = ? WHERE scan_status = 'SCANNING'`,
+		"서버 재시작으로 스캔이 중단되었습니다.", now,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return n, nil
 }
 
 // UpdateScanProgress 스캔 진행률 업데이트 (현재 처리 중인 항목 정보)

--- a/backend/internal/repository/library_repository.go
+++ b/backend/internal/repository/library_repository.go
@@ -383,6 +383,17 @@ func (r *LibraryRepository) UpdateScanStatus(db database.Queryer, id string, sta
 	return err
 }
 
+// ResetStaleScanStates 서버 재시작 시 잔류하는 SCANNING 상태를 IDLE로 초기화
+func (r *LibraryRepository) ResetStaleScanStates() error {
+	db := database.GetQueryer(nil)
+	now := time.Now()
+	_, err := db.Exec(
+		`UPDATE libraries SET scan_status = 'IDLE', last_scan_result = '서버 재시작으로 스캔이 중단되었습니다.', updated_at = ? WHERE scan_status = 'SCANNING'`,
+		now,
+	)
+	return err
+}
+
 // UpdateScanProgress 스캔 진행률 업데이트 (현재 처리 중인 항목 정보)
 func (r *LibraryRepository) UpdateScanProgress(db database.Queryer, id string, currentItem string, progress int) error {
 	db = database.GetQueryer(db)

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -888,6 +888,15 @@ func (s *Scanner) hasDirectPageLikeSeriesContent(entries []fs.DirEntry, excludeP
 	return hasDirectMedia
 }
 
+// ResetStaleScanStates 서버 시작 시 이전 실행에서 잔류한 SCANNING 상태를 IDLE로 초기화
+func (s *Scanner) ResetStaleScanStates() error {
+	if err := s.libraryRepo.ResetStaleScanStates(); err != nil {
+		return fmt.Errorf("failed to reset stale scan states: %w", err)
+	}
+	log.Printf("[SCANNER] Stale SCANNING states have been reset to IDLE.")
+	return nil
+}
+
 // CancelScan 진행 중인 스캔 취소. 취소가 수행되었으면 true, 진행 중인 스캔이 없었으면 false 반환.
 func (s *Scanner) CancelScan(libraryID string) bool {
 	if cancel, ok := s.scanCancelFuncs.Load(libraryID); ok {

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -890,10 +890,13 @@ func (s *Scanner) hasDirectPageLikeSeriesContent(entries []fs.DirEntry, excludeP
 
 // ResetStaleScanStates 서버 시작 시 이전 실행에서 잔류한 SCANNING 상태를 IDLE로 초기화
 func (s *Scanner) ResetStaleScanStates() error {
-	if err := s.libraryRepo.ResetStaleScanStates(); err != nil {
+	n, err := s.libraryRepo.ResetStaleScanStates(nil)
+	if err != nil {
 		return fmt.Errorf("failed to reset stale scan states: %w", err)
 	}
-	log.Printf("[SCANNER] Stale SCANNING states have been reset to IDLE.")
+	if n > 0 {
+		log.Printf("[SCANNER] %d stale SCANNING state(s) have been reset to IDLE.", n)
+	}
 	return nil
 }
 

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.15.0"
+const Version = "v0.15.1"


### PR DESCRIPTION
## 버그

서버(Docker 컨테이너) 재시작 시 이전 스캔 중 DB에 기록된 `scan_status = 'SCANNING'` 상태가 초기화되지 않아 스캔 중 표시가 고착되는 문제.

재시작 후 런타임의 `scanCancelFuncs` 맵은 비어있어 취소 요청도 동작하지 않음.

## 수정 내용

서버 시작 시 `scan_status = 'SCANNING'`인 라이브러리를 `IDLE`로 일괄 초기화한다.

- `LibraryRepository.ResetStaleScanStates()` — bulk UPDATE 쿼리
- `Scanner.ResetStaleScanStates()` — repo 호출 + 로그
- `main.go` — `NewScanner` 직후 호출

## 버전

`v0.15.0` → `v0.15.1`

## 테스트

- `go build ./...` 통과
- `go test ./...` 전체 통과
- `eslint` 통과