### PR TITLE
fix: 라이브러리 시리즈 카드 권화 표시 수정

### DIFF
--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -71,6 +71,9 @@ vi.mock("react-i18next", () => ({
       if (key === "home.library.series_index_jump") {
         return `jump ${String(options?.key ?? "")}`;
       }
+      if (key === "series.unit.total_volume" || key === "series.unit.total_chapter") {
+        return `${key} ${String(options?.count ?? "")}`;
+      }
       return key;
     },
   }),
@@ -118,9 +121,10 @@ vi.mock("../components/Sidebar", () => ({
 }));
 
 vi.mock("../components/SeriesCard", () => ({
-  SeriesCard: ({ item }: { item: Series }) => (
+  SeriesCard: ({ item, customSubtitle }: { item: Series; customSubtitle?: string }) => (
     <article data-testid="series-card">
       {item.title}
+      {customSubtitle && <span data-testid={`series-subtitle-${item.id}`}>{customSubtitle}</span>}
     </article>
   ),
 }));
@@ -139,6 +143,7 @@ const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
   "scrollIntoView",
 );
 const originalScrollToDescriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "scrollTo");
+const originalElementScrollToDescriptor = Object.getOwnPropertyDescriptor(window.Element.prototype, "scrollTo");
 
 const createRect = (overrides: Partial<DOMRect> = {}): DOMRect => ({
   x: overrides.x ?? 0,
@@ -227,6 +232,12 @@ describe("LibraryPage series index", () => {
     });
     Object.defineProperty(window.HTMLElement.prototype, "scrollTo", {
       configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window.Element.prototype, "scrollTo", {
+      configurable: true,
+      writable: true,
       value: vi.fn(),
     });
 
@@ -270,6 +281,11 @@ describe("LibraryPage series index", () => {
       Object.defineProperty(window.HTMLElement.prototype, "scrollTo", originalScrollToDescriptor);
     } else {
       Reflect.deleteProperty(window.HTMLElement.prototype, "scrollTo");
+    }
+    if (originalElementScrollToDescriptor) {
+      Object.defineProperty(window.Element.prototype, "scrollTo", originalElementScrollToDescriptor);
+    } else {
+      Reflect.deleteProperty(window.Element.prototype, "scrollTo");
     }
   });
 
@@ -332,5 +348,30 @@ describe("LibraryPage series index", () => {
     await waitFor(() => {
       expect(nav.querySelector('[aria-hidden="true"]')).toHaveClass(styles.seriesIndexScrollbarVisible);
     });
+  });
+
+  it("중첩 경로가 있어도 시리즈 카드에는 권/화 수를 우선 표시한다", async () => {
+    mocks.libraryGetSeriesMock.mockResolvedValueOnce({
+      data: {
+        series: [
+          {
+            id: "nested-series",
+            library_id: "library-1",
+            title: "가면라이더",
+            path: "/library/1.단편/[ ㄱ ]/가면라이더",
+            display_unit: "volume",
+            volume_count: 3,
+            chapter_count: 12,
+            created_at: "2026-04-10T00:00:00Z",
+            updated_at: "2026-04-10T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    renderLibraryPage();
+
+    expect(await screen.findByTestId("series-subtitle-nested-series")).toHaveTextContent("series.unit.total_volume 3");
+    expect(screen.getByTestId("series-subtitle-nested-series")).not.toHaveTextContent("1.단편 / [ ㄱ ]");
   });
 });

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -326,6 +326,39 @@ describe("LibraryPage series index", () => {
     });
   });
 
+  it("scrollTo를 지원하지 않으면 scrollTop으로 활성 목차 위치를 맞춘다", async () => {
+    renderLibraryPage();
+
+    const targetButton = await screen.findByRole("button", { name: "jump C" });
+    const nav = screen.getByRole("navigation", { name: "series index" });
+    const scrollArea = nav.firstElementChild as HTMLElement;
+
+    setElementScrollMetrics(scrollArea, { clientHeight: 100, scrollHeight: 300 });
+    Object.defineProperty(scrollArea, "getBoundingClientRect", {
+      configurable: true,
+      value: vi.fn(() => createRect({ top: 100, bottom: 200, height: 100 })),
+    });
+    Object.defineProperty(targetButton, "getBoundingClientRect", {
+      configurable: true,
+      value: vi.fn(() => createRect({ top: 180, bottom: 200, height: 20 })),
+    });
+    Object.defineProperty(scrollArea, "scrollTo", {
+      configurable: true,
+      value: undefined,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "jump A" })).toHaveAttribute("aria-current", "location");
+    });
+    scrollArea.scrollTop = 0;
+
+    fireEvent.click(targetButton);
+
+    await waitFor(() => {
+      expect(scrollArea.scrollTop).toBe(40);
+    });
+  });
+
   it("목차 스크롤바는 사용자 조작에서만 표시된다", async () => {
     renderLibraryPage();
 

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -352,10 +352,15 @@ export function LibraryPage() {
       activeButtonRect.top - scrollAreaRect.top + scrollArea.scrollTop + activeButtonRect.height / 2;
     const targetScrollTop =
       buttonCenterInScrollArea - scrollArea.clientHeight / 2;
-    scrollArea.scrollTo({
-      top: Math.max(0, targetScrollTop),
-      behavior: "auto",
-    });
+    const nextScrollTop = Math.max(0, targetScrollTop);
+    if (typeof scrollArea.scrollTo === "function") {
+      scrollArea.scrollTo({
+        top: nextScrollTop,
+        behavior: "auto",
+      });
+    } else {
+      scrollArea.scrollTop = nextScrollTop;
+    }
     if (syncingIndexScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(syncingIndexScrollFrameRef.current);
     }
@@ -656,7 +661,9 @@ export function LibraryPage() {
                     {group.items.map((series, index) => {
                       const displayContext = getSeriesDisplayContext(series.path, library.paths);
                       const countLabel = getLibrarySeriesCountLabelKey(series);
-                      const customSubtitle = displayContext || (countLabel ? t(countLabel.key, { count: countLabel.count }) : undefined);
+                      const customSubtitle = countLabel
+                        ? t(countLabel.key, { count: countLabel.count })
+                        : displayContext || undefined;
                       return (
                         <div
                           key={series.id}


### PR DESCRIPTION
## 변경 사항
- 라이브러리 시리즈 카드 subtitle에서 권/화 수가 있으면 중첩 경로보다 우선 표시
- 권/화 수가 없는 경우 기존 경로 fallback 유지
- 목차 인덱스 자동 스크롤에서 scrollTo 미지원 환경은 scrollTop fallback 처리
- 중첩 경로가 있어도 권/화 수와 count 값이 표시되는 회귀 테스트 추가

## 테스트
- [x] cd web && npm run build
- [x] cd web && npm run lint -- --max-warnings=0
- [x] cd web && npm test -- --run src/pages/Library.test.tsx

## 관련 이슈
Closes #292