### PR TITLE
fix: 홈 계속 읽기 카드 클릭 시 시리즈 페이지로 이동

### DIFF
--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -192,4 +192,28 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     expect(screen.getByText("series.unit.volume")).toBeInTheDocument();
     expect(screen.queryByText("series.unit.chapter_count")).toBeNull();
   });
+
+  it("navigateTo가 있으면 카드 클릭 시 기본 볼륨 경로 대신 지정 경로로 이동한다", () => {
+    render(
+      <SeriesCard
+        type="volume"
+        item={{
+          id: "volume-3",
+          series_id: "series-3",
+          title: "볼륨 3",
+          volume_number: 3,
+          path: "/books/volume-3.zip",
+          library_type: "book",
+          chapter_count: 5,
+          created_at: "2026-03-21T00:00:00Z",
+        }}
+        navigateTo="/series/series-3"
+      />,
+    );
+
+    const card = screen.getByText("볼륨 3").closest('[role="button"]');
+    fireEvent.click(card!);
+
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/series/series-3");
+  });
 });

--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -196,6 +196,10 @@ describe("SeriesCard audiobook bootstrap guard", () => {
 });
 
 describe("SeriesCard navigateTo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("navigateTo가 있으면 카드 클릭 시 기본 볼륨 경로 대신 지정 경로로 이동한다", () => {
     render(
       <SeriesCard

--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -193,6 +193,9 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     expect(screen.queryByText("series.unit.chapter_count")).toBeNull();
   });
 
+});
+
+describe("SeriesCard navigateTo", () => {
   it("navigateTo가 있으면 카드 클릭 시 기본 볼륨 경로 대신 지정 경로로 이동한다", () => {
     render(
       <SeriesCard

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -36,6 +36,7 @@ export interface SeriesCardProps {
   showExtensionBadge?: boolean;
   extensionBadgeText?: string | null;
   extensionBadgePlacement?: "thumbnail" | "meta";
+  navigateTo?: string;
 }
 
 export function SeriesCard({
@@ -52,6 +53,7 @@ export function SeriesCard({
   showExtensionBadge,
   extensionBadgeText = null,
   extensionBadgePlacement = "thumbnail",
+  navigateTo,
 }: SeriesCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -147,6 +149,11 @@ export function SeriesCard({
 
   const handleCardClick = (e: React.MouseEvent) => {
     if (e.defaultPrevented || window.getSelection()?.toString()) return;
+
+    if (navigateTo) {
+      navigate(navigateTo);
+      return;
+    }
 
     if (type === "volume") {
       navigate(`/volumes/${item.id}`);

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -319,7 +319,7 @@ export function HomePage() {
                 progress={progress.progress_percent}
                 chapterId={progress.chapter_id}
                 volumeId={progress.volume_id}
-                navigateTo={progress.series_id ? `/series/${progress.series_id}` : undefined}
+                navigateTo={`/series/${progress.series_id}`}
                 onStatusChange={loadData}
                 showExtensionBadge
                 extensionBadgeText={recentProgressExtensionMap[progress.id]}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -319,6 +319,7 @@ export function HomePage() {
                 progress={progress.progress_percent}
                 chapterId={progress.chapter_id}
                 volumeId={progress.volume_id}
+                navigateTo={progress.series_id ? `/series/${progress.series_id}` : undefined}
                 onStatusChange={loadData}
                 showExtensionBadge
                 extensionBadgeText={recentProgressExtensionMap[progress.id]}


### PR DESCRIPTION
## 변경 사항
- 홈 계속 읽기 섹션에서 볼륨 카드 클릭 시 볼륨 페이지 대신 시리즈 페이지로 이동하도록 변경
- SeriesCard에 `navigateTo` prop 추가하여 카드 클릭 시 이동 경로를 지정할 수 있도록 함

## 테스트
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`