### PR TITLE
feat: EPUB 페이지 모드 시리즈별 설정 추가

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -421,6 +421,7 @@ func Migrate() error {
 		reading_mode TEXT,
 		epub_render_mode TEXT,
 		epub_theme TEXT,
+		epub_flow TEXT,
 		epub_spread TEXT,
 		epub_wheel_direction TEXT,
 		epub_keyboard_direction TEXT,

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -623,6 +623,7 @@ func Migrate() error {
 		{39, "시리즈 등장인물 테이블 추가", migrateSeriesCharacters},
 		{40, "원제 오버라이드 라이브러리별 설정 이전", migrateOriginalTitleOverridePerLibrary},
 		{41, "시리즈 메타데이터 번역된 줄거리 컬럼 추가", migrateSeriesMetadataDescriptionTranslated},
+		{42, "EPUB 페이지 모드(flow) 시리즈별 설정 컬럼 추가", migrateEpubFlowSeriesSetting},
 	}
 
 	// 필요한 마이그레이션만 실행
@@ -1215,6 +1216,11 @@ func migrateOriginalTitleOverridePerLibrary() error {
 // #41 migrateSeriesMetadataDescriptionTranslated series_metadata 테이블에 번역된 줄거리 컬럼 추가
 func migrateSeriesMetadataDescriptionTranslated() error {
 	return addColumn("series_metadata", "description_translated", "TEXT DEFAULT ''")
+}
+
+// #42 migrateEpubFlowSeriesSetting user_series_settings 테이블에 epub_flow 컬럼 추가
+func migrateEpubFlowSeriesSetting() error {
+	return addColumn("user_series_settings", "epub_flow", "TEXT")
 }
 
 // #14 migrateChapterCompletions chapter_completions 테이블 추가

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -75,7 +75,7 @@ func Close() error {
 // 마이그레이션 버전 관리
 // ============================================================
 
-const latestMigrationVersion = 41
+const latestMigrationVersion = 42
 
 // getMigrationVersion server_settings에서 현재 마이그레이션 버전 조회
 func getMigrationVersion() int {

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -1701,6 +1701,9 @@ func (h *SeriesHandler) UpdateViewerSettings(c *fiber.Ctx) error {
 	if req.EpubTheme != nil && *req.EpubTheme != "" && !h.isValidSetting("viewer_epub_theme", *req.EpubTheme) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_theme"})
 	}
+	if req.EpubFlow != nil && *req.EpubFlow != "" && !h.isValidSetting("viewer_epub_flow", *req.EpubFlow) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_flow"})
+	}
 	if req.EpubSpread != nil && *req.EpubSpread != "" && !h.isValidSetting("viewer_epub_spread", *req.EpubSpread) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_spread"})
 	}
@@ -1855,6 +1858,8 @@ func (h *SeriesHandler) isValidSetting(key, value string) bool {
 		return value == "auto" || value == "book" || value == "comic"
 	case "viewer_epub_theme":
 		return value == "light" || value == "dark" || value == "sepia"
+	case "viewer_epub_flow":
+		return value == "paginated" || value == "scrolled"
 	case "viewer_epub_spread":
 		return value == "auto" || value == "none"
 	case "viewer_epub_wheel_direction":

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -265,6 +265,7 @@ type UserSeriesSetting struct {
 	ReadingMode           *string   `json:"reading_mode,omitempty"`
 	EpubRenderMode        *string   `json:"epub_render_mode,omitempty"`        // "auto" | "book" | "comic"
 	EpubTheme             *string   `json:"epub_theme,omitempty"`              // "light" | "dark" | "sepia"
+	EpubFlow              *string   `json:"epub_flow,omitempty"`               // "paginated" | "scrolled"
 	EpubSpread            *string   `json:"epub_spread,omitempty"`             // "auto" | "none"
 	EpubWheelDirection    *string   `json:"epub_wheel_direction,omitempty"`    // "down" | "up"
 	EpubKeyboardDirection *string   `json:"epub_keyboard_direction,omitempty"` // "right" | "left"

--- a/backend/internal/repository/user_series_setting_repository.go
+++ b/backend/internal/repository/user_series_setting_repository.go
@@ -24,13 +24,13 @@ func (r *userSeriesSettingRepository) Get(q database.Queryer, userID, seriesID s
 	q = database.GetQueryer(q)
 	s := &model.UserSeriesSetting{}
 	query := `
-		SELECT user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
+		SELECT user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_flow, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
 		       reading_direction, wheel_direction, swipe_direction, click_direction, keyboard_direction, fit_mode, background_color, updated_at
-		FROM user_series_settings 
+		FROM user_series_settings
 		WHERE user_id = ? AND series_id = ?
 	`
 	err := q.QueryRow(query, userID, seriesID).Scan(
-		&s.UserID, &s.SeriesID, &s.ReadingMode, &s.EpubRenderMode, &s.EpubTheme, &s.EpubSpread, &s.EpubWheelDirection, &s.EpubKeyboardDirection, &s.EpubClickDirection,
+		&s.UserID, &s.SeriesID, &s.ReadingMode, &s.EpubRenderMode, &s.EpubTheme, &s.EpubFlow, &s.EpubSpread, &s.EpubWheelDirection, &s.EpubKeyboardDirection, &s.EpubClickDirection,
 		&s.ReadingDirection, &s.WheelDirection, &s.SwipeDirection, &s.ClickDirection,
 		&s.KeyboardDirection, &s.FitMode, &s.BackgroundColor, &s.UpdatedAt,
 	)
@@ -47,14 +47,15 @@ func (r *userSeriesSettingRepository) Upsert(q database.Queryer, s *model.UserSe
 	q = database.GetQueryer(q)
 	query := `
 		INSERT INTO user_series_settings (
-			user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
+			user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_flow, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
 			reading_direction, wheel_direction, swipe_direction, click_direction, keyboard_direction, fit_mode, background_color, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id, series_id) DO UPDATE SET
 			reading_mode = COALESCE(excluded.reading_mode, user_series_settings.reading_mode),
 			epub_render_mode = COALESCE(excluded.epub_render_mode, user_series_settings.epub_render_mode),
 			epub_theme = COALESCE(excluded.epub_theme, user_series_settings.epub_theme),
+			epub_flow = COALESCE(excluded.epub_flow, user_series_settings.epub_flow),
 			epub_spread = COALESCE(excluded.epub_spread, user_series_settings.epub_spread),
 			epub_wheel_direction = COALESCE(excluded.epub_wheel_direction, user_series_settings.epub_wheel_direction),
 			epub_keyboard_direction = COALESCE(excluded.epub_keyboard_direction, user_series_settings.epub_keyboard_direction),
@@ -69,7 +70,7 @@ func (r *userSeriesSettingRepository) Upsert(q database.Queryer, s *model.UserSe
 			updated_at = excluded.updated_at
 	`
 	_, err := q.Exec(query,
-		s.UserID, s.SeriesID, s.ReadingMode, s.EpubRenderMode, s.EpubTheme, s.EpubSpread, s.EpubWheelDirection, s.EpubKeyboardDirection, s.EpubClickDirection,
+		s.UserID, s.SeriesID, s.ReadingMode, s.EpubRenderMode, s.EpubTheme, s.EpubFlow, s.EpubSpread, s.EpubWheelDirection, s.EpubKeyboardDirection, s.EpubClickDirection,
 		s.ReadingDirection, s.WheelDirection, s.SwipeDirection, s.ClickDirection,
 		s.KeyboardDirection, s.FitMode, s.BackgroundColor, time.Now(),
 	)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -276,8 +276,9 @@ export const seriesAPI = {
   getExtensionsBatch: (seriesIds: string[]) =>
     api.post<{ extensions: Record<string, string> }>("/series/extensions/batch", { series_ids: seriesIds }),
   // 뷰어 설정
-  getViewerSettings: (seriesId: string) => api.get(`/series/${seriesId}/viewer-settings`).then((res) => res.data),
-  updateViewerSettings: (seriesId: string, data: Record<string, unknown>) =>
+  getViewerSettings: (seriesId: string) =>
+    api.get<Partial<UserSeriesSetting>>(`/series/${seriesId}/viewer-settings`).then((res) => res.data),
+  updateViewerSettings: (seriesId: string, data: Partial<UserSeriesSetting>) =>
     api.patch(`/series/${seriesId}/viewer-settings`, data).then((res) => res.data),
   metadataSearch: (seriesId: string, data?: MetadataSearchRequest) =>
     api.post<MetadataSearchResult>(`/series/${seriesId}/metadata/search`, data ?? {}).then((res) => res.data),

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -10,9 +10,16 @@ const mockSetGlobalProgress = vi.fn();
 const mockSetIsAtLastPage = vi.fn();
 const mockSetIncognito = vi.fn();
 const mockReset = vi.fn();
+const mockSetFlow = vi.fn();
 const epubProgressUpdateMock = vi.fn();
 const useViewerSyncMock = vi.fn();
 const useAdjacentChaptersMock = vi.fn();
+const libraryGetMock = vi.fn();
+const seriesGetMock = vi.fn();
+const seriesGetViewerSettingsMock = vi.fn();
+const seriesUpdateViewerSettingsMock = vi.fn();
+const settingListMock = vi.fn();
+const settingUpdateMock = vi.fn();
 let latestViewerProps: {
   onInitializationComplete: () => void;
   initialProgressRatio?: number | null;
@@ -34,6 +41,7 @@ let latestViewerProps: {
   onReady: (total: number) => void;
   onBack?: () => void;
   onReachedStartPrev?: () => void;
+  onFlowChange: (flow: "paginated" | "scrolled") => void;
 } | null = null;
 
 vi.mock("react-i18next", () => ({
@@ -83,7 +91,7 @@ vi.mock("../stores/epubViewerStore", () => ({
     setLineHeight: vi.fn(),
     setTheme: vi.fn(),
     setRenderMode: vi.fn(),
-    setFlow: vi.fn(),
+    setFlow: mockSetFlow,
     setSpread: vi.fn(),
     setWheelDirection: vi.fn(),
     setKeyboardDirection: vi.fn(),
@@ -118,6 +126,7 @@ vi.mock("./EpubViewer", () => ({
     onReady,
     onBack,
     onReachedStartPrev,
+    onFlowChange,
   }: {
     onInitializationComplete: () => void;
     initialProgressRatio?: number | null;
@@ -139,6 +148,7 @@ vi.mock("./EpubViewer", () => ({
     onReady: (total: number) => void;
     onBack?: () => void;
     onReachedStartPrev?: () => void;
+    onFlowChange: (flow: "paginated" | "scrolled") => void;
   }) => {
     latestViewerProps = {
       onInitializationComplete,
@@ -149,6 +159,7 @@ vi.mock("./EpubViewer", () => ({
       onReady,
       onBack,
       onReachedStartPrev,
+      onFlowChange,
     };
     return (
       <div>
@@ -198,15 +209,16 @@ vi.mock("../api/client", () => ({
     update: (...args: unknown[]) => epubProgressUpdateMock(...args),
   },
   libraryAPI: {
-    get: vi.fn(),
+    get: (...args: unknown[]) => libraryGetMock(...args),
   },
   seriesAPI: {
-    get: vi.fn(),
-    getViewerSettings: vi.fn().mockResolvedValue({}),
+    get: (...args: unknown[]) => seriesGetMock(...args),
+    getViewerSettings: (...args: unknown[]) => seriesGetViewerSettingsMock(...args),
+    updateViewerSettings: (...args: unknown[]) => seriesUpdateViewerSettingsMock(...args),
   },
   settingAPI: {
-    list: vi.fn().mockResolvedValue({}),
-    update: vi.fn(),
+    list: (...args: unknown[]) => settingListMock(...args),
+    update: (...args: unknown[]) => settingUpdateMock(...args),
   },
 }));
 
@@ -242,10 +254,23 @@ describe("EpubViewerRoute", () => {
     mockSetIsAtLastPage.mockReset();
     mockSetIncognito.mockReset();
     mockReset.mockReset();
+    mockSetFlow.mockReset();
     epubProgressUpdateMock.mockReset();
     useViewerSyncMock.mockReset();
     useAdjacentChaptersMock.mockReset();
+    libraryGetMock.mockReset();
+    seriesGetMock.mockReset();
+    seriesGetViewerSettingsMock.mockReset();
+    seriesUpdateViewerSettingsMock.mockReset();
+    settingListMock.mockReset();
+    settingUpdateMock.mockReset();
     latestViewerProps = null;
+    libraryGetMock.mockResolvedValue({ data: {} });
+    seriesGetMock.mockResolvedValue({ data: {} });
+    seriesGetViewerSettingsMock.mockResolvedValue({});
+    seriesUpdateViewerSettingsMock.mockResolvedValue({});
+    settingListMock.mockResolvedValue({});
+    settingUpdateMock.mockResolvedValue({});
     useViewerSyncMock.mockReturnValue({
       terminatedInfo: {
         isOpen: false,
@@ -365,6 +390,92 @@ describe("EpubViewerRoute", () => {
       expect(viewerContainer).toHaveStyle({ pointerEvents: "auto" });
       expect(setViewStatus).toHaveBeenCalledWith("ready");
     });
+  });
+
+  it("시리즈별 epub_flow 설정이 전역 설정보다 우선 적용된다", async () => {
+    settingListMock.mockResolvedValueOnce({ epub_flow: "paginated" });
+    seriesGetViewerSettingsMock.mockResolvedValueOnce({ epub_flow: "scrolled" });
+
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "series-1",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(seriesGetViewerSettingsMock).toHaveBeenCalledWith("series-1");
+      expect(mockSetFlow).toHaveBeenCalledWith("scrolled");
+    });
+  });
+
+  it("시리즈가 있는 EPUB flow 변경은 전역 설정이 아니라 시리즈별 설정으로 저장한다", async () => {
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "series-1",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(latestViewerProps).not.toBeNull();
+    });
+
+    act(() => {
+      latestViewerProps?.onFlowChange("scrolled");
+    });
+
+    expect(mockSetFlow).toHaveBeenCalledWith("scrolled");
+    expect(seriesUpdateViewerSettingsMock).toHaveBeenCalledWith("series-1", { epub_flow: "scrolled" });
+    expect(settingUpdateMock).not.toHaveBeenCalledWith("epub_flow", { value: "scrolled" });
   });
 
   it("저장된 current_cfi가 있으면 progress_percent가 100이어도 ratio 복원을 사용하지 않는다", async () => {

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -433,8 +433,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
           setTheme(effectiveTheme);
         }
 
-        if (flow === "paginated" || flow === "scrolled") {
-          setFlow(flow);
+        const effectiveFlow =
+          (seriesSettings?.epub_flow as string | undefined) || flow || "paginated";
+        if (effectiveFlow === "paginated" || effectiveFlow === "scrolled") {
+          setFlow(effectiveFlow);
         }
 
         const effectiveSpread =
@@ -899,11 +901,17 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   const handleFlowChange = useCallback(
     (flow: EpubFlow) => {
       setFlow(flow);
-      void settingAPI.update("epub_flow", { value: flow }).catch((error) => {
-        console.warn("[EpubViewerRoute] Failed to save global epub_flow:", error);
+      if (!seriesId) {
+        void settingAPI.update("epub_flow", { value: flow }).catch((error) => {
+          console.warn("[EpubViewerRoute] Failed to save global epub_flow:", error);
+        });
+        return;
+      }
+      void seriesAPI.updateViewerSettings(seriesId, { epub_flow: flow }).catch((error) => {
+        console.warn("[EpubViewerRoute] Failed to save series epub_flow:", error);
       });
     },
-    [setFlow],
+    [seriesId, setFlow],
   );
 
   const handleWheelDirectionChange = useCallback(

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -14,6 +14,7 @@ import type { UseChapterLoaderReturn } from "../features/viewer/hooks/useChapter
 import { EpubViewer } from "./EpubViewer";
 import { api, epubProgressAPI, libraryAPI, seriesAPI, settingAPI } from "../api/client";
 import type { EpubTOCItem } from "../features/epub-viewer/components/EpubChapterViewer";
+import type { UserSeriesSetting } from "../types/series";
 import { AlertModal } from "../components/modals/AlertModal";
 import { LoadingSpinner } from "../components/common/LoadingSpinner";
 import {
@@ -382,7 +383,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
           default_epub_keyboard_direction?: string;
           default_epub_click_direction?: string;
         } = {};
-        let seriesSettings: Record<string, unknown> = {};
+        let seriesSettings: Partial<UserSeriesSetting> = {};
 
         if (Number.isFinite(fontSize) && fontSize >= 50 && fontSize <= 150) {
           setFontSize(fontSize);
@@ -419,7 +420,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveRenderMode =
-          (seriesSettings?.epub_render_mode as string | undefined) ||
+          seriesSettings.epub_render_mode ||
           libraryDefaults.default_epub_render_mode ||
           globalRenderMode ||
           "auto";
@@ -428,19 +429,19 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveTheme =
-          (seriesSettings?.epub_theme as string | undefined) || libraryDefaults.default_epub_theme || theme || "light";
+          seriesSettings.epub_theme || libraryDefaults.default_epub_theme || theme || "light";
         if (effectiveTheme === "light" || effectiveTheme === "dark" || effectiveTheme === "sepia") {
           setTheme(effectiveTheme);
         }
 
         const effectiveFlow =
-          (seriesSettings?.epub_flow as string | undefined) || flow || "paginated";
+          seriesSettings.epub_flow || flow || "paginated";
         if (effectiveFlow === "paginated" || effectiveFlow === "scrolled") {
           setFlow(effectiveFlow);
         }
 
         const effectiveSpread =
-          (seriesSettings?.epub_spread as string | undefined) ||
+          seriesSettings.epub_spread ||
           libraryDefaults.default_epub_spread ||
           spread ||
           "auto";
@@ -449,7 +450,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveWheelDirection =
-          (seriesSettings?.epub_wheel_direction as string | undefined) ||
+          seriesSettings.epub_wheel_direction ||
           libraryDefaults.default_epub_wheel_direction ||
           wheelDirection ||
           "down";
@@ -458,7 +459,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveKeyboardDirection =
-          (seriesSettings?.epub_keyboard_direction as string | undefined) ||
+          seriesSettings.epub_keyboard_direction ||
           libraryDefaults.default_epub_keyboard_direction ||
           keyboardDirection ||
           "right";
@@ -467,7 +468,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveClickDirection =
-          (seriesSettings?.epub_click_direction as string | undefined) ||
+          seriesSettings.epub_click_direction ||
           libraryDefaults.default_epub_click_direction ||
           clickDirection ||
           (globalClickDirection === "ltr" ? "right" : globalClickDirection === "rtl" ? "left" : "right");

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -168,6 +168,7 @@ export interface UserSeriesSetting {
   reading_mode?: string;
   epub_render_mode?: string;
   epub_theme?: string;
+  epub_flow?: "paginated" | "scrolled";
   epub_spread?: string;
   epub_wheel_direction?: string;
   epub_keyboard_direction?: string;


### PR DESCRIPTION
## 변경 사항
- EPUB flow 설정을 시리즈별 뷰어 설정에 저장하도록 추가
- user_series_settings에 epub_flow 컬럼 마이그레이션 추가
- 기본 user_series_settings schema와 프론트 UserSeriesSetting 타입에 epub_flow 반영
- EpubViewerRoute에서 시리즈별 epub_flow가 전역 설정보다 우선되도록 정리
- getViewerSettings/updateViewerSettings API 타입을 UserSeriesSetting 기반으로 명확화
- 시리즈별 epub_flow 로드/저장 회귀 테스트 추가

## 테스트
- [x] npm test -- EpubViewerRoute --run
- [x] npm run lint
- [x] npm run build
- [x] go test ./...

## 관련 이슈
Closes #297