### PR TITLE
fix: EPUB 스크롤 모드 당김 이동 회귀 수정

### DIFF
--- a/web/src/features/epub-viewer/components/EpubChapterViewer/EpubChapterViewer.module.css
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/EpubChapterViewer.module.css
@@ -20,6 +20,7 @@
 }
 
 .scrolled {
+  flex-direction: column;
   align-items: stretch;
   justify-content: stretch;
   padding: 0;
@@ -27,6 +28,9 @@
 }
 
 .scrolled .viewer {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
   overflow-x: hidden;
   overflow-y: hidden;
 }
@@ -68,4 +72,12 @@
 
 .chapterPageInfo.hidden {
   opacity: 0;
+}
+
+.scrolled .chapterPageInfo {
+  position: static;
+  flex: 0 0 auto;
+  align-self: center;
+  transform: none;
+  margin: 6px auto 6px;
 }

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/EpubChapterViewer.module.css
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/EpubChapterViewer.module.css
@@ -40,8 +40,11 @@
 
 .scrolled .viewer :global(.epub-view),
 .scrolled .viewer iframe {
-  max-width: 100% !important;
-  width: 100% !important;
+  display: block;
+  max-width: min(100%, 960px) !important;
+  width: min(100%, 960px) !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
   overflow-x: hidden !important;
 }
 

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/constants.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/constants.ts
@@ -1,0 +1,1 @@
+export const EPUB_SCROLLED_PULL_THRESHOLD = 80;

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/epubjsSnapshots.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/epubjsSnapshots.ts
@@ -1,0 +1,73 @@
+import type { Rendition } from "epubjs";
+
+export interface EpubjsLocation {
+  start: {
+    cfi: string;
+    displayed: {
+      page: number;
+      total: number;
+    };
+    percentage: number;
+    index: number;
+  };
+  end: {
+    cfi: string;
+  };
+  atStart?: boolean;
+  atEnd?: boolean;
+}
+
+export interface EpubjsNavigationItem {
+  id: string;
+  label: string;
+  href: string;
+  subitems?: EpubjsNavigationItem[];
+}
+
+export interface EpubjsLocationsExtended {
+  length: () => number;
+  locationFromCfi?: (cfi: string) => number;
+  cfiFromPercentage?: (percentage: number) => string;
+  cfiFromLocation?: (location: number) => string;
+  save: () => string;
+}
+
+export interface EpubjsSpine {
+  spineItems: Array<{ index: number; href: string }>;
+}
+
+export interface EpubjsSection {
+  cfiBase?: string;
+  document?: Document;
+  load?: () => Promise<unknown>;
+  unload?: () => void;
+  cfiFromElement?: (el: Element) => string;
+}
+
+export interface EpubManagerSnapshot {
+  container?: HTMLElement;
+  isPaginated?: boolean;
+  settings?: {
+    direction?: "ltr" | "rtl";
+  };
+  layout?: {
+    delta?: number;
+  };
+  updateOffset?: () => void;
+}
+
+export interface EpubContentSnapshot {
+  document?: Document;
+}
+
+export interface EpubRenditionSnapshot {
+  manager?: EpubManagerSnapshot;
+  currentLocation?: () => EpubjsLocation | undefined;
+  resize?: (width: number, height: number) => void;
+  display: (target?: string) => Promise<unknown>;
+  spread?: (value: "auto" | "none") => void;
+  getContents?: () => EpubContentSnapshot[];
+}
+
+export const asEpubRenditionSnapshot = (rendition: Rendition): EpubRenditionSnapshot =>
+  rendition as unknown as EpubRenditionSnapshot;

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
@@ -3,12 +3,31 @@ import { getSafeLocationFromCfi, isLikelyEpubCfi } from "./cfiGuards";
 import { applyOldIOSSafariPointerEventFallback } from "./iosTouchFallback";
 import { applyEpubLineHeightScale } from "./lineHeightScale";
 import { buildEpubInjectedStyle } from "./styleBuilder";
+import { getWheelNavigationAction } from "./wheelNavigation";
 
 const isOldIOSSafariMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../../../../utils/browserDetect", () => ({
   isOldIOSSafari: isOldIOSSafariMock,
 }));
+
+const createScrollContainer = ({
+  scrollHeight,
+  clientHeight,
+  scrollTop,
+}: {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+}) => {
+  const container = document.createElement("div");
+  Object.defineProperties(container, {
+    scrollHeight: { value: scrollHeight, configurable: true },
+    clientHeight: { value: clientHeight, configurable: true },
+    scrollTop: { value: scrollTop, configurable: true, writable: true },
+  });
+  return container;
+};
 
 describe("EPUB CFI guards", () => {
   it("rejects href-like values before calling locationFromCfi", () => {
@@ -160,14 +179,52 @@ describe("buildEpubInjectedStyle", () => {
     );
 
     expect(style).toContain("@media (max-width: 640px)");
-    expect(style).toContain("width: 100% !important;");
-    expect(style).toContain("max-width: 960px !important;");
-    expect(style).toContain("margin-left: auto !important;");
-    expect(style).toContain("margin-right: auto !important;");
-    expect(style).toContain("padding-left: 32px !important;");
-    expect(style).toContain("padding-right: 32px !important;");
-    expect(style).toContain("box-sizing: border-box !important;");
-    expect(style).toContain("overflow-x: hidden !important;");
+    expect(style).toContain("width: 100%;");
+    expect(style).toContain("max-width: 960px;");
+    expect(style).toContain("margin-left: auto;");
+    expect(style).toContain("margin-right: auto;");
+    expect(style).toContain("padding-left: 32px;");
+    expect(style).toContain("padding-right: 32px;");
+    expect(style).toContain("box-sizing: border-box;");
+    expect(style).toContain("overflow-x: hidden;");
+  });
+});
+
+describe("getWheelNavigationAction", () => {
+  it("세로 스크롤 모드에서 내부 스크롤이 없는 작은 페이지는 다음 페이지 이동을 허용한다", () => {
+    const action = getWheelNavigationAction({
+      deltaY: 32,
+      flow: "scrolled",
+      wheelDirection: "down",
+      manager: {
+        isPaginated: false,
+        container: createScrollContainer({
+          scrollHeight: 600,
+          clientHeight: 600,
+          scrollTop: 0,
+        }),
+      },
+    });
+
+    expect(action).toBe("next");
+  });
+
+  it("세로 스크롤 모드에서 내부 스크롤 중이면 페이지 이동을 막는다", () => {
+    const action = getWheelNavigationAction({
+      deltaY: 32,
+      flow: "scrolled",
+      wheelDirection: "down",
+      manager: {
+        isPaginated: false,
+        container: createScrollContainer({
+          scrollHeight: 1200,
+          clientHeight: 600,
+          scrollTop: 200,
+        }),
+      },
+    });
+
+    expect(action).toBeNull();
   });
 });
 

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
@@ -263,6 +263,24 @@ describe("getWheelNavigationAction", () => {
 
     expect(action).toBeNull();
   });
+
+  it("세로 스크롤 모드에서 isPaginated가 undefined이면 초기화 중으로 보고 이동을 막는다", () => {
+    const action = getWheelNavigationAction({
+      deltaY: 32,
+      flow: "scrolled",
+      wheelDirection: "down",
+      manager: {
+        isPaginated: undefined,
+        container: createScrollContainer({
+          scrollHeight: 600,
+          clientHeight: 600,
+          scrollTop: 0,
+        }),
+      },
+    });
+
+    expect(action).toBeNull();
+  });
 });
 
 describe("applyEpubLineHeightScale", () => {

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
@@ -191,6 +191,16 @@ describe("buildEpubInjectedStyle", () => {
 });
 
 describe("getWheelNavigationAction", () => {
+  it("작은 wheel delta는 트랙패드 미세 입력으로 보고 무시한다", () => {
+    const action = getWheelNavigationAction({
+      deltaY: 4,
+      flow: "paginated",
+      wheelDirection: "down",
+    });
+
+    expect(action).toBeNull();
+  });
+
   it("세로 스크롤 모드에서 내부 스크롤이 없는 작은 페이지는 다음 페이지 이동을 허용한다", () => {
     const action = getWheelNavigationAction({
       deltaY: 32,

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
@@ -188,6 +188,31 @@ describe("buildEpubInjectedStyle", () => {
     expect(style).toContain("box-sizing: border-box;");
     expect(style).toContain("overflow-x: hidden;");
   });
+
+  it("세로 스크롤 모드에서는 본문 잘림 방지용 레이아웃 속성을 우선 적용한다", () => {
+    const style = buildEpubInjectedStyle(
+      {
+        fontSize: 100,
+        fontFamily: "original",
+        lineHeight: 1.6,
+        theme: "light",
+        renderMode: "auto",
+        flow: "scrolled",
+        spread: "none",
+        wheelDirection: "down",
+        keyboardDirection: "right",
+        clickDirection: "right",
+      },
+      "book",
+    );
+
+    expect(style).toContain("width: 100% !important;");
+    expect(style).toContain("max-width: 960px !important;");
+    expect(style).toContain("padding-left: 32px !important;");
+    expect(style).toContain("padding-right: 32px !important;");
+    expect(style).toContain("overflow-x: hidden !important;");
+    expect(style).toContain("max-width: 100% !important;");
+  });
 });
 
 describe("getWheelNavigationAction", () => {

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx
@@ -4,6 +4,8 @@ import { applyOldIOSSafariPointerEventFallback } from "./iosTouchFallback";
 import { applyEpubLineHeightScale } from "./lineHeightScale";
 import { buildEpubInjectedStyle } from "./styleBuilder";
 import { getWheelNavigationAction } from "./wheelNavigation";
+import { getScrolledPullCompletionAction } from "./scrolledPull";
+import { EPUB_SCROLLED_PULL_THRESHOLD } from "./constants";
 
 const isOldIOSSafariMock = vi.hoisted(() => vi.fn(() => false));
 
@@ -290,5 +292,42 @@ describe("applyEpubLineHeightScale", () => {
     applyEpubLineHeightScale(document, 1);
 
     expect(paragraph.style.getPropertyValue("line-height")).toBe("20px");
+  });
+});
+
+describe("getScrolledPullCompletionAction (스크롤 당김 완료 액션)", () => {
+  const T = EPUB_SCROLLED_PULL_THRESHOLD;
+
+  it("임계값 초과 + canPrev=true → nav-prev 반환", () => {
+    expect(getScrolledPullCompletionAction(T, true, false)).toBe("nav-prev");
+    expect(getScrolledPullCompletionAction(T + 10, true, true)).toBe("nav-prev");
+  });
+
+  it("임계값 초과 + canNext=true → nav-next 반환", () => {
+    expect(getScrolledPullCompletionAction(-T, false, true)).toBe("nav-next");
+    expect(getScrolledPullCompletionAction(-T - 10, false, true)).toBe("nav-next");
+  });
+
+  it("임계값 초과해도 canPrev/canNext=false 면 none 반환 (네비게이션 미발생)", () => {
+    expect(getScrolledPullCompletionAction(T, false, false)).toBe("none");
+    expect(getScrolledPullCompletionAction(-T, false, false)).toBe("none");
+    expect(getScrolledPullCompletionAction(T + 20, false, true)).toBe("none");
+    expect(getScrolledPullCompletionAction(-T - 20, true, false)).toBe("none");
+  });
+
+  it("임계값 미만 + offset != 0 → decay 반환", () => {
+    expect(getScrolledPullCompletionAction(T - 1, true, true)).toBe("decay");
+    expect(getScrolledPullCompletionAction(-(T - 1), true, true)).toBe("decay");
+    expect(getScrolledPullCompletionAction(1, false, false)).toBe("decay");
+  });
+
+  it("offset = 0 → none 반환", () => {
+    expect(getScrolledPullCompletionAction(0, true, true)).toBe("none");
+    expect(getScrolledPullCompletionAction(0, false, false)).toBe("none");
+  });
+
+  it("커스텀 임계값으로 동작한다", () => {
+    expect(getScrolledPullCompletionAction(50, true, false, 50)).toBe("nav-prev");
+    expect(getScrolledPullCompletionAction(49, true, false, 50)).toBe("decay");
   });
 });

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -598,10 +598,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
             reflowRendition(true);
           });
         }
-        if (import.meta.env.DEV) {
-          console.log("[EpubChapterViewer] relocated:", cfi);
-        }
-
         const currentLocation = rendition.currentLocation() as unknown as EpubjsLocation;
         const start = currentLocation?.start || location.start;
         const displayed = start?.displayed;
@@ -1121,11 +1117,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           allowContentHeuristicRef.current = !(detectedFromMetadata || detectedFromSpine);
           detectedLayoutRef.current = detectedFromMetadata || detectedFromSpine || "book";
           effectiveLayoutRef.current = resolveEffectiveLayout(settings.renderMode, detectedLayoutRef.current);
-          if (import.meta.env.DEV) {
-            console.log(
-              `[EpubChapterViewer] layout resolved: metadata=${detectedFromMetadata ?? "none"}, spine=${detectedFromSpine ?? "none"}, mode=${settings.renderMode}, effective=${effectiveLayoutRef.current}`,
-            );
-          }
           onRenderLayoutChangeRef.current?.(effectiveLayoutRef.current);
 
           applySettings(rendition, settings, effectiveLayoutRef.current);
@@ -1326,9 +1317,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
           if (cachedLocations) {
             // 캐시 히트 → 즉시 로드 + 최적화된 초기 디스플레이
-            if (import.meta.env.DEV) {
-              console.log("[EpubChapterViewer] Loading cached locations");
-            }
             try {
               book.locations.load(cachedLocations);
               locationsReadyRef.current = true;
@@ -1358,9 +1346,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                     : getSafeCfiFromPercentage(book.locations, expectedRatio);
               }
 
-              if (import.meta.env.DEV) {
-                console.log("[EpubChapterViewer] Displaying final position (cached):", targetCFI || "beginning");
-              }
               // flow 변경 또는 이어보기 위치가 있으면 finalizeInit에서 highlight 표시
               pendingAnchorHighlightRef.current = flowAnchor ?? initialCFI ?? null;
               void displayWithFallback(targetCFI, expectedRatio);
@@ -1374,9 +1359,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           }
 
           // 캐시 미스 → 기본 디스플레이 시도 + 백그라운드 생성
-          if (import.meta.env.DEV) {
-            console.log("[EpubChapterViewer] No cached locations, initial display then background generate");
-          }
           const expectedRatio = typeof initialProgressRatio === "number" ? initialProgressRatio : 0;
 
           // flow 변경으로 rendition을 재생성한 경우, 모드 전환 직전 위치를 우선 복원한다.
@@ -1400,9 +1382,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                 try {
                   const serialized = locationsObj.save();
                   localStorage.setItem(CACHE_KEY, serialized);
-                  if (import.meta.env.DEV) {
-                    console.log("[EpubChapterViewer] Locations generated and cached");
-                  }
                 } catch (err) {
                   console.warn("[EpubChapterViewer] Failed to cache locations:", err);
                 }

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from "react";
+import { useEffect, useRef, useCallback, forwardRef, useImperativeHandle, useState } from "react";
 import Epub from "epubjs";
 import type { Book, Contents, Rendition } from "epubjs";
 import type { EpubViewerSettings } from "../../../../stores/epubViewerStore";
@@ -43,6 +43,11 @@ export interface EpubChapterViewerHandles {
   goToCFI: (cfi: string) => void;
   goToProgress: (ratio: number) => void;
   goToPage: (page: number) => void;
+}
+
+interface ScrolledPullState {
+  pullOffset: number;
+  isTouching: boolean;
 }
 
 export type EpubInitialOpenMode = "default" | "last";
@@ -90,9 +95,16 @@ interface EpubChapterViewerProps {
   onPagePrev?: () => void;
   onRenderLayoutChange?: (layout: EpubRenderLayout) => void;
   hideChapterPageInfo?: boolean;
+  canScrolledPullPrev?: boolean;
+  canScrolledPullNext?: boolean;
+  onScrolledPullStateChange?: (state: ScrolledPullState) => void;
 }
 
 const EPUB_VIEWER_STYLE_ID = "kumiho-epub-viewer-settings";
+const SCROLLED_PULL_THRESHOLD = 80;
+const SCROLLED_PULL_SENSITIVITY = 1.0;
+const SCROLLED_PULL_MAX = 180;
+const SCROLLED_PULL_WHEEL_COOLDOWN_MS = 150;
 
 interface NavigationSnapshot {
   cfi: string | null;
@@ -125,6 +137,9 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       onPagePrev,
       onRenderLayoutChange,
       hideChapterPageInfo = false,
+      canScrolledPullPrev = false,
+      canScrolledPullNext = false,
+      onScrolledPullStateChange,
     },
     ref,
   ) => {
@@ -134,6 +149,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
     const locationsReadyRef = useRef(false);
     const invalidPreciseHrefSetRef = useRef<Set<string>>(new Set());
     const generatedTotalRef = useRef(0);
+    const [scrolledPullOffset, setScrolledPullOffsetState] = useState(0);
+    const [isScrolledPullTouching, setIsScrolledPullTouchingState] = useState(false);
 
     // 최신 콜백을 ref로 유지 (stale closure 방지)
     const onViewerClickRef = useRef(onViewerClick);
@@ -144,8 +161,17 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
     const onPageNextRef = useRef(onPageNext);
     const onPagePrevRef = useRef(onPagePrev);
     const onRenderLayoutChangeRef = useRef(onRenderLayoutChange);
+    const onScrolledPullStateChangeRef = useRef(onScrolledPullStateChange);
+    const canScrolledPullPrevRef = useRef(canScrolledPullPrev);
+    const canScrolledPullNextRef = useRef(canScrolledPullNext);
     const settingsRef = useRef(settings);
     const lastWheelNavigationAtRef = useRef(0);
+    const lastScrolledPullWheelAtRef = useRef(0);
+    const scrolledPullOffsetRef = useRef(0);
+    const isScrolledPullTouchingRef = useRef(false);
+    const scrolledPullFrameRef = useRef<number | null>(null);
+    const scrolledPullStartYRef = useRef<number | null>(null);
+    const scrolledPullLastYRef = useRef<number | null>(null);
     const detectedLayoutRef = useRef<EpubRenderLayout>("book");
     const effectiveLayoutRef = useRef<EpubRenderLayout>("book");
     const allowContentHeuristicRef = useRef(true);
@@ -200,8 +226,101 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       onRenderLayoutChangeRef.current = onRenderLayoutChange;
     }, [onRenderLayoutChange]);
     useEffect(() => {
+      onScrolledPullStateChangeRef.current = onScrolledPullStateChange;
+    }, [onScrolledPullStateChange]);
+    useEffect(() => {
+      canScrolledPullPrevRef.current = canScrolledPullPrev;
+    }, [canScrolledPullPrev]);
+    useEffect(() => {
+      canScrolledPullNextRef.current = canScrolledPullNext;
+    }, [canScrolledPullNext]);
+    useEffect(() => {
       settingsRef.current = settings;
     }, [settings]);
+
+    const publishScrolledPullState = useCallback((pullOffset: number, isTouching: boolean) => {
+      onScrolledPullStateChangeRef.current?.({ pullOffset, isTouching });
+    }, []);
+
+    const setScrolledPullOffset = useCallback(
+      (nextOffset: number) => {
+        scrolledPullOffsetRef.current = nextOffset;
+        setScrolledPullOffsetState(nextOffset);
+        publishScrolledPullState(nextOffset, isScrolledPullTouchingRef.current);
+      },
+      [publishScrolledPullState],
+    );
+
+    const setScrolledPullTouching = useCallback(
+      (nextTouching: boolean) => {
+        isScrolledPullTouchingRef.current = nextTouching;
+        setIsScrolledPullTouchingState(nextTouching);
+        publishScrolledPullState(scrolledPullOffsetRef.current, nextTouching);
+      },
+      [publishScrolledPullState],
+    );
+
+    const resetScrolledPullOffset = useCallback(() => {
+      if (scrolledPullFrameRef.current !== null) {
+        cancelAnimationFrame(scrolledPullFrameRef.current);
+        scrolledPullFrameRef.current = null;
+      }
+      setScrolledPullOffset(0);
+    }, [setScrolledPullOffset]);
+
+    const decayScrolledPullOffset = useCallback(() => {
+      if (scrolledPullFrameRef.current !== null) {
+        cancelAnimationFrame(scrolledPullFrameRef.current);
+        scrolledPullFrameRef.current = null;
+      }
+
+      const decay = () => {
+        const current = scrolledPullOffsetRef.current;
+        if (current === 0) {
+          scrolledPullFrameRef.current = null;
+          return;
+        }
+
+        const next = current * 0.82;
+        if (Math.abs(next) < 1) {
+          setScrolledPullOffset(0);
+          scrolledPullFrameRef.current = null;
+          return;
+        }
+
+        setScrolledPullOffset(next);
+        scrolledPullFrameRef.current = requestAnimationFrame(decay);
+      };
+
+      scrolledPullFrameRef.current = requestAnimationFrame(decay);
+    }, [setScrolledPullOffset]);
+
+    const completeScrolledPull = useCallback(() => {
+      const currentOffset = scrolledPullOffsetRef.current;
+      scrolledPullStartYRef.current = null;
+      scrolledPullLastYRef.current = null;
+      setScrolledPullTouching(false);
+
+      if (Math.abs(currentOffset) >= SCROLLED_PULL_THRESHOLD) {
+        resetScrolledPullOffset();
+        if (currentOffset > 0 && canScrolledPullPrevRef.current) {
+          onPagePrevRef.current?.();
+        } else if (currentOffset < 0 && canScrolledPullNextRef.current) {
+          onPageNextRef.current?.();
+        }
+        return;
+      }
+
+      if (currentOffset !== 0) {
+        decayScrolledPullOffset();
+      }
+    }, [decayScrolledPullOffset, resetScrolledPullOffset, setScrolledPullTouching]);
+
+    useEffect(() => {
+      if (settings.flow === "scrolled") return;
+      resetScrolledPullOffset();
+      setScrolledPullTouching(false);
+    }, [resetScrolledPullOffset, setScrolledPullTouching, settings.flow]);
 
     const showAnchorHighlight = useCallback((cfi: string) => {
       const rendition = renditionRef.current;
@@ -573,10 +692,78 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       applySettings(rendition, settings, effectiveLayoutRef.current);
       const wheelContainers = new Set<HTMLElement>();
 
+      const handleScrolledPullWheel = (event: WheelEvent, container: HTMLElement): boolean => {
+        const isAtTop = container.scrollTop <= 0;
+        const isAtBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
+        const currentPull = scrolledPullOffsetRef.current;
+        const isReverseRelease = (currentPull > 0 && event.deltaY > 0) || (currentPull < 0 && event.deltaY < 0);
+        const isSnappedPull = Math.abs(currentPull) >= SCROLLED_PULL_THRESHOLD;
+        const now = Date.now();
+
+        if (now - lastScrolledPullWheelAtRef.current < SCROLLED_PULL_WHEEL_COOLDOWN_MS && !isReverseRelease && !isSnappedPull) {
+          if (isAtTop && event.deltaY < 0 && canScrolledPullPrevRef.current) {
+            event.preventDefault();
+            return true;
+          }
+          if (isAtBottom && event.deltaY > 0 && canScrolledPullNextRef.current) {
+            event.preventDefault();
+            return true;
+          }
+          return false;
+        }
+
+        if (isSnappedPull) {
+          event.preventDefault();
+          if (currentPull > 0) {
+            if (event.deltaY < 0 && canScrolledPullPrevRef.current) {
+              resetScrolledPullOffset();
+              onPagePrevRef.current?.();
+            } else if (event.deltaY > 0) {
+              lastScrolledPullWheelAtRef.current = now;
+              resetScrolledPullOffset();
+            }
+          } else if (currentPull < 0) {
+            if (event.deltaY > 0 && canScrolledPullNextRef.current) {
+              resetScrolledPullOffset();
+              onPageNextRef.current?.();
+            } else if (event.deltaY < 0) {
+              lastScrolledPullWheelAtRef.current = now;
+              resetScrolledPullOffset();
+            }
+          }
+          return true;
+        }
+
+        const nextStep = SCROLLED_PULL_THRESHOLD / 2;
+        if (isAtTop && event.deltaY < 0 && canScrolledPullPrevRef.current) {
+          event.preventDefault();
+          lastScrolledPullWheelAtRef.current = now;
+          setScrolledPullOffset(Math.min(SCROLLED_PULL_THRESHOLD, currentPull + nextStep));
+          return true;
+        }
+        if (isAtBottom && event.deltaY > 0 && canScrolledPullNextRef.current) {
+          event.preventDefault();
+          lastScrolledPullWheelAtRef.current = now;
+          setScrolledPullOffset(Math.max(-SCROLLED_PULL_THRESHOLD, currentPull - nextStep));
+          return true;
+        }
+        if (currentPull !== 0 && isReverseRelease) {
+          event.preventDefault();
+          lastScrolledPullWheelAtRef.current = now;
+          resetScrolledPullOffset();
+          return true;
+        }
+
+        return false;
+      };
+
       const wheelHandler = (event: WheelEvent) => {
         const currentSettings = settingsRef.current;
         const currentRendition = renditionRef.current;
         const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
+        if (currentSettings.flow === "scrolled" && manager?.isPaginated === false && manager.container) {
+          if (handleScrolledPullWheel(event, manager.container)) return;
+        }
         const action = getWheelNavigationAction({
           deltaY: event.deltaY,
           flow: currentSettings.flow,
@@ -658,9 +845,16 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       const touchStartHandler = (event: TouchEvent) => {
         const touch = event.touches[0];
         if (!touch) return;
+        if (scrolledPullFrameRef.current !== null) {
+          cancelAnimationFrame(scrolledPullFrameRef.current);
+          scrolledPullFrameRef.current = null;
+        }
         pointerDownPosRef.current = { x: touch.clientX, y: touch.clientY };
+        scrolledPullStartYRef.current = touch.clientY;
+        scrolledPullLastYRef.current = touch.clientY;
         isDraggingRef.current = false;
         touchHandledRef.current = false;
+        if (settingsRef.current.flow === "scrolled") setScrolledPullTouching(true);
       };
 
       const touchMoveHandler = (event: TouchEvent) => {
@@ -670,6 +864,32 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         const dx = touch.clientX - pointerDownPosRef.current.x;
         const dy = touch.clientY - pointerDownPosRef.current.y;
         if (Math.sqrt(dx * dx + dy * dy) > 8) isDraggingRef.current = true;
+
+        if (settingsRef.current.flow !== "scrolled" || Math.abs(dx) > Math.abs(dy)) return;
+        const currentRendition = renditionRef.current;
+        const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
+        const container = manager?.container;
+        if (!container || manager?.isPaginated === true || scrolledPullLastYRef.current === null) return;
+
+        const diff = touch.clientY - scrolledPullLastYRef.current;
+        scrolledPullLastYRef.current = touch.clientY;
+        const isAtTop = container.scrollTop <= 0;
+        const isAtBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
+        const currentPull = scrolledPullOffsetRef.current;
+
+        if ((isAtTop && diff > 0 && canScrolledPullPrevRef.current) || currentPull > 0) {
+          const resistance = SCROLLED_PULL_SENSITIVITY * (1 - Math.abs(currentPull) / (SCROLLED_PULL_MAX * 2));
+          const nextOffset = Math.max(0, Math.min(currentPull + diff * resistance, SCROLLED_PULL_MAX));
+          setScrolledPullOffset(nextOffset);
+          if (event.cancelable && container.scrollTop <= 0 && nextOffset > 0) event.preventDefault();
+        } else if ((isAtBottom && diff < 0 && canScrolledPullNextRef.current) || currentPull < 0) {
+          const resistance = SCROLLED_PULL_SENSITIVITY * (1 - Math.abs(currentPull) / (SCROLLED_PULL_MAX * 2));
+          const nextOffset = Math.min(0, Math.max(currentPull + diff * resistance, -SCROLLED_PULL_MAX));
+          setScrolledPullOffset(nextOffset);
+          if (event.cancelable && isAtBottom && nextOffset < 0) event.preventDefault();
+        } else if (currentPull !== 0) {
+          setScrolledPullOffset(0);
+        }
       };
 
       const handleContentInput = (content: Contents) => {
@@ -736,13 +956,16 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
             isDraggingRef.current = false;
             const startPos = pointerDownPosRef.current;
             pointerDownPosRef.current = null;
+            if (settingsRef.current.flow === "scrolled") {
+              completeScrolledPull();
+              return;
+            }
             if (startPos) {
               const touch = event.changedTouches[0];
               if (touch) {
                 const dx = touch.clientX - startPos.x;
                 const dy = touch.clientY - startPos.y;
                 if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
-                  if (settingsRef.current.flow === "scrolled") return;
                   const isRTL = settingsRef.current.clickDirection === "left";
                   if (dx < 0) {
                     if (isRTL) onPagePrevRef.current?.();
@@ -761,6 +984,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           const iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
           const iframeRect = iframe?.getBoundingClientRect();
           pointerDownPosRef.current = null;
+          if (settingsRef.current.flow === "scrolled") completeScrolledPull();
           executeZoneAction(resolveZone((iframeRect?.left ?? 0) + clientX));
         };
 
@@ -770,7 +994,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         doc.addEventListener("mousemove", mouseMoveHandler);
         doc.addEventListener("click", clickHandler);
         doc.addEventListener("touchstart", touchStartHandler, { passive: true });
-        doc.addEventListener("touchmove", touchMoveHandler, { passive: true });
+        doc.addEventListener("touchmove", touchMoveHandler, { passive: false });
         doc.addEventListener("touchend", touchEndHandler);
 
         contentDisposersRef.current.set(doc, () => {
@@ -1222,6 +1446,13 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           cancelAnimationFrame(resizeFrameRef.current);
           resizeFrameRef.current = null;
         }
+        if (scrolledPullFrameRef.current !== null) {
+          cancelAnimationFrame(scrolledPullFrameRef.current);
+          scrolledPullFrameRef.current = null;
+        }
+        scrolledPullOffsetRef.current = 0;
+        isScrolledPullTouchingRef.current = false;
+        onScrolledPullStateChangeRef.current?.({ pullOffset: 0, isTouching: false });
         rendition.off("relocated", handleRelocated as unknown as (...args: unknown[]) => void);
         rendition.off("render", renderHandler);
         rendition.off("displayed", displayedHandler);
@@ -1643,7 +1874,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         <div
           ref={containerRef}
           className={styles.viewer}
-          style={{ transition: "opacity 0.15s ease-out" }}
+          style={{
+            transform: settings.flow === "scrolled" ? `translateY(${scrolledPullOffset * 0.3}px)` : "none",
+            transition:
+              settings.flow === "scrolled" && !isScrolledPullTouching && scrolledPullOffset === 0
+                ? "opacity 0.15s ease-out, transform 0.4s cubic-bezier(0.2, 0, 0.2, 1)"
+                : "opacity 0.15s ease-out",
+            willChange: settings.flow === "scrolled" ? "transform, opacity" : "opacity",
+          }}
         />
         {!hideChapterPageInfo && (
           <div className={`${styles.chapterPageInfo} ${isUIVisible ? styles.hidden : ""}`}>

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -600,6 +600,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         const tagName = target?.tagName?.toLowerCase();
         if (tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable))
           return;
+        if (currentSettings.flow === "scrolled") return;
 
         const nextArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";
         const prevArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowLeft" : "ArrowRight";
@@ -631,6 +632,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           onViewerClickRef.current?.();
           return;
         }
+        if (currentSettings.flow === "scrolled") return;
         const isRTL = currentSettings.clickDirection === "left";
         if (zone === "left") {
           if (isRTL) onPageNextRef.current?.();
@@ -740,6 +742,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                 const dx = touch.clientX - startPos.x;
                 const dy = touch.clientY - startPos.y;
                 if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+                  if (settingsRef.current.flow === "scrolled") return;
                   const isRTL = settingsRef.current.clickDirection === "left";
                   if (dx < 0) {
                     if (isRTL) onPagePrevRef.current?.();

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -34,6 +34,7 @@ import {
   toLocationRatio,
 } from "./locationUtils";
 import { getWheelNavigationAction } from "./wheelNavigation";
+import { EPUB_SCROLLED_PULL_THRESHOLD } from "./constants";
 
 export type { EpubRenderLayout } from "../../utils/layoutMode";
 
@@ -101,7 +102,6 @@ interface EpubChapterViewerProps {
 }
 
 const EPUB_VIEWER_STYLE_ID = "kumiho-epub-viewer-settings";
-const SCROLLED_PULL_THRESHOLD = 80;
 const SCROLLED_PULL_SENSITIVITY = 1.0;
 const SCROLLED_PULL_MAX = 180;
 const SCROLLED_PULL_WHEEL_COOLDOWN_MS = 150;
@@ -318,7 +318,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       scrolledPullLastYRef.current = null;
       setScrolledPullTouching(false);
 
-      if (Math.abs(currentOffset) >= SCROLLED_PULL_THRESHOLD) {
+      if (Math.abs(currentOffset) >= EPUB_SCROLLED_PULL_THRESHOLD) {
         resetScrolledPullOffset();
         if (currentOffset > 0 && canScrolledPullPrevRef.current) {
           triggerScrolledPullNavigation("prev");
@@ -704,13 +704,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
       applySettings(rendition, settings, effectiveLayoutRef.current);
       const wheelContainers = new Set<HTMLElement>();
+      const touchContainers = new Set<HTMLElement>();
 
       const handleScrolledPullWheel = (event: WheelEvent, container: HTMLElement): boolean => {
         const isAtTop = container.scrollTop <= 0;
         const isAtBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
         const currentPull = scrolledPullOffsetRef.current;
         const isReverseRelease = (currentPull > 0 && event.deltaY > 0) || (currentPull < 0 && event.deltaY < 0);
-        const isSnappedPull = Math.abs(currentPull) >= SCROLLED_PULL_THRESHOLD;
+        const isSnappedPull = Math.abs(currentPull) >= EPUB_SCROLLED_PULL_THRESHOLD;
         const now = Date.now();
 
         if (now - lastScrolledPullWheelAtRef.current < SCROLLED_PULL_WHEEL_COOLDOWN_MS && !isReverseRelease && !isSnappedPull) {
@@ -747,17 +748,17 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           return true;
         }
 
-        const nextStep = SCROLLED_PULL_THRESHOLD / 2;
+        const nextStep = EPUB_SCROLLED_PULL_THRESHOLD / 2;
         if (isAtTop && event.deltaY < 0 && canScrolledPullPrevRef.current) {
           event.preventDefault();
           lastScrolledPullWheelAtRef.current = now;
-          setScrolledPullOffset(Math.min(SCROLLED_PULL_THRESHOLD, currentPull + nextStep));
+          setScrolledPullOffset(Math.min(EPUB_SCROLLED_PULL_THRESHOLD, currentPull + nextStep));
           return true;
         }
         if (isAtBottom && event.deltaY > 0 && canScrolledPullNextRef.current) {
           event.preventDefault();
           lastScrolledPullWheelAtRef.current = now;
-          setScrolledPullOffset(Math.max(-SCROLLED_PULL_THRESHOLD, currentPull - nextStep));
+          setScrolledPullOffset(Math.max(-EPUB_SCROLLED_PULL_THRESHOLD, currentPull - nextStep));
           return true;
         }
         if (currentPull !== 0 && isReverseRelease) {
@@ -904,6 +905,11 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         }
       };
 
+      const containerTouchEndHandler = () => {
+        pointerDownPosRef.current = null;
+        if (settingsRef.current.flow === "scrolled") completeScrolledPull();
+      };
+
       const handleContentInput = (content: Contents) => {
         const contentWithDocument = content as unknown as { document?: Document };
         const doc = contentWithDocument.document;
@@ -1021,7 +1027,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         });
       };
 
-      const enforceWheelListener = () => {
+      const enforceContainerListeners = () => {
         const currentRendition = renditionRef.current;
         if (!currentRendition) return;
         const manager = asEpubRenditionSnapshot(currentRendition).manager;
@@ -1029,6 +1035,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           manager.container.removeEventListener("wheel", wheelHandler);
           manager.container.addEventListener("wheel", wheelHandler, { passive: false });
           wheelContainers.add(manager.container);
+
+          manager.container.removeEventListener("touchstart", touchStartHandler);
+          manager.container.removeEventListener("touchmove", touchMoveHandler);
+          manager.container.removeEventListener("touchend", containerTouchEndHandler);
+          manager.container.addEventListener("touchstart", touchStartHandler, { passive: true });
+          manager.container.addEventListener("touchmove", touchMoveHandler, { passive: false });
+          manager.container.addEventListener("touchend", containerTouchEndHandler);
+          touchContainers.add(manager.container);
         }
         asEpubRenditionSnapshot(currentRendition)
           .getContents?.()
@@ -1042,15 +1056,15 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
       const contentHookHandler = (content: EpubContentSnapshot) => {
         handleContentInput(content as Contents);
-        enforceWheelListener();
+        enforceContainerListeners();
       };
 
       const renderHandler = () => {
-        enforceWheelListener();
+        enforceContainerListeners();
       };
 
       const displayedHandler = () => {
-        enforceWheelListener();
+        enforceContainerListeners();
       };
 
       rendition.on("relocated", handleRelocated as unknown as (...args: unknown[]) => void);
@@ -1058,7 +1072,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       rendition.on("displayed", displayedHandler);
       rendition.hooks.content.register(contentHookHandler as unknown as (...args: unknown[]) => void);
 
-      enforceWheelListener();
+      enforceContainerListeners();
 
       const waitForLayoutFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
@@ -1464,6 +1478,12 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           container.removeEventListener("wheel", wheelHandler);
         });
         wheelContainers.clear();
+        touchContainers.forEach((container) => {
+          container.removeEventListener("touchstart", touchStartHandler);
+          container.removeEventListener("touchmove", touchMoveHandler);
+          container.removeEventListener("touchend", containerTouchEndHandler);
+        });
+        touchContainers.clear();
         contentDisposers.forEach((dispose) => {
           try {
             dispose();

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -105,6 +105,7 @@ const SCROLLED_PULL_THRESHOLD = 80;
 const SCROLLED_PULL_SENSITIVITY = 1.0;
 const SCROLLED_PULL_MAX = 180;
 const SCROLLED_PULL_WHEEL_COOLDOWN_MS = 150;
+const SCROLLED_PULL_NAVIGATION_LOCK_MS = 450;
 
 interface NavigationSnapshot {
   cfi: string | null;
@@ -170,8 +171,9 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
     const scrolledPullOffsetRef = useRef(0);
     const isScrolledPullTouchingRef = useRef(false);
     const scrolledPullFrameRef = useRef<number | null>(null);
-    const scrolledPullStartYRef = useRef<number | null>(null);
     const scrolledPullLastYRef = useRef<number | null>(null);
+    const scrolledPullNavigationLockRef = useRef(false);
+    const scrolledPullNavigationLockTimerRef = useRef<number | null>(null);
     const detectedLayoutRef = useRef<EpubRenderLayout>("book");
     const effectiveLayoutRef = useRef<EpubRenderLayout>("book");
     const allowContentHeuristicRef = useRef(true);
@@ -295,18 +297,33 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       scrolledPullFrameRef.current = requestAnimationFrame(decay);
     }, [setScrolledPullOffset]);
 
+    const triggerScrolledPullNavigation = useCallback((type: "prev" | "next") => {
+      if (scrolledPullNavigationLockRef.current) return;
+
+      scrolledPullNavigationLockRef.current = true;
+      if (scrolledPullNavigationLockTimerRef.current !== null) {
+        window.clearTimeout(scrolledPullNavigationLockTimerRef.current);
+      }
+      scrolledPullNavigationLockTimerRef.current = window.setTimeout(() => {
+        scrolledPullNavigationLockRef.current = false;
+        scrolledPullNavigationLockTimerRef.current = null;
+      }, SCROLLED_PULL_NAVIGATION_LOCK_MS);
+
+      if (type === "prev") onPagePrevRef.current?.();
+      else onPageNextRef.current?.();
+    }, []);
+
     const completeScrolledPull = useCallback(() => {
       const currentOffset = scrolledPullOffsetRef.current;
-      scrolledPullStartYRef.current = null;
       scrolledPullLastYRef.current = null;
       setScrolledPullTouching(false);
 
       if (Math.abs(currentOffset) >= SCROLLED_PULL_THRESHOLD) {
         resetScrolledPullOffset();
         if (currentOffset > 0 && canScrolledPullPrevRef.current) {
-          onPagePrevRef.current?.();
+          triggerScrolledPullNavigation("prev");
         } else if (currentOffset < 0 && canScrolledPullNextRef.current) {
-          onPageNextRef.current?.();
+          triggerScrolledPullNavigation("next");
         }
         return;
       }
@@ -314,7 +331,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       if (currentOffset !== 0) {
         decayScrolledPullOffset();
       }
-    }, [decayScrolledPullOffset, resetScrolledPullOffset, setScrolledPullTouching]);
+    }, [decayScrolledPullOffset, resetScrolledPullOffset, setScrolledPullTouching, triggerScrolledPullNavigation]);
 
     useEffect(() => {
       if (settings.flow === "scrolled") return;
@@ -717,7 +734,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           if (currentPull > 0) {
             if (event.deltaY < 0 && canScrolledPullPrevRef.current) {
               resetScrolledPullOffset();
-              onPagePrevRef.current?.();
+              triggerScrolledPullNavigation("prev");
             } else if (event.deltaY > 0) {
               lastScrolledPullWheelAtRef.current = now;
               resetScrolledPullOffset();
@@ -725,7 +742,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           } else if (currentPull < 0) {
             if (event.deltaY > 0 && canScrolledPullNextRef.current) {
               resetScrolledPullOffset();
-              onPageNextRef.current?.();
+              triggerScrolledPullNavigation("next");
             } else if (event.deltaY < 0) {
               lastScrolledPullWheelAtRef.current = now;
               resetScrolledPullOffset();
@@ -850,7 +867,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           scrolledPullFrameRef.current = null;
         }
         pointerDownPosRef.current = { x: touch.clientX, y: touch.clientY };
-        scrolledPullStartYRef.current = touch.clientY;
         scrolledPullLastYRef.current = touch.clientY;
         isDraggingRef.current = false;
         touchHandledRef.current = false;
@@ -1450,6 +1466,11 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           cancelAnimationFrame(scrolledPullFrameRef.current);
           scrolledPullFrameRef.current = null;
         }
+        if (scrolledPullNavigationLockTimerRef.current !== null) {
+          window.clearTimeout(scrolledPullNavigationLockTimerRef.current);
+          scrolledPullNavigationLockTimerRef.current = null;
+        }
+        scrolledPullNavigationLockRef.current = false;
         scrolledPullOffsetRef.current = 0;
         isScrolledPullTouchingRef.current = false;
         onScrolledPullStateChangeRef.current?.({ pullOffset: 0, isTouching: false });

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -35,6 +35,7 @@ import {
 } from "./locationUtils";
 import { getWheelNavigationAction } from "./wheelNavigation";
 import { EPUB_SCROLLED_PULL_THRESHOLD } from "./constants";
+import { getScrolledPullCompletionAction } from "./scrolledPull";
 
 export type { EpubRenderLayout } from "../../utils/layoutMode";
 
@@ -318,17 +319,16 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       scrolledPullLastYRef.current = null;
       setScrolledPullTouching(false);
 
-      if (Math.abs(currentOffset) >= EPUB_SCROLLED_PULL_THRESHOLD) {
-        resetScrolledPullOffset();
-        if (currentOffset > 0 && canScrolledPullPrevRef.current) {
-          triggerScrolledPullNavigation("prev");
-        } else if (currentOffset < 0 && canScrolledPullNextRef.current) {
-          triggerScrolledPullNavigation("next");
-        }
-        return;
-      }
+      const action = getScrolledPullCompletionAction(
+        currentOffset,
+        canScrolledPullPrevRef.current,
+        canScrolledPullNextRef.current,
+      );
 
-      if (currentOffset !== 0) {
+      if (action === "nav-prev" || action === "nav-next") {
+        resetScrolledPullOffset();
+        triggerScrolledPullNavigation(action === "nav-prev" ? "prev" : "next");
+      } else if (action === "decay") {
         decayScrolledPullOffset();
       }
     }, [decayScrolledPullOffset, resetScrolledPullOffset, setScrolledPullTouching, triggerScrolledPullNavigation]);

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -1106,7 +1106,10 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           rendition
             .display(undefined)
             .then(() => finalizeInit())
-            .catch(() => finalizeInit());
+            .catch((err: unknown) => {
+              console.warn("[EpubChapterViewer] Initial display fallback failed:", err);
+              return finalizeInit();
+            });
         const displayRatioFallback = () =>
           !fallbackCFI || fallbackCFI === targetCFI
             ? displayBeginning()

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -15,6 +15,25 @@ import styles from "./EpubChapterViewer.module.css";
 import { getSafeLocationFromCfi, isLikelyEpubCfi } from "./cfiGuards";
 import { applyOldIOSSafariPointerEventFallback } from "./iosTouchFallback";
 import { applyEpubLineHeightScale } from "./lineHeightScale";
+import {
+  asEpubRenditionSnapshot,
+  type EpubContentSnapshot,
+  type EpubjsLocation,
+  type EpubjsLocationsExtended,
+  type EpubjsNavigationItem,
+  type EpubjsSection,
+  type EpubjsSpine,
+} from "./epubjsSnapshots";
+import {
+  EPUB_LOCATION_STRIDE,
+  getSafeCfiFromLocation,
+  getSafeCfiFromPercentage,
+  getSafeLocationLength,
+  safeDecodeFragment,
+  safeDecodeURIComponent,
+  toLocationRatio,
+} from "./locationUtils";
+import { getWheelNavigationAction } from "./wheelNavigation";
 
 export type { EpubRenderLayout } from "../../utils/layoutMode";
 
@@ -75,51 +94,6 @@ interface EpubChapterViewerProps {
 
 const EPUB_VIEWER_STYLE_ID = "kumiho-epub-viewer-settings";
 
-// epub.js 관련 내부 타입 정의
-interface EpubjsLocation {
-  start: {
-    cfi: string;
-    displayed: {
-      page: number;
-      total: number;
-    };
-    percentage: number;
-    index: number;
-  };
-  end: {
-    cfi: string;
-  };
-  atStart?: boolean;
-  atEnd?: boolean;
-}
-
-interface EpubjsNavigationItem {
-  id: string;
-  label: string;
-  href: string;
-  subitems?: EpubjsNavigationItem[];
-}
-
-interface EpubjsLocationsExtended {
-  length: () => number;
-  locationFromCfi?: (cfi: string) => number;
-  cfiFromPercentage?: (percentage: number) => string;
-  cfiFromLocation?: (location: number) => string;
-  save: () => string;
-}
-
-interface EpubjsSpine {
-  spineItems: Array<{ index: number; href: string }>;
-}
-
-interface EpubjsSection {
-  cfiBase?: string;
-  document?: Document;
-  load?: () => Promise<unknown>;
-  unload?: () => void;
-  cfiFromElement?: (el: Element) => string;
-}
-
 interface NavigationSnapshot {
   cfi: string | null;
   page: number;
@@ -127,81 +101,6 @@ interface NavigationSnapshot {
   scrollLeft: number;
   scrollTop: number;
 }
-
-interface EpubManagerSnapshot {
-  container?: {
-    scrollLeft?: number;
-    scrollTop?: number;
-    scrollWidth?: number;
-    scrollHeight?: number;
-    clientWidth?: number;
-    clientHeight?: number;
-  };
-  isPaginated?: boolean;
-  settings?: {
-    direction?: "ltr" | "rtl";
-  };
-  layout?: {
-    delta?: number;
-  };
-  updateOffset?: () => void;
-}
-
-const EPUB_LOCATION_STRIDE = 6144; // 6KB 단위로 가상 페이지(위치) 정의. backend/internal/util/epub.go의 EpubPositionStride와 일치해야 함.
-const toLocationRatio = (position: number, total: number): number => {
-  if (!Number.isFinite(position) || !Number.isFinite(total) || total <= 1) return 0;
-  return Math.max(0, Math.min(1, position / (total - 1)));
-};
-const getSafeLocationLength = (locations: unknown): number => {
-  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
-  if (typeof locationSet?.length !== "function") return 0;
-
-  try {
-    const total = locationSet.length();
-    return Number.isFinite(total) && total > 0 ? total : 0;
-  } catch (err) {
-    console.warn("[EpubChapterViewer] location length unavailable:", err);
-    return 0;
-  }
-};
-const getSafeCfiFromPercentage = (locations: unknown, ratio: number): string | undefined => {
-  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
-  if (typeof locationSet?.cfiFromPercentage !== "function") return undefined;
-
-  try {
-    const cfi = locationSet.cfiFromPercentage(Math.max(0, Math.min(1, ratio)));
-    return typeof cfi === "string" && cfi.trim().length > 0 ? cfi : undefined;
-  } catch (err) {
-    console.warn("[EpubChapterViewer] cfiFromPercentage failed:", err);
-    return undefined;
-  }
-};
-const getSafeCfiFromLocation = (locations: unknown, location: number): string | undefined => {
-  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
-  if (typeof locationSet?.cfiFromLocation !== "function") return undefined;
-
-  try {
-    const cfi = locationSet.cfiFromLocation(location);
-    return typeof cfi === "string" && cfi.trim().length > 0 ? cfi : undefined;
-  } catch (err) {
-    console.warn("[EpubChapterViewer] cfiFromLocation failed:", err);
-    return undefined;
-  }
-};
-const safeDecodeURIComponent = (value: string): string => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-};
-const safeDecodeFragment = (value: string): string | null => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return null;
-  }
-};
 
 const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewerProps>(
   (
@@ -403,11 +302,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       if (!forceRedisplay && previous.width === width && previous.height === height) return;
       lastContainerSizeRef.current = { width, height };
 
-      const anyRendition = rendition as unknown as {
-        currentLocation?: () => EpubjsLocation | undefined;
-        resize?: (width: number, height: number) => void;
-        display: (target?: string) => Promise<unknown>;
-      };
+      const anyRendition = asEpubRenditionSnapshot(rendition);
 
       // 레이아웃 전환(spread/settings 변경) 직전에 캡처한 anchor가 있으면 우선 사용.
       // 새 레이아웃 기준으로 오염된 currentLocation()의 CFI를 사용하면 보던 위치에서 벗어날 수 있어,
@@ -463,7 +358,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
     const snapRenditionToVisualEnd = useCallback((rendition: Rendition): boolean => {
       try {
-        const manager = (rendition as unknown as { manager?: EpubManagerSnapshot })?.manager;
+        const manager = asEpubRenditionSnapshot(rendition).manager;
         const container = manager?.container;
         if (!manager || !container) return false;
 
@@ -521,10 +416,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         const isComic = layout === "comic";
 
         // 기존 epub.js가 삽입한 기본 테마 스타일시트 제거
-        const anyRendition = rendition as unknown as {
-          spread?: (value: "auto" | "none") => void;
-          getContents?: () => Array<{ document?: Document }>;
-        };
+        const anyRendition = asEpubRenditionSnapshot(rendition);
         const contents = anyRendition.getContents?.() || [];
         contents.forEach((content) => {
           const doc = content.document;
@@ -582,12 +474,11 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         let chapterTotal = displayed?.total || 0;
 
         try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const manager = (rendition as any).manager;
+          const manager = asEpubRenditionSnapshot(rendition).manager;
           if (manager && manager.isPaginated && manager.container) {
             const scrollWidth = manager.container.scrollWidth;
             const delta = manager.layout?.delta;
-            if (delta > 0 && scrollWidth > 0) {
+            if (typeof delta === "number" && delta > 0 && scrollWidth > 0) {
               const adjustedTotal = Math.ceil((scrollWidth - 3) / delta);
               const newTotal = adjustedTotal > 0 ? adjustedTotal : 1;
               if (newTotal < chapterTotal) {
@@ -680,15 +571,110 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       lastContainerSizeRef.current = { width: 0, height: 0 };
 
       applySettings(rendition, settings, effectiveLayoutRef.current);
+      const wheelContainers = new Set<HTMLElement>();
+
+      const wheelHandler = (event: WheelEvent) => {
+        const currentSettings = settingsRef.current;
+        const currentRendition = renditionRef.current;
+        const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
+        const action = getWheelNavigationAction({
+          deltaY: event.deltaY,
+          flow: currentSettings.flow,
+          wheelDirection: currentSettings.wheelDirection,
+          manager,
+        });
+        if (!action) return;
+
+        const now = Date.now();
+        if (now - lastWheelNavigationAtRef.current < 200) return;
+        lastWheelNavigationAtRef.current = now;
+
+        event.preventDefault();
+        if (action === "next") onPageNextRef.current?.();
+        else onPagePrevRef.current?.();
+      };
+
+      const keydownHandler = (event: KeyboardEvent) => {
+        const currentSettings = settingsRef.current;
+        const target = event.target as HTMLElement | null;
+        const tagName = target?.tagName?.toLowerCase();
+        if (tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable))
+          return;
+
+        const nextArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";
+        const prevArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowLeft" : "ArrowRight";
+
+        if (event.key === nextArrowKey || event.key === "PageDown") {
+          event.preventDefault();
+          onPageNextRef.current?.();
+        } else if (event.key === prevArrowKey || event.key === "PageUp") {
+          event.preventDefault();
+          onPagePrevRef.current?.();
+        }
+      };
+
+      const resolveZone = (clientX: number): "left" | "center" | "right" => {
+        const containerRect = containerRef.current?.getBoundingClientRect();
+        const ratio =
+          containerRect && containerRect.width > 0
+            ? (clientX - containerRect.left) / containerRect.width
+            : clientX / Math.max(window.innerWidth, 1);
+        const clampedRatio = Math.max(0, Math.min(1, ratio));
+        if (clampedRatio < 0.3) return "left";
+        if (clampedRatio > 0.7) return "right";
+        return "center";
+      };
+
+      const executeZoneAction = (zone: "left" | "center" | "right") => {
+        const currentSettings = settingsRef.current;
+        if (zone === "center") {
+          onViewerClickRef.current?.();
+          return;
+        }
+        const isRTL = currentSettings.clickDirection === "left";
+        if (zone === "left") {
+          if (isRTL) onPageNextRef.current?.();
+          else onPagePrevRef.current?.();
+        } else {
+          if (isRTL) onPagePrevRef.current?.();
+          else onPageNextRef.current?.();
+        }
+      };
+
+      const mouseDownHandler = (event: MouseEvent) => {
+        pointerDownPosRef.current = { x: event.clientX, y: event.clientY };
+        isDraggingRef.current = false;
+      };
+
+      const mouseMoveHandler = (event: MouseEvent) => {
+        if (!pointerDownPosRef.current) return;
+        const dx = event.clientX - pointerDownPosRef.current.x;
+        const dy = event.clientY - pointerDownPosRef.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) > 5) isDraggingRef.current = true;
+      };
+
+      const touchStartHandler = (event: TouchEvent) => {
+        const touch = event.touches[0];
+        if (!touch) return;
+        pointerDownPosRef.current = { x: touch.clientX, y: touch.clientY };
+        isDraggingRef.current = false;
+        touchHandledRef.current = false;
+      };
+
+      const touchMoveHandler = (event: TouchEvent) => {
+        if (!pointerDownPosRef.current) return;
+        const touch = event.changedTouches[0];
+        if (!touch) return;
+        const dx = touch.clientX - pointerDownPosRef.current.x;
+        const dy = touch.clientY - pointerDownPosRef.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) > 8) isDraggingRef.current = true;
+      };
 
       const handleContentInput = (content: Contents) => {
         const contentWithDocument = content as unknown as { document?: Document };
         const doc = contentWithDocument.document;
-        if (!doc) return;
-        if (contentDisposers.has(doc)) return;
+        if (!doc || contentDisposersRef.current.has(doc)) return;
 
-        // 구형 iOS Safari: iframe pointer-events를 none으로 설정하여
-        // 터치 이벤트가 부모 <main>으로 관통하도록 한다.
         applyOldIOSSafariPointerEventFallback(doc);
         applyDocumentSettings(doc, settingsRef.current, effectiveLayoutRef.current);
 
@@ -697,11 +683,6 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           if (!autoLayoutLockedRef.current && allowContentHeuristicRef.current) {
             const docLayout = detectLayoutFromDocument(doc) || "book";
             if (docLayout !== effectiveLayoutRef.current) {
-              if (import.meta.env.DEV) {
-                console.log(
-                  `[EpubChapterViewer] auto layout switched by content heuristic: ${effectiveLayoutRef.current} -> ${docLayout}`,
-                );
-              }
               detectedLayoutRef.current = docLayout;
               effectiveLayoutRef.current = docLayout;
               onRenderLayoutChangeRef.current?.(docLayout);
@@ -715,162 +696,36 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           autoLayoutLockedRef.current = true;
         }
 
-        const wheelHandler = (event: WheelEvent) => {
-          const currentSettings = settingsRef.current;
-          if (Math.abs(event.deltaY) < 12) return;
-
-          const isNextDirection = currentSettings.wheelDirection === "down" ? event.deltaY > 0 : event.deltaY < 0;
-          if (currentSettings.flow !== "paginated") {
-            const manager = (renditionRef.current as unknown as { manager?: EpubManagerSnapshot })?.manager;
-            if (!manager || manager.isPaginated !== false || !manager.container) return;
-            const scrollTop = manager.container.scrollTop ?? 0;
-            const scrollHeight = manager.container.scrollHeight ?? 0;
-            const clientHeight = manager.container.clientHeight ?? 0;
-            const atStart = scrollTop <= 2;
-            const atEnd = scrollHeight <= clientHeight || scrollTop + clientHeight >= scrollHeight - 2;
-            if ((isNextDirection && !atEnd) || (!isNextDirection && !atStart)) return;
-          }
-
-          const now = Date.now();
-          if (now - lastWheelNavigationAtRef.current < 300) return;
-          lastWheelNavigationAtRef.current = now;
-
-          event.preventDefault();
-          if (isNextDirection) {
-            onPageNextRef.current?.();
-          } else {
-            onPagePrevRef.current?.();
-          }
-        };
-
-        const keydownHandler = (event: KeyboardEvent) => {
-          const currentSettings = settingsRef.current;
-          const target = event.target as HTMLElement | null;
-          const tagName = target?.tagName?.toLowerCase();
-          const isEditable =
-            tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable);
-          if (isEditable) return;
-
-          const nextArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";
-          const prevArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowLeft" : "ArrowRight";
-
-          if (event.key === nextArrowKey || event.key === "PageDown") {
-            event.preventDefault();
-            onPageNextRef.current?.();
-          } else if (event.key === prevArrowKey || event.key === "PageUp") {
-            event.preventDefault();
-            onPagePrevRef.current?.();
-          }
-        };
-
-        // zone 판별 헬퍼: 뷰어 컨테이너 기준 좌(0~30%) / 중앙(30~70%) / 우(70~100%)
-        const resolveZone = (clientX: number): "left" | "center" | "right" => {
-          const containerRect = containerRef.current?.getBoundingClientRect();
-          const ratio =
-            containerRect && containerRect.width > 0
-              ? (clientX - containerRect.left) / containerRect.width
-              : clientX / Math.max(window.innerWidth, 1);
-          const clampedRatio = Math.max(0, Math.min(1, ratio));
-          if (clampedRatio < 0.3) return "left";
-          if (clampedRatio > 0.7) return "right";
-          return "center";
-        };
-
-        // zone에 따라 UI 토글 또는 페이지 이동 실행
-        const executeZoneAction = (zone: "left" | "center" | "right") => {
-          const currentSettings = settingsRef.current;
-          if (zone === "center") {
-            onViewerClickRef.current?.();
-            return;
-          }
-          const isRTL = currentSettings.clickDirection === "left";
-          if (zone === "left") {
-            if (isRTL) onPageNextRef.current?.();
-            else onPagePrevRef.current?.();
-          } else {
-            if (isRTL) onPagePrevRef.current?.();
-            else onPageNextRef.current?.();
-          }
-        };
-
-        // 마우스 드래그 감지용 (텍스트 선택과 클릭 구분)
-        const mouseDownHandler = (event: MouseEvent) => {
-          pointerDownPosRef.current = { x: event.clientX, y: event.clientY };
-          isDraggingRef.current = false;
-        };
-
-        const mouseMoveHandler = (event: MouseEvent) => {
-          if (!pointerDownPosRef.current) return;
-          const dx = event.clientX - pointerDownPosRef.current.x;
-          const dy = event.clientY - pointerDownPosRef.current.y;
-          if (Math.sqrt(dx * dx + dy * dy) > 5) {
-            isDraggingRef.current = true;
-          }
-        };
-
-        // iframe 내부 클릭 → zone 기반 UI 토글 / 페이지 이동
         const clickHandler = (event: MouseEvent) => {
           if (touchHandledRef.current) {
             touchHandledRef.current = false;
             return;
           }
-
-          // 드래그(텍스트 선택) 후 클릭은 무시
           if (isDraggingRef.current) {
             isDraggingRef.current = false;
             pointerDownPosRef.current = null;
             return;
           }
           pointerDownPosRef.current = null;
-
-          // 텍스트가 선택된 상태면 클릭 무시 (선택 유지)
-          const iframeWindow = doc.defaultView;
-          const selection = iframeWindow?.getSelection();
+          const selection = doc.defaultView?.getSelection();
           if (selection && !selection.isCollapsed) return;
 
           const target = event.target as HTMLElement | null;
           const anchor = target?.closest("a[href]") as HTMLAnchorElement | null;
           if (anchor) {
             const href = anchor.getAttribute("href") || "";
-            if (!href) return;
-            const isExternal = /^https?:\/\//i.test(href);
-            if (isExternal) {
+            if (href && /^https?:\/\//i.test(href)) {
               event.preventDefault();
               event.stopPropagation();
               window.open(href, "_blank", "noopener,noreferrer");
             }
             return;
           }
+          if (target?.closest("button, input, select, textarea, [contenteditable='true']")) return;
 
-          const interactiveTarget = target?.closest("button, input, select, textarea, [contenteditable='true']");
-          if (interactiveTarget) return;
-
-          // iframe 내부 클릭 좌표를 최상위 window 기준으로 변환
           const iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
           const iframeRect = iframe?.getBoundingClientRect();
-          const absoluteX = (iframeRect?.left ?? 0) + event.clientX;
-
-          executeZoneAction(resolveZone(absoluteX));
-        };
-
-        // iframe 내부 터치 → zone 기반 UI 토글 / 페이지 이동
-        const touchStartHandler = (event: TouchEvent) => {
-          const touch = event.touches[0];
-          if (!touch) return;
-          pointerDownPosRef.current = { x: touch.clientX, y: touch.clientY };
-          isDraggingRef.current = false;
-          touchHandledRef.current = false;
-        };
-
-        const touchMoveHandler = (event: TouchEvent) => {
-          if (!pointerDownPosRef.current) return;
-          const touch = event.changedTouches[0];
-          if (!touch) return;
-          const dx = touch.clientX - pointerDownPosRef.current.x;
-          const dy = touch.clientY - pointerDownPosRef.current.y;
-          if (Math.sqrt(dx * dx + dy * dy) > 8) {
-            isDraggingRef.current = true;
-          }
+          executeZoneAction(resolveZone((iframeRect?.left ?? 0) + event.clientX));
         };
 
         const touchEndHandler = (event: TouchEvent) => {
@@ -879,20 +734,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
             isDraggingRef.current = false;
             const startPos = pointerDownPosRef.current;
             pointerDownPosRef.current = null;
-
-            // 스와이프 감지: 수평 이동이 임계값(50px) 이상이고 수직보다 클 때
             if (startPos) {
               const touch = event.changedTouches[0];
               if (touch) {
                 const dx = touch.clientX - startPos.x;
                 const dy = touch.clientY - startPos.y;
-                const SWIPE_THRESHOLD = 50;
-                if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy)) {
-                  const currentSettings = settingsRef.current;
-                  const isRTL = currentSettings.clickDirection === "left";
-                  // 왼쪽으로 스와이프(dx < 0) = LTR에서 다음 페이지
-                  const isSwipeLeft = dx < 0;
-                  if (isSwipeLeft) {
+                if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+                  const isRTL = settingsRef.current.clickDirection === "left";
+                  if (dx < 0) {
                     if (isRTL) onPagePrevRef.current?.();
                     else onPageNextRef.current?.();
                   } else {
@@ -904,16 +753,12 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
             }
             return;
           }
-
-          // 터치 좌표를 최상위 window 기준으로 변환
           const touch = event.changedTouches[0];
           const clientX = touch?.clientX ?? pointerDownPosRef.current?.x ?? 0;
           const iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
           const iframeRect = iframe?.getBoundingClientRect();
-          const absoluteX = (iframeRect?.left ?? 0) + clientX;
-
           pointerDownPosRef.current = null;
-          executeZoneAction(resolveZone(absoluteX));
+          executeZoneAction(resolveZone((iframeRect?.left ?? 0) + clientX));
         };
 
         doc.addEventListener("wheel", wheelHandler, { passive: false });
@@ -925,29 +770,58 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         doc.addEventListener("touchmove", touchMoveHandler, { passive: true });
         doc.addEventListener("touchend", touchEndHandler);
 
-        contentDisposers.set(doc, () => {
-          const eventTarget = doc as Document | undefined;
-          if (typeof eventTarget?.removeEventListener !== "function") return;
-
-          eventTarget.removeEventListener("wheel", wheelHandler);
-          eventTarget.removeEventListener("keydown", keydownHandler);
-          eventTarget.removeEventListener("mousedown", mouseDownHandler);
-          eventTarget.removeEventListener("mousemove", mouseMoveHandler);
-          eventTarget.removeEventListener("click", clickHandler);
-          eventTarget.removeEventListener("touchstart", touchStartHandler);
-          eventTarget.removeEventListener("touchmove", touchMoveHandler);
-          eventTarget.removeEventListener("touchend", touchEndHandler);
+        contentDisposersRef.current.set(doc, () => {
+          doc.removeEventListener("wheel", wheelHandler);
+          doc.removeEventListener("keydown", keydownHandler);
+          doc.removeEventListener("mousedown", mouseDownHandler);
+          doc.removeEventListener("mousemove", mouseMoveHandler);
+          doc.removeEventListener("click", clickHandler);
+          doc.removeEventListener("touchstart", touchStartHandler);
+          doc.removeEventListener("touchmove", touchMoveHandler);
+          doc.removeEventListener("touchend", touchEndHandler);
         });
       };
 
-      rendition.on("relocated", handleRelocated as unknown as (...args: unknown[]) => void);
-      rendition.hooks.content.register(handleContentInput as unknown as (...args: unknown[]) => void);
+      const enforceWheelListener = () => {
+        const currentRendition = renditionRef.current;
+        if (!currentRendition) return;
+        const manager = asEpubRenditionSnapshot(currentRendition).manager;
+        if (manager?.container) {
+          manager.container.removeEventListener("wheel", wheelHandler);
+          manager.container.addEventListener("wheel", wheelHandler, { passive: false });
+          wheelContainers.add(manager.container);
+        }
+        asEpubRenditionSnapshot(currentRendition)
+          .getContents?.()
+          .forEach((content) => {
+            if (content.document) {
+              content.document.removeEventListener("wheel", wheelHandler);
+              content.document.addEventListener("wheel", wheelHandler, { passive: false });
+            }
+          });
+      };
 
-      // === 초기화 헬퍼: 위치 복원 후 초기화 완료 처리 ===
-      const waitForLayoutFrame = () =>
-        new Promise<void>((resolve) => {
-          requestAnimationFrame(() => resolve());
-        });
+      const contentHookHandler = (content: EpubContentSnapshot) => {
+        handleContentInput(content as Contents);
+        enforceWheelListener();
+      };
+
+      const renderHandler = () => {
+        enforceWheelListener();
+      };
+
+      const displayedHandler = () => {
+        enforceWheelListener();
+      };
+
+      rendition.on("relocated", handleRelocated as unknown as (...args: unknown[]) => void);
+      rendition.on("render", renderHandler);
+      rendition.on("displayed", displayedHandler);
+      rendition.hooks.content.register(contentHookHandler as unknown as (...args: unknown[]) => void);
+
+      enforceWheelListener();
+
+      const waitForLayoutFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
       const finalizeInit = async (snapToEnd = initialOpenMode === "last") => {
         if (isDisposed) return;
@@ -963,36 +837,30 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         onInitializationCompleteRef.current?.();
         const loc = rendition.currentLocation() as unknown as EpubjsLocation;
         if (loc) handleRelocated(loc);
-
-        // flow 변경 또는 이어보기로 위치 복원 시 anchor highlight 표시
-        const highlightCfi = pendingAnchorHighlightRef.current;
-        if (highlightCfi) {
+        if (pendingAnchorHighlightRef.current) {
+          const h = pendingAnchorHighlightRef.current;
           pendingAnchorHighlightRef.current = null;
-          showAnchorHighlightRef.current?.(highlightCfi);
+          showAnchorHighlightRef.current?.(h);
         }
       };
+
       const displayWithFallback = (targetCFI?: string, ratioFallback?: number) => {
         const fallbackCFI =
           typeof ratioFallback === "number" && ratioFallback > 0.01
             ? getSafeCfiFromPercentage(book.locations, ratioFallback)
             : undefined;
-
         const displayBeginning = () =>
           rendition
             .display(undefined)
             .then(() => finalizeInit())
-            .catch((fallbackErr: unknown) => {
-              console.error("[EpubChapterViewer] Initial display fallback failed:", fallbackErr);
-              return finalizeInit();
-            });
-
-        const displayRatioFallback = () => {
-          if (!fallbackCFI || fallbackCFI === targetCFI) return displayBeginning();
-          return rendition
-            .display(fallbackCFI)
-            .then(() => finalizeInit())
-            .catch(displayBeginning);
-        };
+            .catch(() => finalizeInit());
+        const displayRatioFallback = () =>
+          !fallbackCFI || fallbackCFI === targetCFI
+            ? displayBeginning()
+            : rendition
+                .display(fallbackCFI)
+                .then(() => finalizeInit())
+                .catch(displayBeginning);
 
         return rendition
           .display(targetCFI)
@@ -1352,10 +1220,16 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           resizeFrameRef.current = null;
         }
         rendition.off("relocated", handleRelocated as unknown as (...args: unknown[]) => void);
+        rendition.off("render", renderHandler);
+        rendition.off("displayed", displayedHandler);
         const contentHook = rendition.hooks.content as unknown as {
           deregister?: (fn: (...args: unknown[]) => void) => void;
         };
-        contentHook.deregister?.(handleContentInput as unknown as (...args: unknown[]) => void);
+        contentHook.deregister?.(contentHookHandler as unknown as (...args: unknown[]) => void);
+        wheelContainers.forEach((container) => {
+          container.removeEventListener("wheel", wheelHandler);
+        });
+        wheelContainers.clear();
         contentDisposers.forEach((dispose) => {
           try {
             dispose();
@@ -1491,16 +1365,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       const getNavigationSnapshot = (): NavigationSnapshot => {
         const rendition = renditionRef.current;
         const currentLocation = rendition?.currentLocation() as EpubjsLocation | undefined;
-        const manager = rendition as unknown as {
-          manager?: EpubManagerSnapshot;
-        };
+        const manager = rendition ? asEpubRenditionSnapshot(rendition).manager : undefined;
 
         return {
           cfi: currentLocation?.start?.cfi ?? null,
           page: currentLocation?.start?.displayed?.page ?? 0,
           index: currentLocation?.start?.index ?? -1,
-          scrollLeft: manager.manager?.container?.scrollLeft ?? 0,
-          scrollTop: manager.manager?.container?.scrollTop ?? 0,
+          scrollLeft: manager?.container?.scrollLeft ?? 0,
+          scrollTop: manager?.container?.scrollTop ?? 0,
         };
       };
 
@@ -1515,18 +1387,20 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       };
 
       const isScrolledManagerAtEnd = (): boolean => {
-        const manager = (renditionRef.current as unknown as { manager?: EpubManagerSnapshot })?.manager;
-        if (!manager || manager.isPaginated !== false || !manager.container) return false;
+        const currentRendition = renditionRef.current;
+        const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
+        if (!manager || manager.isPaginated === true || !manager.container) return false;
         const scrollTop = manager.container.scrollTop ?? 0;
         const scrollHeight = manager.container.scrollHeight ?? 0;
         const clientHeight = manager.container.clientHeight ?? 0;
-        if (scrollHeight <= clientHeight) return true;
+        if (scrollHeight <= clientHeight + 5) return true;
         return scrollTop + clientHeight >= scrollHeight - 2;
       };
 
       const isScrolledManagerAtStart = (): boolean => {
-        const manager = (renditionRef.current as unknown as { manager?: EpubManagerSnapshot })?.manager;
-        if (!manager || manager.isPaginated !== false || !manager.container) return false;
+        const currentRendition = renditionRef.current;
+        const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
+        if (!manager || manager.isPaginated === true || !manager.container) return false;
         return (manager.container.scrollTop ?? 0) <= 2;
       };
 
@@ -1562,13 +1436,13 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         next: async () => {
           if (!renditionRef.current) return false;
           try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const manager = (renditionRef.current as any).manager;
+            const manager = asEpubRenditionSnapshot(renditionRef.current).manager;
             if (manager && manager.isPaginated && manager.container) {
+              const container = manager.container;
               const dir = manager.settings?.direction;
-              const scrollLeft = manager.container.scrollLeft;
-              const scrollWidth = manager.container.scrollWidth;
-              const clientWidth = manager.container.clientWidth;
+              const scrollLeft = container.scrollLeft;
+              const scrollWidth = container.scrollWidth;
+              const clientWidth = container.clientWidth;
               const delta = manager.layout?.delta || clientWidth;
 
               if (dir === "ltr") {
@@ -1578,8 +1452,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                     const targetLeft = Math.max(0, scrollWidth - clientWidth);
                     if (targetLeft - scrollLeft > 2) {
                       return withNavigation(() => {
-                        manager.container.scrollLeft = targetLeft;
-                        manager.updateOffset();
+                        container.scrollLeft = targetLeft;
+                        manager.updateOffset?.();
                         return true;
                       });
                     }
@@ -1592,8 +1466,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                     const targetLeft = 0;
                     if (scrollLeft - targetLeft > 2) {
                       return withNavigation(() => {
-                        manager.container.scrollLeft = targetLeft;
-                        manager.updateOffset();
+                        container.scrollLeft = targetLeft;
+                        manager.updateOffset?.();
                         return true;
                       });
                     }
@@ -1620,13 +1494,13 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         prev: async () => {
           if (!renditionRef.current) return false;
           try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const manager = (renditionRef.current as any).manager;
+            const manager = asEpubRenditionSnapshot(renditionRef.current).manager;
             if (manager && manager.isPaginated && manager.container) {
+              const container = manager.container;
               const dir = manager.settings?.direction;
-              const scrollLeft = manager.container.scrollLeft;
-              const scrollWidth = manager.container.scrollWidth;
-              const clientWidth = manager.container.clientWidth;
+              const scrollLeft = container.scrollLeft;
+              const scrollWidth = container.scrollWidth;
+              const clientWidth = container.clientWidth;
               const delta = manager.layout?.delta || clientWidth;
 
               if (dir === "ltr") {
@@ -1636,8 +1510,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                     const targetLeft = 0;
                     if (scrollLeft - targetLeft > 2) {
                       return withNavigation(() => {
-                        manager.container.scrollLeft = targetLeft;
-                        manager.updateOffset();
+                        container.scrollLeft = targetLeft;
+                        manager.updateOffset?.();
                         return true;
                       });
                     }
@@ -1650,8 +1524,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
                     const targetLeft = Math.max(0, scrollWidth - clientWidth);
                     if (targetLeft - scrollLeft > 2) {
                       return withNavigation(() => {
-                        manager.container.scrollLeft = targetLeft;
-                        manager.updateOffset();
+                        container.scrollLeft = targetLeft;
+                        manager.updateOffset?.();
                         return true;
                       });
                     }
@@ -1674,8 +1548,9 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
             const afterIndex = afterLoc?.start?.index;
             if (beforeIndex !== undefined && afterIndex !== undefined && beforeIndex !== afterIndex) {
               try {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const mgr = (renditionRef.current as any).manager;
+                const currentRendition = renditionRef.current;
+                if (!currentRendition) return;
+                const mgr = asEpubRenditionSnapshot(currentRendition).manager;
                 if (mgr?.isPaginated && mgr.container) {
                   const d = mgr.settings?.direction;
                   const sw = mgr.container.scrollWidth;
@@ -1703,7 +1578,8 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
           const movedToPrev = await withNavigation(() => renditionRef.current!.display(prevSpineItem.href));
           try {
-            const manager = (renditionRef.current as unknown as { manager?: EpubManagerSnapshot })?.manager;
+            const currentRendition = renditionRef.current;
+            const manager = currentRendition ? asEpubRenditionSnapshot(currentRendition).manager : undefined;
             const container = manager?.container;
             if (manager?.isPaginated === false && container) {
               container.scrollTop = Math.max(0, (container.scrollHeight ?? 0) - (container.clientHeight ?? 0));

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -1012,7 +1012,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         doc.addEventListener("mousemove", mouseMoveHandler);
         doc.addEventListener("click", clickHandler);
         doc.addEventListener("touchstart", touchStartHandler, { passive: true });
-        doc.addEventListener("touchmove", touchMoveHandler, { passive: false });
+        doc.addEventListener("touchmove", touchMoveHandler, { passive: settings.flow !== "scrolled" });
         doc.addEventListener("touchend", touchEndHandler);
 
         contentDisposersRef.current.set(doc, () => {
@@ -1040,7 +1040,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
           manager.container.removeEventListener("touchmove", touchMoveHandler);
           manager.container.removeEventListener("touchend", containerTouchEndHandler);
           manager.container.addEventListener("touchstart", touchStartHandler, { passive: true });
-          manager.container.addEventListener("touchmove", touchMoveHandler, { passive: false });
+          manager.container.addEventListener("touchmove", touchMoveHandler, { passive: settings.flow !== "scrolled" });
           manager.container.addEventListener("touchend", containerTouchEndHandler);
           touchContainers.add(manager.container);
         }

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/locationUtils.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/locationUtils.ts
@@ -1,0 +1,63 @@
+import type { EpubjsLocationsExtended } from "./epubjsSnapshots";
+
+export const EPUB_LOCATION_STRIDE = 6144; // 6KB 단위로 가상 페이지(위치) 정의. backend/internal/util/epub.go의 EpubPositionStride와 일치해야 함.
+
+export const toLocationRatio = (position: number, total: number): number => {
+  if (!Number.isFinite(position) || !Number.isFinite(total) || total <= 1) return 0;
+  return Math.max(0, Math.min(1, position / (total - 1)));
+};
+
+export const getSafeLocationLength = (locations: unknown): number => {
+  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
+  if (typeof locationSet?.length !== "function") return 0;
+
+  try {
+    const total = locationSet.length();
+    return Number.isFinite(total) && total > 0 ? total : 0;
+  } catch (err) {
+    console.warn("[EpubChapterViewer] location length unavailable:", err);
+    return 0;
+  }
+};
+
+export const getSafeCfiFromPercentage = (locations: unknown, ratio: number): string | undefined => {
+  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
+  if (typeof locationSet?.cfiFromPercentage !== "function") return undefined;
+
+  try {
+    const cfi = locationSet.cfiFromPercentage(Math.max(0, Math.min(1, ratio)));
+    return typeof cfi === "string" && cfi.trim().length > 0 ? cfi : undefined;
+  } catch (err) {
+    console.warn("[EpubChapterViewer] cfiFromPercentage failed:", err);
+    return undefined;
+  }
+};
+
+export const getSafeCfiFromLocation = (locations: unknown, location: number): string | undefined => {
+  const locationSet = locations as Partial<EpubjsLocationsExtended> | null | undefined;
+  if (typeof locationSet?.cfiFromLocation !== "function") return undefined;
+
+  try {
+    const cfi = locationSet.cfiFromLocation(location);
+    return typeof cfi === "string" && cfi.trim().length > 0 ? cfi : undefined;
+  } catch (err) {
+    console.warn("[EpubChapterViewer] cfiFromLocation failed:", err);
+    return undefined;
+  }
+};
+
+export const safeDecodeURIComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const safeDecodeFragment = (value: string): string | null => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+};

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/scrolledPull.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/scrolledPull.ts
@@ -1,0 +1,24 @@
+import { EPUB_SCROLLED_PULL_THRESHOLD } from "./constants";
+
+export type ScrolledPullCompletionAction = "nav-prev" | "nav-next" | "decay" | "none";
+
+/**
+ * 스크롤 당김 완료 시 취해야 할 액션을 결정한다.
+ * - 임계값 초과 + canPrev/canNext → 네비게이션
+ * - 임계값 미만 + offset ≠ 0 → decay
+ * - 그 외 → none
+ */
+export function getScrolledPullCompletionAction(
+  offset: number,
+  canPrev: boolean,
+  canNext: boolean,
+  threshold = EPUB_SCROLLED_PULL_THRESHOLD,
+): ScrolledPullCompletionAction {
+  if (Math.abs(offset) >= threshold) {
+    if (offset > 0 && canPrev) return "nav-prev";
+    if (offset < 0 && canNext) return "nav-next";
+    return "none";
+  }
+  if (offset !== 0) return "decay";
+  return "none";
+}

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/styleBuilder.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/styleBuilder.ts
@@ -51,29 +51,29 @@ export function buildEpubInjectedStyle(settings: EpubViewerSettings, layout: Epu
     }
 
     body {
-      width: 100% !important;
-      max-width: 960px !important;
-      min-height: 100vh !important;
-      margin-left: auto !important;
-      margin-right: auto !important;
-      padding-top: 72px !important;
-      padding-bottom: 96px !important;
-      padding-left: 32px !important;
-      padding-right: 32px !important;
-      box-sizing: border-box !important;
-      overflow-x: hidden !important;
+      width: 100%;
+      max-width: 960px;
+      min-height: 100vh;
+      margin-left: auto;
+      margin-right: auto;
+      padding-top: 72px;
+      padding-bottom: 96px;
+      padding-left: 32px;
+      padding-right: 32px;
+      box-sizing: border-box;
+      overflow-x: hidden;
     }
 
     *, *::before, *::after {
-      box-sizing: border-box !important;
+      box-sizing: border-box;
     }
 
     img, svg, video, canvas, table {
-      max-width: 100% !important;
+      max-width: 100%;
     }
 
     img, svg, video, canvas {
-      height: auto !important;
+      height: auto;
     }
   `
     : "";
@@ -104,23 +104,23 @@ export function buildEpubInjectedStyle(settings: EpubViewerSettings, layout: Epu
 
     body {
       ${bodyTypographyRule}
-      column-fill: auto !important;
-      padding-top: 0 !important;
-      padding-bottom: 0 !important;
-      padding-left: 8px !important;
-      padding-right: 8px !important;
+      column-fill: auto;
+      padding-top: 0;
+      padding-bottom: 0;
+      padding-left: 8px;
+      padding-right: 8px;
     }
 
     @media (max-width: 640px) {
       body {
-        width: 100% !important;
-        max-width: 960px !important;
-        margin-left: auto !important;
-        margin-right: auto !important;
-        padding-left: 32px !important;
-        padding-right: 32px !important;
-        box-sizing: border-box !important;
-        overflow-x: hidden !important;
+        width: 100%;
+        max-width: 960px;
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 32px;
+        padding-right: 32px;
+        box-sizing: border-box;
+        overflow-x: hidden;
       }
     }
 
@@ -160,25 +160,29 @@ export function buildEpubInjectedStyle(settings: EpubViewerSettings, layout: Epu
     }
 
     section, .epub-type-contains-word-section {
-      display: block !important;
-      break-inside: auto !important;
-      page-break-inside: auto !important;
-      overflow: visible !important;
-      height: auto !important;
+      display: block;
+      break-inside: auto;
+      page-break-inside: auto;
+      overflow: visible;
+      height: auto;
     }
 
     .box_brown, .box_white, .box_grey {
-      break-inside: avoid !important;
-      -webkit-break-inside: avoid !important;
-      page-break-inside: avoid !important;
-      min-height: 100% !important;
+      break-inside: avoid;
+      -webkit-break-inside: avoid;
+      page-break-inside: avoid;
+      min-height: 100%;
     }
 
-    ${settings.theme !== "dark" ? `
+    ${
+      settings.theme !== "dark"
+        ? `
     img[epub\\:type~='se:image.color-depth.black-on-transparent'],
     img.epub-type-contains-word-se-image-color-depth-black-on-transparent {
       filter: none !important;
       background: transparent !important;
-    }` : ""}
+    }`
+        : ""
+    }
   `;
 }

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/styleBuilder.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/styleBuilder.ts
@@ -51,17 +51,17 @@ export function buildEpubInjectedStyle(settings: EpubViewerSettings, layout: Epu
     }
 
     body {
-      width: 100%;
-      max-width: 960px;
-      min-height: 100vh;
-      margin-left: auto;
-      margin-right: auto;
-      padding-top: 72px;
-      padding-bottom: 96px;
-      padding-left: 32px;
-      padding-right: 32px;
-      box-sizing: border-box;
-      overflow-x: hidden;
+      width: 100% !important;
+      max-width: 960px !important;
+      min-height: 100vh !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+      padding-top: 72px !important;
+      padding-bottom: 96px !important;
+      padding-left: 32px !important;
+      padding-right: 32px !important;
+      box-sizing: border-box !important;
+      overflow-x: hidden !important;
     }
 
     *, *::before, *::after {
@@ -69,7 +69,7 @@ export function buildEpubInjectedStyle(settings: EpubViewerSettings, layout: Epu
     }
 
     img, svg, video, canvas, table {
-      max-width: 100%;
+      max-width: 100% !important;
     }
 
     img, svg, video, canvas {

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
@@ -1,0 +1,34 @@
+import type { EpubViewerSettings } from "../../../../stores/epubViewerStore";
+import type { EpubManagerSnapshot } from "./epubjsSnapshots";
+
+export type WheelNavigationAction = "next" | "prev" | null;
+
+interface WheelNavigationInput {
+  deltaY: number;
+  flow: EpubViewerSettings["flow"];
+  wheelDirection: EpubViewerSettings["wheelDirection"];
+  manager?: EpubManagerSnapshot;
+}
+
+export function getWheelNavigationAction({
+  deltaY,
+  flow,
+  wheelDirection,
+  manager,
+}: WheelNavigationInput): WheelNavigationAction {
+  if (Math.abs(deltaY) < 1) return null;
+
+  const isNextDirection = wheelDirection === "down" ? deltaY > 0 : deltaY < 0;
+  if (flow !== "paginated") {
+    if (!manager || manager.isPaginated === true || !manager.container) return null;
+
+    const { scrollHeight, clientHeight, scrollTop } = manager.container;
+    if (scrollHeight > clientHeight + 5) {
+      const atStart = scrollTop <= 5;
+      const atEnd = scrollTop + clientHeight >= scrollHeight - 8;
+      if ((isNextDirection && !atEnd) || (!isNextDirection && !atStart)) return null;
+    }
+  }
+
+  return isNextDirection ? "next" : "prev";
+}

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
@@ -22,7 +22,7 @@ export function getWheelNavigationAction({
 
   const isNextDirection = wheelDirection === "down" ? deltaY > 0 : deltaY < 0;
   if (flow !== "paginated") {
-    if (!manager || manager.isPaginated === true || !manager.container) return null;
+    if (!manager || manager.isPaginated !== false || !manager.container) return null;
 
     const { scrollHeight, clientHeight, scrollTop } = manager.container;
     if (scrollHeight > clientHeight + 5) {

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/wheelNavigation.ts
@@ -3,6 +3,8 @@ import type { EpubManagerSnapshot } from "./epubjsSnapshots";
 
 export type WheelNavigationAction = "next" | "prev" | null;
 
+const WHEEL_NAVIGATION_DELTA_THRESHOLD = 8;
+
 interface WheelNavigationInput {
   deltaY: number;
   flow: EpubViewerSettings["flow"];
@@ -16,7 +18,7 @@ export function getWheelNavigationAction({
   wheelDirection,
   manager,
 }: WheelNavigationInput): WheelNavigationAction {
-  if (Math.abs(deltaY) < 1) return null;
+  if (Math.abs(deltaY) < WHEEL_NAVIGATION_DELTA_THRESHOLD) return null;
 
   const isNextDirection = wheelDirection === "down" ? deltaY > 0 : deltaY < 0;
   if (flow !== "paginated") {

--- a/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
@@ -355,6 +355,31 @@ describe("EpubViewer UI", () => {
     expect(viewerNextSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("should keep center click UI toggle in scrolled mode", () => {
+    const baseProps = createDefaultProps();
+    const props = {
+      ...baseProps,
+      settings: {
+        ...baseProps.settings,
+        flow: "scrolled" as const,
+      },
+    };
+
+    const { container } = render(
+      <MemoryRouter>
+        <EpubViewer {...props} />
+      </MemoryRouter>,
+    );
+
+    const main = getMain(container);
+
+    fireEvent.click(main, { clientX: 500 });
+
+    expect(props.onViewerClick).toHaveBeenCalledTimes(1);
+    expect(viewerPrevSpy).not.toHaveBeenCalled();
+    expect(viewerNextSpy).not.toHaveBeenCalled();
+  });
+
   it("should ignore left and right click zones in scrolled mode", () => {
     const baseProps = createDefaultProps();
     const props = {

--- a/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
@@ -355,6 +355,32 @@ describe("EpubViewer UI", () => {
     expect(viewerNextSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("should ignore left and right click zones in scrolled mode", () => {
+    const baseProps = createDefaultProps();
+    const props = {
+      ...baseProps,
+      settings: {
+        ...baseProps.settings,
+        flow: "scrolled" as const,
+      },
+    };
+
+    const { container } = render(
+      <MemoryRouter>
+        <EpubViewer {...props} />
+      </MemoryRouter>,
+    );
+
+    const main = getMain(container);
+
+    fireEvent.click(main, { clientX: 100 });
+    fireEvent.click(main, { clientX: 900 });
+
+    expect(viewerPrevSpy).not.toHaveBeenCalled();
+    expect(viewerNextSpy).not.toHaveBeenCalled();
+    expect(props.onViewerClick).not.toHaveBeenCalled();
+  });
+
   it("should invert left and right tap navigation when clickDirection is left", () => {
     isOldIOSSafariMock.mockReturnValue(true);
     const baseProps = createDefaultProps();

--- a/web/src/features/viewer/components/PullIndicator/PullIndicator.module.css
+++ b/web/src/features/viewer/components/PullIndicator/PullIndicator.module.css
@@ -49,7 +49,7 @@
 
 .pullIndicator.prev {
   top: 0;
-  padding-top: 56px; /* 헤더 공간 확보 */
+  padding-top: 10px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   /* 끝부분 흐릿하게 처리 (마스크) */
   -webkit-mask-image: linear-gradient(to bottom, black 85%, transparent 100%);

--- a/web/src/features/viewer/components/PullIndicator/index.tsx
+++ b/web/src/features/viewer/components/PullIndicator/index.tsx
@@ -50,7 +50,11 @@ export function PullIndicator({
     if (!isVisible) return;
 
     if (onActivate) {
-      await onActivate(type);
+      try {
+        await onActivate(type);
+      } catch (err) {
+        console.warn("Failed to activate pull indicator", err);
+      }
       return;
     }
 

--- a/web/src/features/viewer/components/PullIndicator/index.tsx
+++ b/web/src/features/viewer/components/PullIndicator/index.tsx
@@ -32,8 +32,8 @@ export function PullIndicator({
   const viewerFrom = typeof location.state?.from === "string" ? location.state.from : undefined;
   const routeIsIncognito = location.state?.isIncognito === true;
 
-  // 챕터 ID가 없으면 아예 렌더링하지 않음
-  if (!chapterId) return null;
+  // 라우팅 기반 챕터 이동은 chapterId가 필요하지만, 커스텀 활성화 콜백은 chapterId 없이도 동작한다.
+  if (!chapterId && !onActivate) return null;
 
   // 오프셋이 있으면 visible 클래스 적용
   // 작은 오프셋이라도 감지되면 일단 보여주고(opacity 1), 0이 되면 CSS transition(1s)을 통해 사라짐

--- a/web/src/features/viewer/components/PullIndicator/index.tsx
+++ b/web/src/features/viewer/components/PullIndicator/index.tsx
@@ -14,6 +14,7 @@ interface PullIndicatorProps {
   chapterId: string | null;
   chapterTitle: string | null;
   saveProgress: () => Promise<void>;
+  onActivate?: (type: "prev" | "next") => Promise<void> | void;
 }
 
 export function PullIndicator({
@@ -23,6 +24,7 @@ export function PullIndicator({
   chapterId,
   chapterTitle,
   saveProgress,
+  onActivate,
 }: PullIndicatorProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -40,6 +42,11 @@ export function PullIndicator({
   const handleClick = async () => {
     // visible 상태일 때만 클릭 허용 (pointer-events로 제어하지만 안전장치)
     if (!isVisible) return;
+
+    if (onActivate) {
+      await onActivate(type);
+      return;
+    }
 
     await saveProgress().catch((err) => console.warn("Failed to save progress", err));
     startChapterSwitching(isDocumentFullscreen());

--- a/web/src/features/viewer/components/PullIndicator/index.tsx
+++ b/web/src/features/viewer/components/PullIndicator/index.tsx
@@ -15,6 +15,9 @@ interface PullIndicatorProps {
   chapterTitle: string | null;
   saveProgress: () => Promise<void>;
   onActivate?: (type: "prev" | "next") => Promise<void> | void;
+  labelText?: string;
+  hintText?: string;
+  ariaActionLabel?: string;
 }
 
 export function PullIndicator({
@@ -25,6 +28,9 @@ export function PullIndicator({
   chapterTitle,
   saveProgress,
   onActivate,
+  labelText,
+  hintText,
+  ariaActionLabel,
 }: PullIndicatorProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -62,6 +68,10 @@ export function PullIndicator({
   };
 
   const progress = Math.min(100, Math.round((Math.abs(pullOffset) / pullThreshold) * 100));
+  const defaultLabelText = type === "prev" ? t("viewer.guide.scroll_prev_label") : t("viewer.guide.scroll_next_label");
+  const defaultHintText = type === "prev" ? t("viewer.guide.scroll_prev_hint") : t("viewer.guide.scroll_next_hint");
+  const defaultAriaActionLabel =
+    type === "prev" ? t("viewer.guide.aria_prev_chapter") : t("viewer.guide.aria_next_chapter");
 
   return (
     <button
@@ -74,16 +84,14 @@ export function PullIndicator({
             : `translateY(${Math.max(0, 15 - Math.abs(pullOffset) / 4)}px)`,
       }}
       onClick={handleClick}
-      aria-label={`${type === "prev" ? t("viewer.guide.aria_prev_chapter") : t("viewer.guide.aria_next_chapter")}: ${chapterTitle || t("viewer.guide.no_title")}`}
+      aria-label={`${ariaActionLabel ?? defaultAriaActionLabel}: ${chapterTitle || t("viewer.guide.no_title")}`}
     >
       <div className={styles.content}>
         <span className={styles.label}>
-          {type === "prev" ? t("viewer.guide.scroll_prev_label") : t("viewer.guide.scroll_next_label")} ({progress}%)
+          {labelText ?? defaultLabelText} ({progress}%)
         </span>
         <span className={styles.title}>{chapterTitle || t("viewer.guide.no_title")}</span>
-        <span className={styles.hint}>
-          {type === "prev" ? t("viewer.guide.scroll_prev_hint") : t("viewer.guide.scroll_next_hint")}
-        </span>
+        <span className={styles.hint}>{hintText ?? defaultHintText}</span>
       </div>
     </button>
   );

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1017,15 +1017,15 @@
         "label": "PDF Top Zoom Controls",
         "show": "Show",
         "hide": "Hide"
-      },
-      "footer": {
-        "pages_1": "1 Page",
-        "pages_2": "2 Pages",
-        "offset": "Offset",
-        "progress": "Page navigation",
-        "marker_jump": "Jump to: {{label}}",
-        "chapter_list": "Chapter list"
       }
+    },
+    "footer": {
+      "pages_1": "1 Page",
+      "pages_2": "2 Pages",
+      "offset": "Offset",
+      "progress": "Page navigation",
+      "marker_jump": "Jump to: {{label}}",
+      "chapter_list": "Chapter list"
     },
     "sync": {
       "title": "Sync Progress",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1023,7 +1023,8 @@
         "pages_2": "2 Pages",
         "offset": "Offset",
         "progress": "Page navigation",
-        "marker_jump": "Jump to: {{label}}"
+        "marker_jump": "Jump to: {{label}}",
+        "chapter_list": "Chapter list"
       }
     },
     "sync": {
@@ -1119,6 +1120,10 @@
       "progress": "Progress bar",
       "pages_1": "1-page",
       "pages_2": "2-page"
+    },
+    "scroll_pull": {
+      "prev_part": "Previous part",
+      "next_part": "Next part"
     },
     "progress_marker": {
       "navigate": "Navigate TOC: {{label}}"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1123,7 +1123,13 @@
     },
     "scroll_pull": {
       "prev_part": "Previous part",
-      "next_part": "Next part"
+      "next_part": "Next part",
+      "prev_part_label": "▲ Previous part",
+      "next_part_label": "▼ Next part",
+      "prev_part_hint": "Keep scrolling up to move to the previous part",
+      "next_part_hint": "Keep scrolling down to move to the next part",
+      "aria_prev_part": "Go to previous part",
+      "aria_next_part": "Go to next part"
     },
     "progress_marker": {
       "navigate": "Navigate TOC: {{label}}"

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1122,7 +1122,13 @@
     },
     "scroll_pull": {
       "prev_part": "前のpart",
-      "next_part": "次のpart"
+      "next_part": "次のpart",
+      "prev_part_label": "▲ 前のpart",
+      "next_part_label": "▼ 次のpart",
+      "prev_part_hint": "上にスクロールし続けると前のpartへ移動",
+      "next_part_hint": "下にスクロールし続けると次のpartへ移動",
+      "aria_prev_part": "前のpartへ移動",
+      "aria_next_part": "次のpartへ移動"
     },
     "progress_marker": {
       "navigate": "目次移動: {{label}}"

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1024,7 +1024,8 @@
       "pages_2": "2ページ",
       "offset": "オフセット",
       "progress": "ページナビゲーション",
-      "marker_jump": "目次へ移動: {{label}}"
+      "marker_jump": "目次へ移動: {{label}}",
+      "chapter_list": "チャプター一覧"
     },
     "sync": {
       "title": "進捗同期",
@@ -1118,6 +1119,10 @@
       "progress": "進行バー",
       "pages_1": "1ページ",
       "pages_2": "2ページ"
+    },
+    "scroll_pull": {
+      "prev_part": "前のpart",
+      "next_part": "次のpart"
     },
     "progress_marker": {
       "navigate": "目次移動: {{label}}"

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -1024,7 +1024,8 @@
       "pages_2": "2페이지",
       "offset": "오프셋",
       "progress": "페이지 탐색",
-      "marker_jump": "목차로 이동: {{label}}"
+      "marker_jump": "목차로 이동: {{label}}",
+      "chapter_list": "챕터 목록"
     },
     "sync": {
       "title": "진행도 동기화",
@@ -1119,6 +1120,10 @@
       "progress": "진행 바",
       "pages_1": "1페이지",
       "pages_2": "2페이지"
+    },
+    "scroll_pull": {
+      "prev_part": "이전 part",
+      "next_part": "다음 part"
     },
     "progress_marker": {
       "navigate": "목차 이동: {{label}}"

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -1123,7 +1123,13 @@
     },
     "scroll_pull": {
       "prev_part": "이전 part",
-      "next_part": "다음 part"
+      "next_part": "다음 part",
+      "prev_part_label": "▲ 이전 part",
+      "next_part_label": "▼ 다음 part",
+      "prev_part_hint": "계속 위로 스크롤하면 이전 part로 이동",
+      "next_part_hint": "계속 아래로 스크롤하면 다음 part로 이동",
+      "aria_prev_part": "이전 part로 이동",
+      "aria_next_part": "다음 part로 이동"
     },
     "progress_marker": {
       "navigate": "목차 이동: {{label}}"

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -195,8 +195,8 @@ export function EpubViewer({
   const [spinePosition, setSpinePosition] = useState({
     spineIndex: 0,
     spineLength: 0,
-    atStart: true,
-    atEnd: false,
+    atStart: undefined as boolean | undefined,
+    atEnd: undefined as boolean | undefined,
   });
   const [nextHintTriggeredChapterId, setNextHintTriggeredChapterId] = useState<string | null>(null);
   const [prevHintTriggeredChapterId, setPrevHintTriggeredChapterId] = useState<string | null>(null);
@@ -301,8 +301,8 @@ export function EpubViewer({
       setSpinePosition({
         spineIndex: location.spineIndex,
         spineLength: location.spineLength,
-        atStart: location.atStart === true,
-        atEnd: location.atEnd === true,
+        atStart: location.atStart,
+        atEnd: location.atEnd,
       });
       onLocationChange(location);
     },
@@ -366,10 +366,10 @@ export function EpubViewer({
 
   const isVisibleAtStart = chapterPageDisplay <= 1;
   const isVisibleAtEnd = chapterTotalDisplay > 0 && chapterPageDisplay >= chapterTotalDisplay;
-  const hasInternalPrevPart = spinePosition.spineIndex > 0 || !spinePosition.atStart;
+  const hasInternalPrevPart = spinePosition.spineIndex > 0 || spinePosition.atStart === false;
   const hasInternalNextPart =
     (spinePosition.spineLength > 0 && spinePosition.spineIndex < spinePosition.spineLength - 1) ||
-    !spinePosition.atEnd;
+    spinePosition.atEnd === false;
   const canScrolledPullPrev = hasInternalPrevPart || Boolean(onReachedStartPrev && prevChapterTitle);
   const canScrolledPullNext = hasInternalNextPart || Boolean(onReachedEndNext && nextChapterTitle);
   const prevPullTitle = hasInternalPrevPart

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -572,6 +572,7 @@ export function EpubViewer({
         onViewerClick();
         return;
       }
+      if (settings.flow === "scrolled") return;
 
       // 좌/우 클릭 → 페이지 이동
       const isRTL = settings.clickDirection === "left";
@@ -583,7 +584,7 @@ export function EpubViewer({
         else handleNext();
       }
     },
-    [getZoneRatio, handleNext, handlePrev, onViewerClick, settings.clickDirection],
+    [getZoneRatio, handleNext, handlePrev, onViewerClick, settings.clickDirection, settings.flow],
   );
 
   useEffect(() => {

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -317,7 +317,6 @@ export function EpubViewer({
 
       if (!isEndNavigationReady) return;
       if (showNextHint && onReachedEndNext) {
-        // 두 번째 클릭: 실제 이동
         clearHintTimeout();
         setNextHintTriggeredChapterId(null);
         onReachedEndNext();
@@ -340,8 +339,14 @@ export function EpubViewer({
 
     void attemptNext();
   }, [
-    onReachedEndNext, isEndNavigationReady,
-    showNextHint, showPrevHint, nextChapterTitle, chapterId, clearPendingProgress, clearHintTimeout,
+    onReachedEndNext,
+    isEndNavigationReady,
+    showNextHint,
+    showPrevHint,
+    nextChapterTitle,
+    chapterId,
+    clearPendingProgress,
+    clearHintTimeout,
   ]);
 
   const isVisibleAtStart = chapterPageDisplay <= 1;
@@ -386,8 +391,14 @@ export function EpubViewer({
 
     void attemptPrev();
   }, [
-    isStartNavigationReady, onReachedStartPrev,
-    showPrevHint, showNextHint, prevChapterTitle, chapterId, clearPendingProgress, clearHintTimeout,
+    isStartNavigationReady,
+    onReachedStartPrev,
+    showPrevHint,
+    showNextHint,
+    prevChapterTitle,
+    chapterId,
+    clearPendingProgress,
+    clearHintTimeout,
   ]);
 
   const handleTOCJump = useCallback(
@@ -880,164 +891,162 @@ export function EpubViewer({
         onMouseEnter={onInteractionStart}
         onMouseLeave={onInteractionEnd}
       >
-          <div className={styles.footerControls}>
-            <button
-              className={styles.navBtn}
-              onClick={() => viewerRef.current?.goToProgress?.(0)}
-              disabled={isVisibleAtStart}
-              aria-label={t("epub_viewer.footer.first_page")}
-            >
-              <ChevronsLeft size={20} />
-            </button>
-            <button
-              className={styles.navBtn}
-              onClick={handlePrev}
-              disabled={isVisibleAtStart && (!onReachedStartPrev || !isStartNavigationReady)}
-              aria-label={t("epub_viewer.footer.prev_page")}
-            >
-              <ChevronLeft size={20} />
-            </button>
+        <div className={styles.footerControls}>
+          <button
+            className={styles.navBtn}
+            onClick={() => viewerRef.current?.goToProgress?.(0)}
+            disabled={isVisibleAtStart}
+            aria-label={t("epub_viewer.footer.first_page")}
+          >
+            <ChevronsLeft size={20} />
+          </button>
+          <button
+            className={styles.navBtn}
+            onClick={handlePrev}
+            disabled={isVisibleAtStart && (!onReachedStartPrev || !isStartNavigationReady)}
+            aria-label={t("epub_viewer.footer.prev_page")}
+          >
+            <ChevronLeft size={20} />
+          </button>
 
-            <div className={styles.pageSliderContainer}>
-              <div className={styles.progressBarWrap}>
-                <div
-                  className={styles.progressBarInteractive}
-                  onMouseMove={handleProgressHover}
-                  onMouseLeave={handleProgressLeave}
-                  onClick={(event) => handleProgressSeek(getRatioFromEvent(event))}
-                  role="slider"
-                  tabIndex={0}
-                  aria-label={t("epub_viewer.footer.progress")}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={
-                    currentProgressPercent >= 0 ? currentProgressPercent : Math.round(currentProgressRatio * 100)
+          <div className={styles.pageSliderContainer}>
+            <div className={styles.progressBarWrap}>
+              <div
+                className={styles.progressBarInteractive}
+                onMouseMove={handleProgressHover}
+                onMouseLeave={handleProgressLeave}
+                onClick={(event) => handleProgressSeek(getRatioFromEvent(event))}
+                role="slider"
+                tabIndex={0}
+                aria-label={t("epub_viewer.footer.progress")}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={
+                  currentProgressPercent >= 0 ? currentProgressPercent : Math.round(currentProgressRatio * 100)
+                }
+                onKeyDown={(event) => {
+                  let nextRatio = currentProgressRatio;
+                  const step = 0.05;
+                  if (event.key === "ArrowRight") {
+                    event.preventDefault();
+                    nextRatio = Math.min(1, currentProgressRatio + step);
+                  } else if (event.key === "ArrowLeft") {
+                    event.preventDefault();
+                    nextRatio = Math.max(0, currentProgressRatio - step);
+                  } else if (event.key === "Home") {
+                    event.preventDefault();
+                    nextRatio = 0;
+                  } else if (event.key === "End") {
+                    event.preventDefault();
+                    nextRatio = 1;
+                  } else {
+                    return;
                   }
-                  onKeyDown={(event) => {
-                    let nextRatio = currentProgressRatio;
-                    const step = 0.05;
-                    if (event.key === "ArrowRight") {
-                      event.preventDefault();
-                      nextRatio = Math.min(1, currentProgressRatio + step);
-                    } else if (event.key === "ArrowLeft") {
-                      event.preventDefault();
-                      nextRatio = Math.max(0, currentProgressRatio - step);
-                    } else if (event.key === "Home") {
-                      event.preventDefault();
-                      nextRatio = 0;
-                    } else if (event.key === "End") {
-                      event.preventDefault();
-                      nextRatio = 1;
-                    } else {
-                      return;
-                    }
-                    handleProgressSeek(nextRatio);
-                  }}
-                >
-                  <div className={styles.progressBarTrack}>
-                    <div
-                      className={styles.progressBarFill}
-                      style={{ width: `${currentProgressRatio * 100}%` }}
+                  handleProgressSeek(nextRatio);
+                }}
+              >
+                <div className={styles.progressBarTrack}>
+                  <div
+                    className={styles.progressBarFill}
+                    style={{ width: `${currentProgressRatio * 100}%` }}
+                  />
+                  <div
+                    className={styles.progressBarThumb}
+                    style={{ left: `${currentProgressRatio * 100}%` }}
+                  />
+                  {chapterMarkers.map((marker) => (
+                    <button
+                      key={`${marker.id}-${marker.href}-${marker.ratio}`}
+                      type="button"
+                      className={styles.progressMarker}
+                      style={{ left: `${marker.ratio * 100}%` }}
+                      title={marker.label || marker.href}
+                      aria-label={t("epub_viewer.progress_marker.navigate", {
+                        label: marker.label || marker.href,
+                      })}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setPendingProgressRatio(marker.ratio);
+                        viewerRef.current?.goToCFI(marker.target);
+                        (event.currentTarget as HTMLButtonElement).blur();
+                      }}
+                      onMouseEnter={() => setHoveredMarker({ ratio: marker.ratio, label: marker.label })}
+                      onMouseLeave={() => setHoveredMarker(null)}
                     />
-                    <div
-                      className={styles.progressBarThumb}
-                      style={{ left: `${currentProgressRatio * 100}%` }}
-                    />
-                    {chapterMarkers.map((marker) => (
-                      <button
-                        key={`${marker.id}-${marker.href}-${marker.ratio}`}
-                        type="button"
-                        className={styles.progressMarker}
-                        style={{ left: `${marker.ratio * 100}%` }}
-                        title={marker.label || marker.href}
-                        aria-label={t("epub_viewer.progress_marker.navigate", {
-                          label: marker.label || marker.href,
-                        })}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setPendingProgressRatio(marker.ratio);
-                          viewerRef.current?.goToCFI(marker.target);
-                          (event.currentTarget as HTMLButtonElement).blur();
-                        }}
-                        onMouseEnter={() => setHoveredMarker({ ratio: marker.ratio, label: marker.label })}
-                        onMouseLeave={() => setHoveredMarker(null)}
-                      />
-                    ))}
-                  </div>
-                  {hoveredTooltipRatio !== null && hoveredPage !== null && (
-                    <div
-                      className={styles.progressTooltip}
-                      style={{ left: `${hoveredTooltipRatio * 100}%` }}
-                    >
-                      {hoveredChapterLabel && (
-                        <span className={styles.progressTooltipLabel}>{hoveredChapterLabel}</span>
-                      )}
-                      <span>{hoveredPage} P</span>
-                    </div>
-                  )}
+                  ))}
                 </div>
-              </div>
-              <div className={styles.pageInfo}>
-                {currentPage >= 0 && (
-                  <span className={styles.pageInfoClickable}>
-                    {chapterPageDisplay > 0 && chapterTotalDisplay > 0 ? (
-                      <>
-                        {chapterPageDisplay} / {chapterTotalDisplay} P
-                        {currentProgressPercent >= 0 && (
-                          <span style={{ fontSize: "0.85em", opacity: 0.8, marginLeft: "8px" }}>
-                            | {currentProgressPercent}%
-                          </span>
-                        )}
-                      </>
-                    ) : (
-                      <>{currentProgressPercent >= 0 ? `${currentProgressPercent}%` : ""}</>
-                    )}
-                  </span>
+                {hoveredTooltipRatio !== null && hoveredPage !== null && (
+                  <div
+                    className={styles.progressTooltip}
+                    style={{ left: `${hoveredTooltipRatio * 100}%` }}
+                  >
+                    {hoveredChapterLabel && <span className={styles.progressTooltipLabel}>{hoveredChapterLabel}</span>}
+                    <span>{hoveredPage} P</span>
+                  </div>
                 )}
               </div>
             </div>
-
-            <button
-              className={styles.navBtn}
-              onClick={handleNext}
-              disabled={isVisibleAtEnd && (!onReachedEndNext || !isEndNavigationReady)}
-              aria-label={t("epub_viewer.footer.next_page")}
-            >
-              <ChevronRight size={20} />
-            </button>
-            <button
-              className={styles.navBtn}
-              onClick={() => viewerRef.current?.goToProgress?.(1)}
-              disabled={isVisibleAtEnd}
-              aria-label={t("epub_viewer.footer.last_page")}
-            >
-              <ChevronsRight size={20} />
-            </button>
-
-            {/* 토글 버튼 (태블릿/데스크탑) */}
-            {settings.flow === "paginated" && (
-              <div className={styles.footerToggles}>
-                <button
-                  className={`${styles.toggleBtn} ${settings.spread === "auto" ? styles.active : ""}`}
-                  onClick={handleSpreadToggle}
-                >
-                  {settings.spread === "auto" ? t("epub_viewer.footer.pages_2") : t("epub_viewer.footer.pages_1")}
-                </button>
-              </div>
-            )}
-
-            {/* 시리즈 목록 */}
-            {seriesId && onOpenChapterList && (
-              <button
-                className={styles.navBtn}
-                onClick={onOpenChapterList}
-                title={t("viewer.footer.chapter_list")}
-                aria-label={t("viewer.footer.chapter_list")}
-              >
-                <LayoutGrid size={20} />
-              </button>
-            )}
+            <div className={styles.pageInfo}>
+              {currentPage >= 0 && (
+                <span className={styles.pageInfoClickable}>
+                  {chapterPageDisplay > 0 && chapterTotalDisplay > 0 ? (
+                    <>
+                      {chapterPageDisplay} / {chapterTotalDisplay} P
+                      {currentProgressPercent >= 0 && (
+                        <span style={{ fontSize: "0.85em", opacity: 0.8, marginLeft: "8px" }}>
+                          | {currentProgressPercent}%
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>{currentProgressPercent >= 0 ? `${currentProgressPercent}%` : ""}</>
+                  )}
+                </span>
+              )}
+            </div>
           </div>
+
+          <button
+            className={styles.navBtn}
+            onClick={handleNext}
+            disabled={isVisibleAtEnd && (!onReachedEndNext || !isEndNavigationReady)}
+            aria-label={t("epub_viewer.footer.next_page")}
+          >
+            <ChevronRight size={20} />
+          </button>
+          <button
+            className={styles.navBtn}
+            onClick={() => viewerRef.current?.goToProgress?.(1)}
+            disabled={isVisibleAtEnd}
+            aria-label={t("epub_viewer.footer.last_page")}
+          >
+            <ChevronsRight size={20} />
+          </button>
+
+          {/* 토글 버튼 (태블릿/데스크탑) */}
+          {settings.flow === "paginated" && (
+            <div className={styles.footerToggles}>
+              <button
+                className={`${styles.toggleBtn} ${settings.spread === "auto" ? styles.active : ""}`}
+                onClick={handleSpreadToggle}
+              >
+                {settings.spread === "auto" ? t("epub_viewer.footer.pages_2") : t("epub_viewer.footer.pages_1")}
+              </button>
+            </div>
+          )}
+
+          {/* 시리즈 목록 */}
+          {seriesId && onOpenChapterList && (
+            <button
+              className={styles.navBtn}
+              onClick={onOpenChapterList}
+              title={t("viewer.footer.chapter_list")}
+              aria-label={t("viewer.footer.chapter_list")}
+            >
+              <LayoutGrid size={20} />
+            </button>
+          )}
+        </div>
       </footer>
     </div>
   );

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -191,7 +191,7 @@ export function EpubViewer({
   const [pendingProgressRatio, setPendingProgressRatio] = useState<number | null>(null);
   const [chapterPageDisplay, setChapterPageDisplay] = useState(visiblePage);
   const [chapterTotalDisplay, setChapterTotalDisplay] = useState(visibleTotalPages);
-  const [scrolledPullState, setScrolledPullState] = useState({ pullOffset: 0, isTouching: false });
+  const [scrolledPullOffset, setScrolledPullOffset] = useState(0);
   const [spinePosition, setSpinePosition] = useState({
     spineIndex: 0,
     spineLength: 0,
@@ -915,7 +915,7 @@ export function EpubViewer({
           hideChapterPageInfo={hideChapterPageInfo}
           canScrolledPullPrev={canScrolledPullPrev}
           canScrolledPullNext={canScrolledPullNext}
-          onScrolledPullStateChange={setScrolledPullState}
+          onScrolledPullStateChange={(s) => setScrolledPullOffset(s.pullOffset)}
         />
       </main>
 
@@ -924,7 +924,7 @@ export function EpubViewer({
         <>
           <PullIndicator
             type="prev"
-            pullOffset={scrolledPullState.pullOffset}
+            pullOffset={scrolledPullOffset}
             pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
             chapterId={null}
             chapterTitle={prevPullTitle}
@@ -936,7 +936,7 @@ export function EpubViewer({
           />
           <PullIndicator
             type="next"
-            pullOffset={scrolledPullState.pullOffset}
+            pullOffset={scrolledPullOffset}
             pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
             chapterId={null}
             chapterTitle={nextPullTitle}

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -33,6 +33,7 @@ import {
   type EpubInitialOpenMode,
   type EpubRenderLayout,
 } from "../features/epub-viewer/components/EpubChapterViewer";
+import { EPUB_SCROLLED_PULL_THRESHOLD } from "../features/epub-viewer/components/EpubChapterViewer/constants";
 import type { EpubChapterViewerHandles } from "../features/epub-viewer/components/EpubChapterViewer";
 import { EpubSettingsPanel } from "../features/epub-viewer/components/EpubSettingsPanel";
 import { EpubTOC } from "../features/epub-viewer/components/EpubTOC";
@@ -119,7 +120,6 @@ const THEME_BG: Record<string, string> = {
   sepia: "#f4ecd8",
 };
 const CHAPTER_NAV_HINT_DURATION_MS = 3000;
-const EPUB_SCROLLED_PULL_THRESHOLD = 80;
 
 export function EpubViewer({
   chapterTitle,
@@ -370,14 +370,32 @@ export function EpubViewer({
   const hasInternalNextPart =
     (spinePosition.spineLength > 0 && spinePosition.spineIndex < spinePosition.spineLength - 1) ||
     spinePosition.atEnd === false;
-  const canScrolledPullPrev = hasInternalPrevPart || Boolean(onReachedStartPrev && prevChapterTitle);
-  const canScrolledPullNext = hasInternalNextPart || Boolean(onReachedEndNext && nextChapterTitle);
+  const canScrolledPullPrev = hasInternalPrevPart || Boolean(onReachedStartPrev);
+  const canScrolledPullNext = hasInternalNextPart || Boolean(onReachedEndNext);
   const prevPullTitle = hasInternalPrevPart
     ? t("epub_viewer.scroll_pull.prev_part", { defaultValue: "이전 part" })
     : (prevChapterTitle ?? null);
   const nextPullTitle = hasInternalNextPart
     ? t("epub_viewer.scroll_pull.next_part", { defaultValue: "다음 part" })
     : (nextChapterTitle ?? null);
+  const prevPullLabel = hasInternalPrevPart
+    ? t("epub_viewer.scroll_pull.prev_part_label", { defaultValue: "▲ 이전 part" })
+    : undefined;
+  const nextPullLabel = hasInternalNextPart
+    ? t("epub_viewer.scroll_pull.next_part_label", { defaultValue: "▼ 다음 part" })
+    : undefined;
+  const prevPullHint = hasInternalPrevPart
+    ? t("epub_viewer.scroll_pull.prev_part_hint", { defaultValue: "계속 위로 스크롤하면 이전 part로 이동" })
+    : undefined;
+  const nextPullHint = hasInternalNextPart
+    ? t("epub_viewer.scroll_pull.next_part_hint", { defaultValue: "계속 아래로 스크롤하면 다음 part로 이동" })
+    : undefined;
+  const prevPullAria = hasInternalPrevPart
+    ? t("epub_viewer.scroll_pull.aria_prev_part", { defaultValue: "이전 part로 이동" })
+    : undefined;
+  const nextPullAria = hasInternalNextPart
+    ? t("epub_viewer.scroll_pull.aria_next_part", { defaultValue: "다음 part로 이동" })
+    : undefined;
   const noopSaveProgress = useCallback(() => Promise.resolve(), []);
 
   const handlePrev = useCallback(() => {
@@ -912,6 +930,9 @@ export function EpubViewer({
             chapterTitle={prevPullTitle}
             saveProgress={noopSaveProgress}
             onActivate={canScrolledPullPrev ? handlePrev : undefined}
+            labelText={prevPullLabel}
+            hintText={prevPullHint}
+            ariaActionLabel={prevPullAria}
           />
           <PullIndicator
             type="next"
@@ -921,6 +942,9 @@ export function EpubViewer({
             chapterTitle={nextPullTitle}
             saveProgress={noopSaveProgress}
             onActivate={canScrolledPullNext ? handleNext : undefined}
+            labelText={nextPullLabel}
+            hintText={nextPullHint}
+            ariaActionLabel={nextPullAria}
           />
         </>
       )}

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -908,19 +908,19 @@ export function EpubViewer({
             type="prev"
             pullOffset={scrolledPullState.pullOffset}
             pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
-            chapterId={canScrolledPullPrev ? "epub-prev-part" : null}
+            chapterId={null}
             chapterTitle={prevPullTitle}
             saveProgress={noopSaveProgress}
-            onActivate={handlePrev}
+            onActivate={canScrolledPullPrev ? handlePrev : undefined}
           />
           <PullIndicator
             type="next"
             pullOffset={scrolledPullState.pullOffset}
             pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
-            chapterId={canScrolledPullNext ? "epub-next-part" : null}
+            chapterId={null}
             chapterTitle={nextPullTitle}
             saveProgress={noopSaveProgress}
-            onActivate={handleNext}
+            onActivate={canScrolledPullNext ? handleNext : undefined}
           />
         </>
       )}

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -37,6 +37,7 @@ import type { EpubChapterViewerHandles } from "../features/epub-viewer/component
 import { EpubSettingsPanel } from "../features/epub-viewer/components/EpubSettingsPanel";
 import { EpubTOC } from "../features/epub-viewer/components/EpubTOC";
 import { ChapterNavHint } from "../features/viewer/components/ChapterNavHint";
+import { PullIndicator } from "../features/viewer/components/PullIndicator";
 import styles from "./EpubViewer.module.css";
 
 interface EpubViewerProps {
@@ -118,6 +119,7 @@ const THEME_BG: Record<string, string> = {
   sepia: "#f4ecd8",
 };
 const CHAPTER_NAV_HINT_DURATION_MS = 3000;
+const EPUB_SCROLLED_PULL_THRESHOLD = 80;
 
 export function EpubViewer({
   chapterTitle,
@@ -189,6 +191,13 @@ export function EpubViewer({
   const [pendingProgressRatio, setPendingProgressRatio] = useState<number | null>(null);
   const [chapterPageDisplay, setChapterPageDisplay] = useState(visiblePage);
   const [chapterTotalDisplay, setChapterTotalDisplay] = useState(visibleTotalPages);
+  const [scrolledPullState, setScrolledPullState] = useState({ pullOffset: 0, isTouching: false });
+  const [spinePosition, setSpinePosition] = useState({
+    spineIndex: 0,
+    spineLength: 0,
+    atStart: true,
+    atEnd: false,
+  });
   const [nextHintTriggeredChapterId, setNextHintTriggeredChapterId] = useState<string | null>(null);
   const [prevHintTriggeredChapterId, setPrevHintTriggeredChapterId] = useState<string | null>(null);
   const hintTimeoutRef = useRef<number | null>(null);
@@ -289,6 +298,12 @@ export function EpubViewer({
       if (location.chapterTotal > 0) {
         setChapterTotalDisplay(location.chapterTotal);
       }
+      setSpinePosition({
+        spineIndex: location.spineIndex,
+        spineLength: location.spineLength,
+        atStart: location.atStart === true,
+        atEnd: location.atEnd === true,
+      });
       onLocationChange(location);
     },
     [onLocationChange],
@@ -351,6 +366,19 @@ export function EpubViewer({
 
   const isVisibleAtStart = chapterPageDisplay <= 1;
   const isVisibleAtEnd = chapterTotalDisplay > 0 && chapterPageDisplay >= chapterTotalDisplay;
+  const hasInternalPrevPart = spinePosition.spineIndex > 0 || !spinePosition.atStart;
+  const hasInternalNextPart =
+    (spinePosition.spineLength > 0 && spinePosition.spineIndex < spinePosition.spineLength - 1) ||
+    !spinePosition.atEnd;
+  const canScrolledPullPrev = hasInternalPrevPart || Boolean(onReachedStartPrev && prevChapterTitle);
+  const canScrolledPullNext = hasInternalNextPart || Boolean(onReachedEndNext && nextChapterTitle);
+  const prevPullTitle = hasInternalPrevPart
+    ? t("epub_viewer.scroll_pull.prev_part", { defaultValue: "이전 part" })
+    : (prevChapterTitle ?? null);
+  const nextPullTitle = hasInternalNextPart
+    ? t("epub_viewer.scroll_pull.next_part", { defaultValue: "다음 part" })
+    : (nextChapterTitle ?? null);
+  const noopSaveProgress = useCallback(() => Promise.resolve(), []);
 
   const handlePrev = useCallback(() => {
     const attemptPrev = async () => {
@@ -565,6 +593,7 @@ export function EpubViewer({
       const isEditable =
         tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable);
       if (isEditable) return;
+      if (settings.flow === "scrolled") return;
 
       const nextArrowKey = settings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";
       const prevArrowKey = settings.keyboardDirection === "right" ? "ArrowLeft" : "ArrowRight";
@@ -580,7 +609,7 @@ export function EpubViewer({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [settings.keyboardDirection, handleNext, handlePrev]);
+  }, [settings.flow, settings.keyboardDirection, handleNext, handlePrev]);
 
   // === 구형 iOS Safari: <main>에 터치 이벤트 핸들러 등록 ===
   // iframe pointer-events:none으로 터치가 관통하므로 부모에서 처리한다.
@@ -618,6 +647,11 @@ export function EpubViewer({
       lastTouchTimeRef.current = Date.now();
 
       if (dragging) {
+        if (settings.flow === "scrolled") {
+          startPos = null;
+          dragging = false;
+          return;
+        }
         // 스와이프 감지
         const touch = e.changedTouches[0];
         if (touch) {
@@ -647,6 +681,8 @@ export function EpubViewer({
 
       if (ratio >= 0.3 && ratio <= 0.7) {
         onViewerClick();
+      } else if (settings.flow === "scrolled") {
+        return;
       } else {
         const isRTL = settings.clickDirection === "left";
         if (ratio < 0.3) {
@@ -668,7 +704,7 @@ export function EpubViewer({
       mainEl.removeEventListener("touchmove", onTouchMove);
       mainEl.removeEventListener("touchend", onTouchEnd);
     };
-  }, [getZoneRatio, settings.clickDirection, handleNext, handlePrev, onViewerClick]);
+  }, [getZoneRatio, settings.clickDirection, settings.flow, handleNext, handlePrev, onViewerClick]);
 
   return (
     <div
@@ -858,8 +894,35 @@ export function EpubViewer({
           onPagePrev={handlePrev}
           onRenderLayoutChange={setEffectiveLayout}
           hideChapterPageInfo={hideChapterPageInfo}
+          canScrolledPullPrev={canScrolledPullPrev}
+          canScrolledPullNext={canScrolledPullNext}
+          onScrolledPullStateChange={setScrolledPullState}
         />
       </main>
+
+      {/* 세로 스크롤 모드 당김 인디케이터 */}
+      {settings.flow === "scrolled" && (
+        <>
+          <PullIndicator
+            type="prev"
+            pullOffset={scrolledPullState.pullOffset}
+            pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
+            chapterId={canScrolledPullPrev ? "epub-prev-part" : null}
+            chapterTitle={prevPullTitle}
+            saveProgress={noopSaveProgress}
+            onActivate={handlePrev}
+          />
+          <PullIndicator
+            type="next"
+            pullOffset={scrolledPullState.pullOffset}
+            pullThreshold={EPUB_SCROLLED_PULL_THRESHOLD}
+            chapterId={canScrolledPullNext ? "epub-next-part" : null}
+            chapterTitle={nextPullTitle}
+            saveProgress={noopSaveProgress}
+            onActivate={handleNext}
+          />
+        </>
+      )}
 
       {/* 챕터 이동 힌트 */}
       <ChapterNavHint

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -653,7 +653,6 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
       atEnd = false,
     ) => {
       if (isInitializingRef.current || effectiveIncognito) {
-        if (isInitializingRef.current) console.log("[EpubViewerRoute] saveProgress skipped: isInitializing is true");
         return;
       }
 
@@ -813,7 +812,6 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   );
 
   const handleInitializationComplete = useCallback(() => {
-    console.log("[EpubViewerRoute] Viewer reported initialization complete");
     if (initFallbackTimerRef.current) {
       window.clearTimeout(initFallbackTimerRef.current);
       initFallbackTimerRef.current = null;


### PR DESCRIPTION
## 변경 사항
- 스크롤 모드 중앙 클릭 UI 토글 회귀 방지 테스트 추가
- EPUB spine 위치의 atStart/atEnd 미확정 상태를 내부 part 이동 가능 상태로 오판하지 않도록 수정
- pull threshold 초과 후 touch/wheel 후속 입력이 중복 이동을 만들지 않도록 짧은 navigation lock 추가
- 사용되지 않는 scrolledPullStartYRef 제거

## 테스트
- [x] npm test -- --run src/features/epub-viewer/components/EpubChapterViewer/index.test.tsx src/features/epub-viewer/components/EpubViewer_UI.test.tsx
- [x] npm run lint
- [x] npm run build

## 관련 이슈
- 없음