### PR TITLE
fix: 메타데이터 변경 시 업데이트된 시리즈 섹션에서 제외 (#289)

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1227,7 +1227,7 @@ func migrateEpubFlowSeriesSetting() error {
 }
 
 func migrateSeriesLastContentUpdatedAt() error {
-	if err := addColumn("series", "last_content_updated_at", "DATETIME"); err != nil {
+	if err := addColumn("series", "last_content_updated_at", "DATETIME DEFAULT CURRENT_TIMESTAMP"); err != nil {
 		return err
 	}
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1235,7 +1235,7 @@ func migrateSeriesLastContentUpdatedAt() error {
 	if columnExists("series", "updated_at") {
 		initExpr = "updated_at"
 	}
-	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s WHERE last_content_updated_at IS NULL`, initExpr)); err != nil {
+	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s`, initExpr)); err != nil {
 		return fmt.Errorf("initialize last_content_updated_at: %w", err)
 	}
 	return nil

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -75,7 +75,7 @@ func Close() error {
 // 마이그레이션 버전 관리
 // ============================================================
 
-const latestMigrationVersion = 42
+const latestMigrationVersion = 43
 
 // getMigrationVersion server_settings에서 현재 마이그레이션 버전 조회
 func getMigrationVersion() int {
@@ -281,7 +281,8 @@ func Migrate() error {
 		thumbnail_path TEXT,
 		extension TEXT DEFAULT '',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		last_content_updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
 
 	-- 시리즈 메타데이터 (부가 정보)
@@ -625,6 +626,7 @@ func Migrate() error {
 		{40, "원제 오버라이드 라이브러리별 설정 이전", migrateOriginalTitleOverridePerLibrary},
 		{41, "시리즈 메타데이터 번역된 줄거리 컬럼 추가", migrateSeriesMetadataDescriptionTranslated},
 		{42, "EPUB 페이지 모드(flow) 시리즈별 설정 컬럼 추가", migrateEpubFlowSeriesSetting},
+		{43, "시리즈 콘텐츠 업데이트 시간 컬럼 추가", migrateSeriesLastContentUpdatedAt},
 	}
 
 	// 필요한 마이그레이션만 실행
@@ -1222,6 +1224,21 @@ func migrateSeriesMetadataDescriptionTranslated() error {
 // #42 migrateEpubFlowSeriesSetting user_series_settings 테이블에 epub_flow 컬럼 추가
 func migrateEpubFlowSeriesSetting() error {
 	return addColumn("user_series_settings", "epub_flow", "TEXT")
+}
+
+func migrateSeriesLastContentUpdatedAt() error {
+	if err := addColumn("series", "last_content_updated_at", "DATETIME"); err != nil {
+		return err
+	}
+
+	initExpr := "CURRENT_TIMESTAMP"
+	if columnExists("series", "updated_at") {
+		initExpr = "updated_at"
+	}
+	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s WHERE last_content_updated_at IS NULL`, initExpr)); err != nil {
+		return fmt.Errorf("initialize last_content_updated_at: %w", err)
+	}
+	return nil
 }
 
 // #14 migrateChapterCompletions chapter_completions 테이블 추가

--- a/backend/internal/handler/image_handler.go
+++ b/backend/internal/handler/image_handler.go
@@ -768,7 +768,7 @@ func (h *ImageHandler) GetThumbnail(c *fiber.Ctx) error {
 
 				if err := util.ExtractPdfThumbnail(volume.Path, newThumbPath); err == nil {
 					volume.ThumbnailPath = &newThumbPath
-					if uErr := h.volumeRepo.Update(nil, volume); uErr != nil {
+					if uErr := h.volumeRepo.UpdatePreservingContentUpdatedAt(nil, volume); uErr != nil {
 						log.Printf("[IMAGE_HANDLER] Failed to update volume thumbnail path in DB: %v", uErr)
 					}
 					customThumbnailPath = newThumbPath

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aha-hyeong/kumiho/backend/internal/repository"
 	"github.com/aha-hyeong/kumiho/backend/internal/service"
 	"github.com/aha-hyeong/kumiho/backend/internal/sse"
+	"github.com/aha-hyeong/kumiho/backend/internal/util"
 )
 
 type ProgressHandler struct {
@@ -1077,7 +1078,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 					}
 
 					if volume.ThumbnailPath != nil && *volume.ThumbnailPath != "" {
-						url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, volume.UpdatedAt.Unix())
+						url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, volume.UpdatedAt)
 						result[i].ThumbnailURL = &url
 					} else {
 						pageID, err := h.volumeRepo.GetFirstPageID(nil, volume.ID)

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -901,7 +901,7 @@ func (h *SeriesHandler) UploadThumbnail(c *fiber.Ctx) error {
 	}
 
 	// 썸네일 URL 업데이트 (응답용)
-	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+	url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 	series.ThumbnailURL = &url
 
 	return c.JSON(series)
@@ -1033,7 +1033,7 @@ func (h *SeriesHandler) DownloadThumbnail(c *fiber.Ctx) error {
 	}
 
 	// 썸네일 URL 업데이트 (응답용)
-	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+	url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 	series.ThumbnailURL = &url
 
 	return c.JSON(series)

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -492,7 +492,7 @@ func (h *SeriesHandler) UpdateVolume(c *fiber.Ctx) error {
 	}
 
 	// DB 업데이트
-	if err := h.volumeRepo.Update(nil, volume); err != nil {
+	if err := h.volumeRepo.UpdatePreservingContentUpdatedAt(nil, volume); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume",
 		})
@@ -613,7 +613,7 @@ func (h *SeriesHandler) UploadVolumeThumbnail(c *fiber.Ctx) error {
 
 	// DB 업데이트
 	volume.ThumbnailPath = &path
-	if err := h.volumeRepo.Update(nil, volume); err != nil {
+	if err := h.volumeRepo.UpdatePreservingContentUpdatedAt(nil, volume); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume thumbnail path",
 		})
@@ -737,7 +737,7 @@ func (h *SeriesHandler) UploadVolumeThumbnailFromURL(c *fiber.Ctx) error {
 	}
 
 	volume.ThumbnailPath = &path
-	if err := h.volumeRepo.Update(nil, volume); err != nil {
+	if err := h.volumeRepo.UpdatePreservingContentUpdatedAt(nil, volume); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume thumbnail path",
 		})
@@ -784,7 +784,7 @@ func (h *SeriesHandler) DeleteVolumeThumbnail(c *fiber.Ctx) error {
 	volume.ThumbnailPath = nil
 	volume.ThumbnailURL = nil
 
-	if upErr := h.volumeRepo.Update(nil, volume); upErr != nil {
+	if upErr := h.volumeRepo.UpdatePreservingContentUpdatedAt(nil, volume); upErr != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume",
 		})

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -65,6 +65,7 @@ type Series struct {
 	IsBookmarked  bool      `json:"is_bookmarked" db:"is_bookmarked"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
+	LastContentUpdatedAt time.Time `json:"last_content_updated_at"`
 	Extension     string    `json:"extension" db:"extension"` // 시리즈 대표 확장자
 	LibraryType   string    `json:"library_type" db:"-"`      // "book", "audiobook" (JOIN으로 채움)
 

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -34,11 +34,7 @@ func (r *ChapterRepository) Create(db database.Queryer, chapter *model.Chapter) 
 	if err != nil {
 		return err
 	}
-	var seriesID string
-	if err := db.QueryRow(`SELECT series_id FROM volumes WHERE id = ?`, chapter.VolumeID).Scan(&seriesID); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, chapter.UpdatedAt, seriesID); err != nil {
+	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = (SELECT series_id FROM volumes WHERE id = ?)`, chapter.UpdatedAt, chapter.VolumeID); err != nil {
 		return err
 	}
 	return nil

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -35,8 +35,11 @@ func (r *ChapterRepository) Create(db database.Queryer, chapter *model.Chapter) 
 		return err
 	}
 	var seriesID string
-	if rowErr := db.QueryRow(`SELECT series_id FROM volumes WHERE id = ?`, chapter.VolumeID).Scan(&seriesID); rowErr == nil {
-		_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, now, seriesID)
+	if err := db.QueryRow(`SELECT series_id FROM volumes WHERE id = ?`, chapter.VolumeID).Scan(&seriesID); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, chapter.UpdatedAt, seriesID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -31,7 +31,14 @@ func (r *ChapterRepository) Create(db database.Queryer, chapter *model.Chapter) 
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		chapter.ID, chapter.VolumeID, chapter.Title, chapter.ChapterNumber, chapter.Path, chapter.PageCount, chapter.TotalBytes, chapter.TotalPositions, chapter.HasAudio, chapter.Duration, chapter.CreatedAt, chapter.UpdatedAt,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	var seriesID string
+	if rowErr := db.QueryRow(`SELECT series_id FROM volumes WHERE id = ?`, chapter.VolumeID).Scan(&seriesID); rowErr == nil {
+		_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, now, seriesID)
+	}
+	return nil
 }
 
 // FindByVolumeID 볼륨 ID로 챕터 목록 조회

--- a/backend/internal/repository/series_repository.go
+++ b/backend/internal/repository/series_repository.go
@@ -311,6 +311,11 @@ func (r *SeriesRepository) FindByID(db database.Queryer, id string, userID strin
 		s.Extension = ext.String
 	}
 	s.LibraryType = normalizeLibraryType(libraryType)
+	if lastContentUpdatedAt.Valid {
+		s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+	} else {
+		s.LastContentUpdatedAt = s.UpdatedAt
+	}
 
 	m.SeriesID = s.ID
 	if desc.Valid {
@@ -398,6 +403,11 @@ func (r *SeriesRepository) FindByPath(db database.Queryer, path string, userID s
 		s.Extension = ext.String
 	}
 	s.LibraryType = normalizeLibraryType(libraryType)
+	if lastContentUpdatedAt.Valid {
+		s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+	} else {
+		s.LastContentUpdatedAt = s.UpdatedAt
+	}
 
 	m.SeriesID = s.ID
 	if desc.Valid {
@@ -918,11 +928,12 @@ func (r *SeriesRepository) Search(db database.Queryer, query string, userID stri
 		var s model.Series
 		var m model.SeriesMetadata
 		var thumbnail, ext sql.NullString
+		var lastContentUpdatedAt sql.NullTime
 		var desc, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
 		var isBookmarked sql.NullBool
 
 		err := rows.Scan(
-			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt,
+			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
 			&desc, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
 		)
 		if err != nil {
@@ -934,6 +945,11 @@ func (r *SeriesRepository) Search(db database.Queryer, query string, userID stri
 		}
 		if ext.Valid {
 			s.Extension = ext.String
+		}
+		if lastContentUpdatedAt.Valid {
+			s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+		} else {
+			s.LastContentUpdatedAt = s.UpdatedAt
 		}
 
 		m.SeriesID = s.ID

--- a/backend/internal/repository/series_repository.go
+++ b/backend/internal/repository/series_repository.go
@@ -42,13 +42,16 @@ func (r *SeriesRepository) Create(db database.Queryer, series *model.Series) err
 	if series.UpdatedAt.IsZero() {
 		series.UpdatedAt = now
 	}
+	if series.LastContentUpdatedAt.IsZero() {
+		series.LastContentUpdatedAt = series.UpdatedAt
+	}
 
 	// 1. series 테이블 저장
 	_, err := db.Exec(
-		`INSERT INTO series (id, library_id, title, path, thumbnail_path, extension, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO series (id, library_id, title, path, thumbnail_path, extension, created_at, updated_at, last_content_updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		series.ID, series.LibraryID, series.Title, series.Path, series.ThumbnailPath, series.Extension,
-		series.CreatedAt, series.UpdatedAt,
+		series.CreatedAt, series.UpdatedAt, series.LastContentUpdatedAt,
 	)
 	if err != nil {
 		return err
@@ -74,7 +77,7 @@ func (r *SeriesRepository) Create(db database.Queryer, series *model.Series) err
 func (r *SeriesRepository) FindByLibraryID(db database.Queryer, libraryID string, userID string) ([]model.Series, error) {
 	db = database.GetQueryer(db)
 	rows, err := db.Query(
-		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at,
+		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
 		        sm.description, sm.description_translated, (ub.series_id IS NOT NULL) AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
 				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn,
 				l.library_type
@@ -95,12 +98,13 @@ func (r *SeriesRepository) FindByLibraryID(db database.Queryer, libraryID string
 		var s model.Series
 		var m model.SeriesMetadata
 		var thumbnail, ext sql.NullString
+		var lastContentUpdatedAt sql.NullTime
 		var desc, descTranslated, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
 		var isBookmarked sql.NullBool
 		var libraryType sql.NullString
 
 		err := rows.Scan(
-			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt,
+			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
 			&desc, &descTranslated, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
 			&libraryType,
 		)
@@ -115,6 +119,11 @@ func (r *SeriesRepository) FindByLibraryID(db database.Queryer, libraryID string
 			s.Extension = ext.String
 		}
 		s.LibraryType = normalizeLibraryType(libraryType)
+		if lastContentUpdatedAt.Valid {
+			s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+		} else {
+			s.LastContentUpdatedAt = s.UpdatedAt
+		}
 
 		m.SeriesID = s.ID
 		if desc.Valid {
@@ -166,7 +175,7 @@ func (r *SeriesRepository) FindByLibraryID(db database.Queryer, libraryID string
 func (r *SeriesRepository) FindBookmarked(db database.Queryer, userID string) ([]model.Series, error) {
 	db = database.GetQueryer(db)
 	rows, err := db.Query(
-		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at,
+		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
 		        sm.description, sm.description_translated, 1 AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
 				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn,
 				l.library_type
@@ -187,12 +196,13 @@ func (r *SeriesRepository) FindBookmarked(db database.Queryer, userID string) ([
 		var s model.Series
 		var m model.SeriesMetadata
 		var thumbnail, ext sql.NullString
+		var lastContentUpdatedAt sql.NullTime
 		var desc, descTranslated, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
 		var isBookmarked sql.NullBool
 		var libraryType sql.NullString
 
 		err := rows.Scan(
-			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt,
+			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
 			&desc, &descTranslated, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
 			&libraryType,
 		)
@@ -207,6 +217,11 @@ func (r *SeriesRepository) FindBookmarked(db database.Queryer, userID string) ([
 			s.Extension = ext.String
 		}
 		s.LibraryType = normalizeLibraryType(libraryType)
+		if lastContentUpdatedAt.Valid {
+			s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+		} else {
+			s.LastContentUpdatedAt = s.UpdatedAt
+		}
 
 		m.SeriesID = s.ID
 		if desc.Valid {
@@ -262,10 +277,11 @@ func (r *SeriesRepository) FindByID(db database.Queryer, id string, userID strin
 	var thumbnail, ext sql.NullString
 	var desc, descTranslated, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
 	var isBookmarked sql.NullBool
+	var lastContentUpdatedAt sql.NullTime
 
 	var libraryType sql.NullString
 	err := db.QueryRow(
-		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at,
+		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
 		        sm.description, sm.description_translated, (ub.series_id IS NOT NULL) AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
 				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn,
 				l.library_type
@@ -276,7 +292,7 @@ func (r *SeriesRepository) FindByID(db database.Queryer, id string, userID strin
 		 WHERE s.id = ?`,
 		userID, id,
 	).Scan(
-		&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt,
+		&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
 		&desc, &descTranslated, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
 		&libraryType,
 	)
@@ -348,10 +364,11 @@ func (r *SeriesRepository) FindByPath(db database.Queryer, path string, userID s
 	var thumbnail, ext sql.NullString
 	var desc, descTranslated, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
 	var isBookmarked sql.NullBool
+	var lastContentUpdatedAt sql.NullTime
 	var libraryType sql.NullString
 
 	err := db.QueryRow(
-		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at,
+		`SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
 		        sm.description, sm.description_translated, (ub.series_id IS NOT NULL) AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
 				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn,
 				l.library_type
@@ -362,7 +379,7 @@ func (r *SeriesRepository) FindByPath(db database.Queryer, path string, userID s
 		 WHERE s.path = ?`,
 		userID, path,
 	).Scan(
-		&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt,
+		&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
 		&desc, &descTranslated, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
 		&libraryType,
 	)
@@ -856,7 +873,7 @@ func (r *SeriesRepository) Search(db database.Queryer, query string, userID stri
 	searchPattern := "%" + sb.String() + "%"
 
 	// SQLite에서 공백, 하이픈, 언더바를 모두 제거하고 비교 (중첩 REPLACE)
-	sqlStr := `SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at,
+	sqlStr := `SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
 		        sm.description, (ub.series_id IS NOT NULL) AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
 				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn
 		 FROM series s

--- a/backend/internal/repository/series_repository_test.go
+++ b/backend/internal/repository/series_repository_test.go
@@ -50,6 +50,47 @@ func TestSeriesRepositoryUpdatePreservingUpdatedAtKeepsDatabaseTimestamp(t *test
 	}
 }
 
+func TestVolumeCreateUsesDetectionTimeForLastContentUpdatedAt(t *testing.T) {
+	connectSeriesRepositoryTestDB(t)
+
+	seriesRepo := NewSeriesRepository()
+	series := seedSeriesRepositoryTestSeries(t, seriesRepo)
+
+	oldContentTime := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+	if err := seriesRepo.UpdateUpdatedAt(nil, series.ID, oldContentTime); err != nil {
+		t.Fatalf("UpdateUpdatedAt() error = %v", err)
+	}
+
+	volumeRepo := NewVolumeRepository()
+	oldFileTime := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	volume := &model.Volume{
+		SeriesID:     series.ID,
+		Title:        "Volume 1",
+		VolumeNumber: 1,
+		Path:         "/tmp/volume-1.cbz",
+		CreatedAt:    oldFileTime,
+		UpdatedAt:    oldFileTime,
+	}
+	beforeCreate := time.Now().Add(-1 * time.Minute)
+	if err := volumeRepo.Create(nil, volume); err != nil {
+		t.Fatalf("VolumeRepository.Create() error = %v", err)
+	}
+
+	refreshed, err := seriesRepo.FindByID(nil, series.ID, "")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if refreshed == nil {
+		t.Fatal("refreshed series = nil")
+	}
+	if refreshed.LastContentUpdatedAt.Before(beforeCreate) {
+		t.Fatalf("LastContentUpdatedAt = %v, expected detection time after %v", refreshed.LastContentUpdatedAt, beforeCreate)
+	}
+	if refreshed.LastContentUpdatedAt.Equal(oldFileTime) {
+		t.Fatalf("LastContentUpdatedAt should not reuse old file time %v", oldFileTime)
+	}
+}
+
 func TestProgressAggregationUsesFixedPageTotalForNormalText(t *testing.T) {
 	connectSeriesRepositoryTestDB(t)
 	seedProgressAggregationFixture(t, "txt-normal", "txt-volume-normal", "txt-chapter-normal", 100, 100000, 25, 100, 99, "")

--- a/backend/internal/repository/series_repository_test.go
+++ b/backend/internal/repository/series_repository_test.go
@@ -91,6 +91,57 @@ func TestVolumeCreateUsesDetectionTimeForLastContentUpdatedAt(t *testing.T) {
 	}
 }
 
+func TestChapterCreateUpdatesSeriesLastContentUpdatedAt(t *testing.T) {
+	connectSeriesRepositoryTestDB(t)
+
+	seriesRepo := NewSeriesRepository()
+	series := seedSeriesRepositoryTestSeries(t, seriesRepo)
+	volumeRepo := NewVolumeRepository()
+	volume := &model.Volume{
+		SeriesID:     series.ID,
+		Title:        "Volume 1",
+		VolumeNumber: 1,
+		Path:         "/tmp/chapter-volume.cbz",
+	}
+	if err := volumeRepo.Create(nil, volume); err != nil {
+		t.Fatalf("VolumeRepository.Create() error = %v", err)
+	}
+
+	oldContentTime := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+	if _, err := database.DB.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, oldContentTime, series.ID); err != nil {
+		t.Fatalf("set old last_content_updated_at error = %v", err)
+	}
+
+	chapterRepo := NewChapterRepository()
+	beforeCreate := time.Now().Add(-1 * time.Minute)
+	chapter := &model.Chapter{
+		VolumeID:       volume.ID,
+		Title:          "Chapter 1",
+		ChapterNumber:  1,
+		Path:           "/tmp/chapter-1.cbz",
+		PageCount:      10,
+		TotalBytes:     100,
+		TotalPositions: 10,
+	}
+	if err := chapterRepo.Create(nil, chapter); err != nil {
+		t.Fatalf("ChapterRepository.Create() error = %v", err)
+	}
+
+	refreshed, err := seriesRepo.FindByID(nil, series.ID, "")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if refreshed == nil {
+		t.Fatal("refreshed series = nil")
+	}
+	if refreshed.LastContentUpdatedAt.Before(beforeCreate) {
+		t.Fatalf("LastContentUpdatedAt = %v, expected chapter create time after %v", refreshed.LastContentUpdatedAt, beforeCreate)
+	}
+	if refreshed.LastContentUpdatedAt.Equal(oldContentTime) {
+		t.Fatalf("LastContentUpdatedAt should not remain old value %v", oldContentTime)
+	}
+}
+
 func TestProgressAggregationUsesFixedPageTotalForNormalText(t *testing.T) {
 	connectSeriesRepositoryTestDB(t)
 	seedProgressAggregationFixture(t, "txt-normal", "txt-volume-normal", "txt-chapter-normal", 100, 100000, 25, 100, 99, "")

--- a/backend/internal/repository/series_repository_test.go
+++ b/backend/internal/repository/series_repository_test.go
@@ -57,8 +57,8 @@ func TestVolumeCreateUsesDetectionTimeForLastContentUpdatedAt(t *testing.T) {
 	series := seedSeriesRepositoryTestSeries(t, seriesRepo)
 
 	oldContentTime := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
-	if err := seriesRepo.UpdateUpdatedAt(nil, series.ID, oldContentTime); err != nil {
-		t.Fatalf("UpdateUpdatedAt() error = %v", err)
+	if _, err := database.DB.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, oldContentTime, series.ID); err != nil {
+		t.Fatalf("set old last_content_updated_at error = %v", err)
 	}
 
 	volumeRepo := NewVolumeRepository()

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -47,11 +47,21 @@ func (r *VolumeRepository) Create(db database.Queryer, volume *model.Volume) err
 	return nil
 }
 
-// Update 볼륨 정보 수정
+// Update 볼륨 정보 수정 (콘텐츠 변경으로 간주)
 func (r *VolumeRepository) Update(db database.Queryer, volume *model.Volume) error {
 	db = database.GetQueryer(db)
 	volume.UpdatedAt = time.Now()
+	return r.update(db, volume, true)
+}
 
+// UpdatePreservingContentUpdatedAt 볼륨 메타데이터만 수정하고 시리즈 콘텐츠 갱신 시간은 보존
+func (r *VolumeRepository) UpdatePreservingContentUpdatedAt(db database.Queryer, volume *model.Volume) error {
+	db = database.GetQueryer(db)
+	volume.UpdatedAt = time.Now()
+	return r.update(db, volume, false)
+}
+
+func (r *VolumeRepository) update(db database.Queryer, volume *model.Volume, updateContentTimestamp bool) error {
 	_, err := db.Exec(
 		`UPDATE volumes 
 		 SET title = ?, volume_number = ?, path = ?, thumbnail_path = ?, has_audio = ?, unit = ?, chapter_count = ?, parent_id = ?, description = ?, authors = ?, publication_year = ?, extension = ?, updated_at = ?
@@ -60,6 +70,9 @@ func (r *VolumeRepository) Update(db database.Queryer, volume *model.Volume) err
 	)
 	if err != nil {
 		return err
+	}
+	if !updateContentTimestamp {
+		return nil
 	}
 	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID); err != nil {
 		return err

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -54,11 +54,16 @@ func (r *VolumeRepository) Update(db database.Queryer, volume *model.Volume) err
 	return r.update(db, volume, true)
 }
 
-// UpdatePreservingContentUpdatedAt 볼륨 메타데이터만 수정하고 시리즈 콘텐츠 갱신 시간은 보존
+// UpdatePreservingContentUpdatedAt 볼륨 메타데이터만 수정하고 시리즈 콘텐츠 갱신 시간과 볼륨 updated_at을 보존
 func (r *VolumeRepository) UpdatePreservingContentUpdatedAt(db database.Queryer, volume *model.Volume) error {
 	db = database.GetQueryer(db)
-	volume.UpdatedAt = time.Now()
-	return r.update(db, volume, false)
+	_, err := db.Exec(
+		`UPDATE volumes 
+		 SET title = ?, volume_number = ?, path = ?, thumbnail_path = ?, has_audio = ?, unit = ?, chapter_count = ?, parent_id = ?, description = ?, authors = ?, publication_year = ?, extension = ?
+		 WHERE id = ?`,
+		volume.Title, volume.VolumeNumber, volume.Path, volume.ThumbnailPath, volume.HasAudio, volume.Unit, volume.ChapterCount, volume.ParentID, volume.Description, volume.Authors, volume.PublicationYear, volume.Extension, volume.ID,
+	)
+	return err
 }
 
 func (r *VolumeRepository) update(db database.Queryer, volume *model.Volume, updateContentTimestamp bool) error {

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -41,7 +41,9 @@ func (r *VolumeRepository) Create(db database.Queryer, volume *model.Volume) err
 	if err != nil {
 		return err
 	}
-	_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, now, volume.SeriesID)
+	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -59,7 +61,9 @@ func (r *VolumeRepository) Update(db database.Queryer, volume *model.Volume) err
 	if err != nil {
 		return err
 	}
-	_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID)
+	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -38,7 +38,11 @@ func (r *VolumeRepository) Create(db database.Queryer, volume *model.Volume) err
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		volume.ID, volume.SeriesID, volume.Title, volume.VolumeNumber, volume.Path, volume.ThumbnailPath, volume.HasAudio, volume.Unit, volume.ChapterCount, volume.ParentID, volume.Description, volume.Authors, volume.PublicationYear, volume.Extension, volume.CreatedAt, volume.UpdatedAt,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, now, volume.SeriesID)
+	return nil
 }
 
 // Update 볼륨 정보 수정
@@ -52,7 +56,11 @@ func (r *VolumeRepository) Update(db database.Queryer, volume *model.Volume) err
 		 WHERE id = ?`,
 		volume.Title, volume.VolumeNumber, volume.Path, volume.ThumbnailPath, volume.HasAudio, volume.Unit, volume.ChapterCount, volume.ParentID, volume.Description, volume.Authors, volume.PublicationYear, volume.Extension, volume.UpdatedAt, volume.ID,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	_, _ = db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID)
+	return nil
 }
 
 // UpdateHasAudio has_audio 플래그만 업데이트

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -41,7 +41,7 @@ func (r *VolumeRepository) Create(db database.Queryer, volume *model.Volume) err
 	if err != nil {
 		return err
 	}
-	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, volume.UpdatedAt, volume.SeriesID); err != nil {
+	if _, err := db.Exec(`UPDATE series SET last_content_updated_at = ? WHERE id = ?`, now, volume.SeriesID); err != nil {
 		return err
 	}
 	return nil

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -3403,7 +3403,7 @@ func (s *Scanner) ensureVolumePdfThumbnailIfMissing(
 	volume.ThumbnailPath = &newThumbPath
 	url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, time.Now().Unix())
 	volume.ThumbnailURL = &url
-	if uErr := s.volumeRepo.Update(tx, volume); uErr != nil {
+	if uErr := s.volumeRepo.UpdatePreservingContentUpdatedAt(tx, volume); uErr != nil {
 		log.Printf("[SCANNER] Failed to update volume thumbnail: %v", uErr)
 		return
 	}

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -1497,7 +1497,7 @@ func (s *Scanner) processArchiveAsSeries(
 
 		// ThumbnailURL은 고유한 ID(Create 호출 시 생성됨)가 필요함
 		if series.ThumbnailPath != nil && *series.ThumbnailPath != "" {
-			url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+			url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 			series.ThumbnailURL = &url
 		}
 	}
@@ -1661,7 +1661,7 @@ func (s *Scanner) processSeries(
 
 		// ThumbnailURL은 고유한 ID(Create 호출 시 생성됨)가 필요함
 		if series.ThumbnailPath != nil && *series.ThumbnailPath != "" {
-			url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+			url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 			series.ThumbnailURL = &url
 		}
 	}
@@ -3037,18 +3037,18 @@ func (s *Scanner) saveVolumeRecursive(tx database.Queryer, seriesID string, pare
 
 	if foundThumbnailPath != "" {
 		volume.ThumbnailPath = &foundThumbnailPath
-		url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, time.Now().Unix())
+		url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, time.Now())
 		volume.ThumbnailURL = &url
 		log.Printf("[SCANNER] Linked existing thumbnail for volume %s: %s", volData.Title, foundThumbnailPath)
 	} else if volData.ThumbnailPath != nil && *volData.ThumbnailPath != "" {
 		volume.ThumbnailPath = volData.ThumbnailPath
-		url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, time.Now().Unix())
+		url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, time.Now())
 		volume.ThumbnailURL = &url
 		log.Printf("[SCANNER] Linked folder cover for volume %s: %s", volData.Title, *volData.ThumbnailPath)
 	} else if strings.ToLower(filepath.Ext(volData.Path)) == ".pdf" {
 		if newThumbPath, err := s.ensurePdfThumbnail(volData.Path, thumbnailsDir); err == nil {
 			volume.ThumbnailPath = &newThumbPath
-			url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, time.Now().Unix())
+			url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, time.Now())
 			volume.ThumbnailURL = &url
 			log.Printf("[SCANNER] Extracted PDF thumbnail for volume %s: %s", volData.Title, newThumbPath)
 		} else {
@@ -3338,7 +3338,7 @@ func (s *Scanner) ensureSeriesPdfThumbnailIfMissing(
 	}
 
 	series.ThumbnailPath = &newThumbPath
-	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+	url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 	series.ThumbnailURL = &url
 	if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); uErr != nil {
 		log.Printf("[SCANNER] Failed to update series thumbnail: %v", uErr)
@@ -3370,7 +3370,7 @@ func (s *Scanner) ensureSeriesEpubThumbnailIfMissing(
 	}
 
 	series.ThumbnailPath = &newThumbPath
-	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+	url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 	series.ThumbnailURL = &url
 	if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); uErr != nil {
 		log.Printf("[SCANNER] Failed to update series thumbnail: %v", uErr)
@@ -3401,7 +3401,7 @@ func (s *Scanner) ensureVolumePdfThumbnailIfMissing(
 	}
 
 	volume.ThumbnailPath = &newThumbPath
-	url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volume.ID, time.Now().Unix())
+	url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, time.Now())
 	volume.ThumbnailURL = &url
 	if uErr := s.volumeRepo.UpdatePreservingContentUpdatedAt(tx, volume); uErr != nil {
 		log.Printf("[SCANNER] Failed to update volume thumbnail: %v", uErr)

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -244,7 +244,7 @@ func (s *Scanner) normalizeStoredSeriesTitlesForLibraryTx(tx *sql.Tx, libraryID 
 			continue
 		}
 		series.Title = baseTitle
-		if err := s.seriesRepo.Update(tx, series); err != nil {
+		if err := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); err != nil {
 			return err
 		}
 	}
@@ -1391,7 +1391,7 @@ func (s *Scanner) processArchiveAsSeries(
 			seriesChanged = true
 		}
 		if seriesChanged {
-			if uErr := s.seriesRepo.Update(tx, series); uErr != nil {
+			if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); uErr != nil {
 				return nil, uErr
 			}
 		}
@@ -1593,7 +1593,7 @@ func (s *Scanner) processSeries(
 			seriesChanged = true
 		}
 		if seriesChanged {
-			if uErr := s.seriesRepo.Update(nil, series); uErr != nil {
+			if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(nil, series); uErr != nil {
 				return nil, uErr
 			}
 		}
@@ -3340,7 +3340,7 @@ func (s *Scanner) ensureSeriesPdfThumbnailIfMissing(
 	series.ThumbnailPath = &newThumbPath
 	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
 	series.ThumbnailURL = &url
-	if uErr := s.seriesRepo.Update(tx, series); uErr != nil {
+	if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); uErr != nil {
 		log.Printf("[SCANNER] Failed to update series thumbnail: %v", uErr)
 		return
 	}
@@ -3372,7 +3372,7 @@ func (s *Scanner) ensureSeriesEpubThumbnailIfMissing(
 	series.ThumbnailPath = &newThumbPath
 	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
 	series.ThumbnailURL = &url
-	if uErr := s.seriesRepo.Update(tx, series); uErr != nil {
+	if uErr := s.seriesRepo.UpdatePreservingUpdatedAt(tx, series); uErr != nil {
 		log.Printf("[SCANNER] Failed to update series thumbnail: %v", uErr)
 		return
 	}

--- a/backend/internal/service/metadata_plugin.go
+++ b/backend/internal/service/metadata_plugin.go
@@ -735,7 +735,7 @@ func (s *MetadataService) applySeriesThumbnail(ctx context.Context, series *mode
 	}
 
 	series.ThumbnailPath = &path
-	url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, time.Now().Unix())
+	url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, time.Now())
 	series.ThumbnailURL = &url
 	return true, nil
 }
@@ -771,7 +771,7 @@ func (s *MetadataService) enrichSeriesThumbnail(series *model.Series) {
 		return
 	}
 	if series.ThumbnailPath != nil && strings.TrimSpace(*series.ThumbnailPath) != "" {
-		url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", series.ID, series.UpdatedAt.Unix())
+		url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, series.UpdatedAt)
 		series.ThumbnailURL = &url
 		return
 	}
@@ -788,7 +788,7 @@ func (s *MetadataService) enrichSeriesThumbnail(series *model.Series) {
 	}
 	vol, volErr := s.volumeRepo.GetFirstVolume(nil, series.ID)
 	if volErr == nil && vol != nil && vol.ThumbnailPath != nil && strings.TrimSpace(*vol.ThumbnailPath) != "" {
-		url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", vol.ID, vol.UpdatedAt.Unix())
+		url := util.BuildVolumeThumbnailURL(vol.ID, vol.ThumbnailPath, vol.UpdatedAt)
 		series.ThumbnailURL = &url
 	}
 }

--- a/backend/internal/service/series_enrich.go
+++ b/backend/internal/service/series_enrich.go
@@ -50,7 +50,7 @@ func (svc *SeriesEnrichService) EnrichSingle(s *model.Series, userID string) {
 func (svc *SeriesEnrichService) enrichSingle(s *model.Series, userID string, displayUnits map[string]string, usePrefetchedDisplayUnit bool) {
 	// 썸네일 URL 설정
 	if s.ThumbnailPath != nil && *s.ThumbnailPath != "" {
-		url := fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", s.ID, s.UpdatedAt.Unix())
+		url := util.BuildSeriesThumbnailURL(s.ID, s.ThumbnailPath, s.UpdatedAt)
 		s.ThumbnailURL = &url
 	} else {
 		pageID, err := svc.seriesRepo.GetFirstPageID(nil, s.ID)
@@ -61,7 +61,7 @@ func (svc *SeriesEnrichService) enrichSingle(s *model.Series, userID string, dis
 			// 페이지가 없는 경우 (PDF 등) 첫 번째 볼륨의 썸네일을 시도
 			vol, vErr := svc.volumeRepo.GetFirstVolume(nil, s.ID)
 			if vErr == nil && vol != nil && vol.ThumbnailPath != nil && *vol.ThumbnailPath != "" {
-				url := fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", vol.ID, vol.UpdatedAt.Unix())
+				url := util.BuildVolumeThumbnailURL(vol.ID, vol.ThumbnailPath, vol.UpdatedAt)
 				s.ThumbnailURL = &url
 			}
 		}

--- a/backend/internal/util/thumbnail_url.go
+++ b/backend/internal/util/thumbnail_url.go
@@ -3,13 +3,38 @@ package util
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 )
 
+type thumbnailStatCacheEntry struct {
+	value    int64
+	cachedAt time.Time
+}
+
+var (
+	thumbnailStatCache   = map[string]thumbnailStatCacheEntry{}
+	thumbnailStatCacheMu sync.RWMutex
+)
+
+const thumbnailStatCacheTTL = time.Second
+
 func thumbnailCacheBuster(path *string, fallback time.Time) int64 {
 	if path != nil && *path != "" {
+		now := time.Now()
+		thumbnailStatCacheMu.RLock()
+		entry, ok := thumbnailStatCache[*path]
+		thumbnailStatCacheMu.RUnlock()
+		if ok && now.Sub(entry.cachedAt) < thumbnailStatCacheTTL {
+			return entry.value
+		}
+
 		if info, err := os.Stat(*path); err == nil {
-			return info.ModTime().Unix()
+			value := info.ModTime().Unix()
+			thumbnailStatCacheMu.Lock()
+			thumbnailStatCache[*path] = thumbnailStatCacheEntry{value: value, cachedAt: now}
+			thumbnailStatCacheMu.Unlock()
+			return value
 		}
 	}
 	return fallback.Unix()

--- a/backend/internal/util/thumbnail_url.go
+++ b/backend/internal/util/thumbnail_url.go
@@ -17,7 +17,18 @@ var (
 	thumbnailStatCacheMu sync.RWMutex
 )
 
-const thumbnailStatCacheTTL = time.Second
+const (
+	thumbnailStatCacheTTL     = time.Second
+	thumbnailStatCacheMaxSize = 1024
+)
+
+func purgeExpiredThumbnailStatCacheEntries(now time.Time) {
+	for key, entry := range thumbnailStatCache {
+		if now.Sub(entry.cachedAt) >= thumbnailStatCacheTTL {
+			delete(thumbnailStatCache, key)
+		}
+	}
+}
 
 func thumbnailCacheBuster(path *string, fallback time.Time) int64 {
 	if path != nil && *path != "" {
@@ -26,14 +37,30 @@ func thumbnailCacheBuster(path *string, fallback time.Time) int64 {
 		entry, ok := thumbnailStatCache[*path]
 		thumbnailStatCacheMu.RUnlock()
 		if ok && now.Sub(entry.cachedAt) < thumbnailStatCacheTTL {
-			return entry.value
+			if entry.value >= 0 {
+				return entry.value
+			}
+			return fallback.Unix()
 		}
 
+		value := int64(-1)
 		if info, err := os.Stat(*path); err == nil {
-			value := info.ModTime().Unix()
-			thumbnailStatCacheMu.Lock()
-			thumbnailStatCache[*path] = thumbnailStatCacheEntry{value: value, cachedAt: now}
-			thumbnailStatCacheMu.Unlock()
+			value = info.ModTime().Unix()
+		}
+
+		thumbnailStatCacheMu.Lock()
+		if len(thumbnailStatCache) >= thumbnailStatCacheMaxSize {
+			purgeExpiredThumbnailStatCacheEntries(now)
+			if len(thumbnailStatCache) >= thumbnailStatCacheMaxSize {
+				for key := range thumbnailStatCache {
+					delete(thumbnailStatCache, key)
+					break
+				}
+			}
+		}
+		thumbnailStatCache[*path] = thumbnailStatCacheEntry{value: value, cachedAt: now}
+		thumbnailStatCacheMu.Unlock()
+		if value >= 0 {
 			return value
 		}
 	}

--- a/backend/internal/util/thumbnail_url.go
+++ b/backend/internal/util/thumbnail_url.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func thumbnailCacheBuster(path *string, fallback time.Time) int64 {
+	if path != nil && *path != "" {
+		if info, err := os.Stat(*path); err == nil {
+			return info.ModTime().Unix()
+		}
+	}
+	return fallback.Unix()
+}
+
+func BuildSeriesThumbnailURL(seriesID string, thumbnailPath *string, fallback time.Time) string {
+	return fmt.Sprintf("/api/v1/series/%s/thumbnail?t=%d", seriesID, thumbnailCacheBuster(thumbnailPath, fallback))
+}
+
+func BuildVolumeThumbnailURL(volumeID string, thumbnailPath *string, fallback time.Time) string {
+	return fmt.Sprintf("/api/v1/volumes/%s/thumbnail?t=%d", volumeID, thumbnailCacheBuster(thumbnailPath, fallback))
+}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -134,12 +134,16 @@ export function HomePage() {
           const cutoffDate = new Date();
           cutoffDate.setDate(cutoffDate.getDate() - periodDays);
 
-          // updated_at 기준 최신순 정렬
-          allSeries.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+          // last_content_updated_at 기준 최신순 정렬 (없으면 updated_at fallback)
+          allSeries.sort((a, b) => {
+            const aDate = new Date(a.last_content_updated_at || a.updated_at);
+            const bDate = new Date(b.last_content_updated_at || b.updated_at);
+            return bDate.getTime() - aDate.getTime();
+          });
 
           // 기간 필터링 적용
           const filteredSeries = allSeries.filter((series) => {
-            const updatedDate = new Date(series.updated_at);
+            const updatedDate = new Date(series.last_content_updated_at || series.updated_at);
             return updatedDate >= cutoffDate;
           });
 

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -48,6 +48,7 @@ export interface Series {
   chapter_count?: number;
   created_at: string;
   updated_at: string;
+  last_content_updated_at?: string;
   extension?: ExtensionBadge | "";
   library_type?: LibraryType;
   has_audio?: boolean;


### PR DESCRIPTION
## 관련 이슈

Closes #289

## 문제

시리즈 메타데이터(제목, 썸네일, 설명 등) 변경 시 홈페이지 "업데이트된 시리즈" 섹션에 반영되고 있었습니다.

## 원인

- 스캐너에서 썸네일 보정, 타이틀 정규화, EPUB 메타 반영 시 `seriesRepo.Update()`를 호출하여 `updated_at`이 함께 갱신됨
- 홈페이지는 `updated_at` 기준으로만 업데이트된 시리즈를 필터링

## 해결

1. `series` 테이블에 `last_content_updated_at` 컬럼 추가
2. 볼륨/챕터 생성·수정 시에만 `last_content_updated_at` 갱신
3. 스캐너의 메타성 변경은 `UpdatePreservingUpdatedAt()`으로 전환
4. 홈페이지 필터 기준을 `updated_at` → `last_content_updated_at`으로 변경

## 검증

- `golangci-lint run` 통과
- `go test ./...` 전체 패키지 통과