### PR TITLE
feat: 계속 읽기 시리즈 위치 이동 추가

### DIFF
--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -192,4 +192,33 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     expect(screen.getByText("series.unit.volume")).toBeInTheDocument();
     expect(screen.queryByText("series.unit.chapter_count")).toBeNull();
   });
+
+  it("navigateTo가 있으면 카드 클릭 시 기본 볼륨 경로 대신 지정 경로로 이동한다", () => {
+    render(
+      <SeriesCard
+        type="volume"
+        item={{
+          id: "volume-3",
+          series_id: "series-3",
+          title: "볼륨 3",
+          volume_number: 3,
+          path: "/books/volume-3.zip",
+          library_type: "book",
+          chapter_count: 5,
+          created_at: "2026-03-21T00:00:00Z",
+        }}
+        navigateTo="/series/series-3"
+        navigateState={{ scrollToVolumeId: "volume-3" }}
+      />,
+    );
+
+    const card = screen.getByText("볼륨 3").closest('[role="button"]');
+    expect(card).not.toBeNull();
+
+    fireEvent.click(card!);
+
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/series/series-3", {
+      state: { scrollToVolumeId: "volume-3" },
+    });
+  });
 });

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, useMemo } from "react";
+import { forwardRef, useState, useRef, useEffect, useLayoutEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
@@ -36,9 +36,11 @@ export interface SeriesCardProps {
   showExtensionBadge?: boolean;
   extensionBadgeText?: string | null;
   extensionBadgePlacement?: "thumbnail" | "meta";
+  navigateTo?: string;
+  navigateState?: unknown;
 }
 
-export function SeriesCard({
+export const SeriesCard = forwardRef<HTMLDivElement, SeriesCardProps>(function SeriesCard({
   item,
   type = "series",
   customSubtitle,
@@ -52,7 +54,9 @@ export function SeriesCard({
   showExtensionBadge,
   extensionBadgeText = null,
   extensionBadgePlacement = "thumbnail",
-}: SeriesCardProps) {
+  navigateTo,
+  navigateState,
+}, ref) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -147,6 +151,15 @@ export function SeriesCard({
 
   const handleCardClick = (e: React.MouseEvent) => {
     if (e.defaultPrevented || window.getSelection()?.toString()) return;
+
+    if (navigateTo) {
+      if (navigateState !== undefined) {
+        navigate(navigateTo, { state: navigateState });
+      } else {
+        navigate(navigateTo);
+      }
+      return;
+    }
 
     if (type === "volume") {
       navigate(`/volumes/${item.id}`);
@@ -451,6 +464,7 @@ export function SeriesCard({
 
   return (
     <div
+      ref={ref}
       onClick={handleCardClick}
       className={`${styles.seriesCard} ${isUpdating ? styles.updating : ""}`}
       role="button"
@@ -700,4 +714,4 @@ export function SeriesCard({
       />
     </div>
   );
-}
+});

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -85,7 +85,23 @@ vi.mock("../components/common/HorizontalDragScroll", () => ({
 }));
 
 vi.mock("../components/SeriesCard", () => ({
-  SeriesCard: ({ item }: { item: { title?: string } }) => <div>{item.title}</div>,
+  SeriesCard: ({
+    item,
+    navigateTo,
+    navigateState,
+  }: {
+    item: { id?: string; title?: string };
+    navigateTo?: string;
+    navigateState?: { scrollToVolumeId?: string };
+  }) => (
+    <div
+      data-testid={item.id ? `series-card-${item.id}` : "series-card"}
+      data-navigate-to={navigateTo}
+      data-scroll-volume-id={navigateState?.scrollToVolumeId}
+    >
+      {item.title}
+    </div>
+  ),
 }));
 
 describe("HomePage", () => {
@@ -127,5 +143,33 @@ describe("HomePage", () => {
       expect(screen.getByText("새 시리즈")).toBeInTheDocument();
     });
     expect(screen.queryByText("home.sections.updated.empty")).not.toBeInTheDocument();
+  });
+
+  it("계속 읽기 볼륨 카드는 시리즈 페이지와 해당 볼륨 앵커로 이동하도록 렌더링한다", async () => {
+    mocks.getRecentMock.mockResolvedValueOnce({
+      data: {
+        recent_progress: [
+          {
+            id: "progress-1",
+            series_id: "series-9",
+            series_title: "긴 시리즈",
+            volume_id: "volume-9",
+            volume_title: "9권",
+            volume_number: 9,
+            volume_unit: "volume",
+            current_page: 1,
+            total_pages: 100,
+            progress_percent: 12,
+            updated_at: "2026-04-22T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    render(<HomePage />);
+
+    const card = await screen.findByTestId("series-card-volume-9");
+    expect(card).toHaveAttribute("data-navigate-to", "/series/series-9");
+    expect(card).toHaveAttribute("data-scroll-volume-id", "volume-9");
   });
 });

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -319,6 +319,12 @@ export function HomePage() {
                 progress={progress.progress_percent}
                 chapterId={progress.chapter_id}
                 volumeId={progress.volume_id}
+                navigateTo={`/series/${progress.series_id}`}
+                navigateState={
+                  progress.volume_id
+                    ? { scrollToVolumeId: progress.volume_id }
+                    : undefined
+                }
                 onStatusChange={loadData}
                 showExtensionBadge
                 extensionBadgeText={recentProgressExtensionMap[progress.id]}

--- a/web/src/pages/Series.test.tsx
+++ b/web/src/pages/Series.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type { ReactNode } from "react";
@@ -8,12 +8,14 @@ const { mocks } = vi.hoisted(() => {
   const navigateMock = vi.fn();
   const apiGetMock = vi.fn();
   const bootstrapAndPlayMock = vi.fn();
+  const routeState = { value: undefined as unknown };
 
   return {
     mocks: {
       navigateMock,
       apiGetMock,
       bootstrapAndPlayMock,
+      routeState,
     },
   };
 });
@@ -35,7 +37,7 @@ vi.mock("react-router-dom", async () => {
   return {
     ...actual,
     useNavigate: () => mocks.navigateMock,
-    useLocation: () => ({ pathname: "/series/series-1", search: "" }),
+    useLocation: () => ({ pathname: "/series/series-1", search: "", state: mocks.routeState.value }),
   };
 });
 
@@ -84,9 +86,19 @@ vi.mock("../components/Sidebar", () => ({
   Sidebar: () => null,
 }));
 
-vi.mock("../components/SeriesCard", () => ({
-  SeriesCard: () => <div data-testid="series-card" />,
-}));
+vi.mock("../components/SeriesCard", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    SeriesCard: React.forwardRef<HTMLDivElement, { item: { title?: string } }>(({ item }, ref) => (
+      <div
+        ref={ref}
+        data-testid="series-card"
+      >
+        {item.title}
+      </div>
+    )),
+  };
+});
 
 vi.mock("../components/SeriesInfoCard", () => ({
   SeriesInfoCard: ({ onPlay }: { onPlay: () => void | Promise<void> }) => (
@@ -108,9 +120,27 @@ vi.mock("../components/common/LoadingSpinner", () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner" />,
 }));
 
+const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "scrollIntoView");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.routeState.value = undefined;
+  Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  if (originalScrollIntoViewDescriptor) {
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
+  } else {
+    Reflect.deleteProperty(window.HTMLElement.prototype, "scrollIntoView");
+  }
+});
+
 describe("SeriesPage audiobook bootstrap guard", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     mocks.bootstrapAndPlayMock.mockResolvedValue({ ok: true });
   });
 
@@ -229,10 +259,6 @@ describe("SeriesPage audiobook bootstrap guard", () => {
 });
 
 describe("SeriesPage count label", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   const renderPage = () =>
     render(
       <MemoryRouter initialEntries={["/series/series-1"]}>
@@ -284,5 +310,72 @@ describe("SeriesPage count label", () => {
 
     expect(await screen.findByText("series.chapter_count 12")).toBeInTheDocument();
     expect(screen.queryByText("series.count")).toBeNull();
+  });
+
+  it("라우트 state에 scrollToVolumeId가 있으면 해당 볼륨 카드로 스크롤한다", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    mocks.routeState.value = { scrollToVolumeId: "volume-2" };
+    mocks.apiGetMock.mockImplementation((url: string) => {
+      if (url === "/series/series-1") {
+        return Promise.resolve({
+          data: {
+            id: "series-1",
+            library_id: "library-1",
+            title: "긴 시리즈",
+            path: "/books/series",
+            library_type: "book",
+            created_at: "2026-03-21T00:00:00Z",
+            updated_at: "2026-03-21T00:00:00Z",
+          },
+        });
+      }
+      if (url === "/series/series-1/volumes?parent_id=root") {
+        return Promise.resolve({
+          data: {
+            volumes: [
+              {
+                id: "volume-1",
+                series_id: "series-1",
+                title: "1권",
+                volume_number: 1,
+                path: "/books/series/1.zip",
+                created_at: "2026-03-21T00:00:00Z",
+              },
+              {
+                id: "volume-2",
+                series_id: "series-1",
+                title: "2권",
+                volume_number: 2,
+                path: "/books/series/2.zip",
+                created_at: "2026-03-21T00:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      if (url === "/series/series-1/progress") {
+        return Promise.resolve({ data: { progress: null, summary: null } });
+      }
+      if (url === "/libraries/library-1") {
+        return Promise.resolve({
+          data: {
+            id: "library-1",
+            name: "서재",
+          },
+        });
+      }
+      throw new Error(`Unhandled api.get(${url})`);
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("2권")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "center", behavior: "auto" });
+    });
   });
 });

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -25,6 +25,8 @@ export function SeriesPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const viewerFrom = `${location.pathname}${location.search}`;
+  const routeState = location.state as { scrollToVolumeId?: unknown } | null;
+  const scrollToVolumeId = typeof routeState?.scrollToVolumeId === "string" ? routeState.scrollToVolumeId : null;
   const [series, setSeries] = useState<Series | null>(null);
   const [characters, setCharacters] = useState<SeriesCharacter[]>([]);
 
@@ -54,6 +56,8 @@ export function SeriesPage() {
   const [progress, setProgress] = useState<ReadingProgress | undefined>(undefined);
   const [summary, setSummary] = useState<SeriesProgressSummary | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
+  const volumeCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const scrolledVolumeIdRef = useRef<string | null>(null);
 
   // 사이드바 상태
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -180,6 +184,21 @@ export function SeriesPage() {
   useEffect(() => {
     if (id) loadData();
   }, [id, loadData]);
+
+  useEffect(() => {
+    if (!scrollToVolumeId || isLoading || volumes.length === 0) return;
+    if (scrolledVolumeIdRef.current === scrollToVolumeId) return;
+
+    const target = volumeCardRefs.current[scrollToVolumeId];
+    if (!target) return;
+
+    scrolledVolumeIdRef.current = scrollToVolumeId;
+    const frameId = window.requestAnimationFrame(() => {
+      target.scrollIntoView({ block: "center", behavior: "auto" });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [isLoading, scrollToVolumeId, volumes]);
 
   // 시리즈 데이터가 변경될 때마다 오디오 플레이어 스토어 동기화
   useEffect(() => {
@@ -494,6 +513,9 @@ export function SeriesPage() {
                 {volumes.map((volume) => (
                   <SeriesCard
                     key={volume.id}
+                    ref={(node) => {
+                      volumeCardRefs.current[volume.id] = node;
+                    }}
                     item={volume}
                     type="volume"
                     progressStyle="overlay"


### PR DESCRIPTION
## 변경 사항
- 계속 읽기 카드 본체 클릭 시 볼륨 페이지 대신 시리즈 페이지로 이동
- 계속 읽기 카드가 마지막 읽은 볼륨 ID를 route state로 전달
- 시리즈 페이지는 전달받은 볼륨 ID가 있으면 볼륨 목록 로드 후 해당 카드 위치로 스크롤
- SeriesCard에 카드 본체 이동 경로를 지정할 수 있는 navigateTo, navigateState 옵션 추가

## 테스트
- [x] cd web && npm test -- --run src/components/SeriesCard.test.tsx src/pages/Home.test.tsx src/pages/Series.test.tsx
- [x] cd web && npm run lint -- --max-warnings=0
- [x] cd web && npm run build

## 관련 이슈
- 없음