### PR TITLE
fix: 시리즈 콘텐츠 업데이트 시간 마이그레이션 수정

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1226,8 +1226,26 @@ func migrateEpubFlowSeriesSetting() error {
 	return addColumn("user_series_settings", "epub_flow", "TEXT")
 }
 
+func ensureSeriesLastContentUpdatedAtInsertTrigger() error {
+	if _, err := DB.Exec(`
+		CREATE TRIGGER IF NOT EXISTS trg_series_last_content_updated_at_insert
+		AFTER INSERT ON series
+		FOR EACH ROW
+		WHEN NEW.last_content_updated_at IS NULL
+		BEGIN
+			UPDATE series
+			SET last_content_updated_at = COALESCE(NEW.updated_at, CURRENT_TIMESTAMP)
+			WHERE id = NEW.id;
+		END;
+	`); err != nil {
+		return fmt.Errorf("create trigger series.last_content_updated_at insert: %w", err)
+	}
+
+	return nil
+}
+
 func migrateSeriesLastContentUpdatedAt() error {
-	if err := addColumn("series", "last_content_updated_at", "DATETIME DEFAULT CURRENT_TIMESTAMP"); err != nil {
+	if err := addColumn("series", "last_content_updated_at", "DATETIME"); err != nil {
 		return err
 	}
 
@@ -1238,6 +1256,11 @@ func migrateSeriesLastContentUpdatedAt() error {
 	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s`, initExpr)); err != nil {
 		return fmt.Errorf("initialize last_content_updated_at: %w", err)
 	}
+
+	if err := ensureSeriesLastContentUpdatedAtInsertTrigger(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1253,7 +1253,7 @@ func migrateSeriesLastContentUpdatedAt() error {
 	if columnExists("series", "updated_at") {
 		initExpr = "COALESCE(updated_at, CURRENT_TIMESTAMP)"
 	}
-	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s`, initExpr)); err != nil {
+	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s WHERE last_content_updated_at IS NULL`, initExpr)); err != nil {
 		return fmt.Errorf("initialize last_content_updated_at: %w", err)
 	}
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1226,18 +1226,30 @@ func migrateEpubFlowSeriesSetting() error {
 	return addColumn("user_series_settings", "epub_flow", "TEXT")
 }
 
+func seriesLastContentUpdatedAtInitExpr() string {
+	if columnExists("series", "updated_at") {
+		return "COALESCE(updated_at, CURRENT_TIMESTAMP)"
+	}
+	return "CURRENT_TIMESTAMP"
+}
+
 func ensureSeriesLastContentUpdatedAtInsertTrigger() error {
-	if _, err := DB.Exec(`
+	insertExpr := "CURRENT_TIMESTAMP"
+	if columnExists("series", "updated_at") {
+		insertExpr = "COALESCE(NEW.updated_at, CURRENT_TIMESTAMP)"
+	}
+
+	if _, err := DB.Exec(fmt.Sprintf(`
 		CREATE TRIGGER IF NOT EXISTS trg_series_last_content_updated_at_insert
 		AFTER INSERT ON series
 		FOR EACH ROW
 		WHEN NEW.last_content_updated_at IS NULL
 		BEGIN
 			UPDATE series
-			SET last_content_updated_at = COALESCE(NEW.updated_at, CURRENT_TIMESTAMP)
+			SET last_content_updated_at = %s
 			WHERE id = NEW.id;
 		END;
-	`); err != nil {
+	`, insertExpr)); err != nil {
 		return fmt.Errorf("create trigger series.last_content_updated_at insert: %w", err)
 	}
 
@@ -1249,10 +1261,7 @@ func migrateSeriesLastContentUpdatedAt() error {
 		return err
 	}
 
-	initExpr := "CURRENT_TIMESTAMP"
-	if columnExists("series", "updated_at") {
-		initExpr = "COALESCE(updated_at, CURRENT_TIMESTAMP)"
-	}
+	initExpr := seriesLastContentUpdatedAtInitExpr()
 	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s WHERE last_content_updated_at IS NULL`, initExpr)); err != nil {
 		return fmt.Errorf("initialize last_content_updated_at: %w", err)
 	}

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1251,7 +1251,7 @@ func migrateSeriesLastContentUpdatedAt() error {
 
 	initExpr := "CURRENT_TIMESTAMP"
 	if columnExists("series", "updated_at") {
-		initExpr = "updated_at"
+		initExpr = "COALESCE(updated_at, CURRENT_TIMESTAMP)"
 	}
 	if _, err := DB.Exec(fmt.Sprintf(`UPDATE series SET last_content_updated_at = %s`, initExpr)); err != nil {
 		return fmt.Errorf("initialize last_content_updated_at: %w", err)

--- a/backend/internal/database/migration_43_test.go
+++ b/backend/internal/database/migration_43_test.go
@@ -7,6 +7,15 @@ import (
 )
 
 func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
+	t.Run("updated_at column exists", func(t *testing.T) {
+		testMigrateSeriesLastContentUpdatedAtWithUpdatedAt(t)
+	})
+	t.Run("updated_at column missing", func(t *testing.T) {
+		testMigrateSeriesLastContentUpdatedAtWithoutUpdatedAt(t)
+	})
+}
+
+func testMigrateSeriesLastContentUpdatedAtWithUpdatedAt(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "migration-43.db")
 
 	db, err := sql.Open("sqlite3", dbPath)
@@ -98,5 +107,67 @@ func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
 	}
 	if insertedValue != "2026-05-03 10:45:00" {
 		t.Fatalf("inserted last_content_updated_at = %s, want 2026-05-03 10:45:00", insertedValue)
+	}
+}
+
+func testMigrateSeriesLastContentUpdatedAtWithoutUpdatedAt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-43-no-updated-at.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+		DB = nil
+	}()
+
+	DB = db
+
+	if _, err := DB.Exec(`
+		CREATE TABLE series (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create legacy series table error = %v", err)
+	}
+
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title)
+		VALUES ('legacy-series-1', 'Legacy Series 1')
+	`); err != nil {
+		t.Fatalf("seed legacy series error = %v", err)
+	}
+
+	if err := migrateSeriesLastContentUpdatedAt(); err != nil {
+		t.Fatalf("migrateSeriesLastContentUpdatedAt() on legacy schema error = %v", err)
+	}
+
+	if !columnExists("series", "last_content_updated_at") {
+		t.Fatal("last_content_updated_at column was not added on legacy schema")
+	}
+
+	var migratedValue sql.NullString
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'legacy-series-1'`).Scan(&migratedValue); err != nil {
+		t.Fatalf("select legacy migrated last_content_updated_at error = %v", err)
+	}
+	if !migratedValue.Valid {
+		t.Fatal("legacy series last_content_updated_at should be backfilled")
+	}
+
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title)
+		VALUES ('legacy-series-2', 'Legacy Series 2')
+	`); err != nil {
+		t.Fatalf("insert legacy series after migration error = %v", err)
+	}
+
+	var insertedValue sql.NullString
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'legacy-series-2'`).Scan(&insertedValue); err != nil {
+		t.Fatalf("select legacy inserted last_content_updated_at error = %v", err)
+	}
+	if !insertedValue.Valid {
+		t.Fatal("legacy inserted series last_content_updated_at should be initialized by trigger")
 	}
 }

--- a/backend/internal/database/migration_43_test.go
+++ b/backend/internal/database/migration_43_test.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
@@ -38,6 +36,12 @@ func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("seed series error = %v", err)
 	}
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title, updated_at)
+		VALUES ('series-null-updated-at', 'Series Null UpdatedAt', NULL)
+	`); err != nil {
+		t.Fatalf("seed series with null updated_at error = %v", err)
+	}
 
 	if err := migrateSeriesLastContentUpdatedAt(); err != nil {
 		t.Fatalf("migrateSeriesLastContentUpdatedAt() error = %v", err)
@@ -53,6 +57,14 @@ func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
 	}
 	if migratedValue != "2026-05-03 09:30:00" {
 		t.Fatalf("migrated last_content_updated_at = %s, want 2026-05-03 09:30:00", migratedValue)
+	}
+
+	var nullBackfilledValue sql.NullString
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'series-null-updated-at'`).Scan(&nullBackfilledValue); err != nil {
+		t.Fatalf("select null-updated_at backfill error = %v", err)
+	}
+	if !nullBackfilledValue.Valid {
+		t.Fatal("last_content_updated_at should be backfilled when updated_at is NULL")
 	}
 
 	if _, err := DB.Exec(`

--- a/backend/internal/database/migration_43_test.go
+++ b/backend/internal/database/migration_43_test.go
@@ -1,0 +1,72 @@
+package database
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-43.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+		DB = nil
+	}()
+
+	DB = db
+
+	if _, err := DB.Exec(`
+		CREATE TABLE series (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			updated_at DATETIME
+		)
+	`); err != nil {
+		t.Fatalf("create series table error = %v", err)
+	}
+
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title, updated_at)
+		VALUES ('series-1', 'Series 1', '2026-05-03 09:30:00')
+	`); err != nil {
+		t.Fatalf("seed series error = %v", err)
+	}
+
+	if err := migrateSeriesLastContentUpdatedAt(); err != nil {
+		t.Fatalf("migrateSeriesLastContentUpdatedAt() error = %v", err)
+	}
+
+	if !columnExists("series", "last_content_updated_at") {
+		t.Fatal("last_content_updated_at column was not added")
+	}
+
+	var migratedValue string
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'series-1'`).Scan(&migratedValue); err != nil {
+		t.Fatalf("select migrated last_content_updated_at error = %v", err)
+	}
+	if migratedValue != "2026-05-03 09:30:00" {
+		t.Fatalf("migrated last_content_updated_at = %s, want 2026-05-03 09:30:00", migratedValue)
+	}
+
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title, updated_at)
+		VALUES ('series-2', 'Series 2', '2026-05-03 10:45:00')
+	`); err != nil {
+		t.Fatalf("insert series after migration error = %v", err)
+	}
+
+	var insertedValue string
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'series-2'`).Scan(&insertedValue); err != nil {
+		t.Fatalf("select inserted last_content_updated_at error = %v", err)
+	}
+	if insertedValue != "2026-05-03 10:45:00" {
+		t.Fatalf("inserted last_content_updated_at = %s, want 2026-05-03 10:45:00", insertedValue)
+	}
+}

--- a/backend/internal/database/migration_43_test.go
+++ b/backend/internal/database/migration_43_test.go
@@ -42,7 +42,6 @@ func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("seed series with null updated_at error = %v", err)
 	}
-
 	if err := migrateSeriesLastContentUpdatedAt(); err != nil {
 		t.Fatalf("migrateSeriesLastContentUpdatedAt() error = %v", err)
 	}
@@ -65,6 +64,25 @@ func TestMigrateSeriesLastContentUpdatedAt(t *testing.T) {
 	}
 	if !nullBackfilledValue.Valid {
 		t.Fatal("last_content_updated_at should be backfilled when updated_at is NULL")
+	}
+
+	if _, err := DB.Exec(`
+		INSERT INTO series (id, title, updated_at, last_content_updated_at)
+		VALUES ('series-existing-last-content', 'Series Existing Last Content', '2026-05-03 10:10:00', '2026-05-01 08:00:00')
+	`); err != nil {
+		t.Fatalf("insert series with existing last_content_updated_at error = %v", err)
+	}
+
+	if err := migrateSeriesLastContentUpdatedAt(); err != nil {
+		t.Fatalf("re-run migrateSeriesLastContentUpdatedAt() error = %v", err)
+	}
+
+	var preservedValue string
+	if err := DB.QueryRow(`SELECT datetime(last_content_updated_at) FROM series WHERE id = 'series-existing-last-content'`).Scan(&preservedValue); err != nil {
+		t.Fatalf("select preserved last_content_updated_at error = %v", err)
+	}
+	if preservedValue != "2026-05-01 08:00:00" {
+		t.Fatalf("preserved last_content_updated_at = %s, want 2026-05-01 08:00:00", preservedValue)
 	}
 
 	if _, err := DB.Exec(`


### PR DESCRIPTION
## 변경 사항
- SQLite 기존 DB 업그레이드 경로에서 `ALTER TABLE ... ADD COLUMN ... DEFAULT CURRENT_TIMESTAMP` 가 실패하던 migration 43을 수정
- `last_content_updated_at` 컬럼은 기본값 없이 추가하고, 기존 행은 `updated_at` 기준으로 backfill
- 업그레이드된 DB에서 이후 `series` insert 시 `last_content_updated_at` 이 비지 않도록 insert trigger 추가
- 기존 스키마에서 migration 43을 직접 재현하는 회귀 테스트 추가

## 테스트
- [x] `cd backend && go test ./...`
- [x] `cd backend && go build ./...`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`

## 관련 이슈
- 없음
