### PR TITLE
fix(web): SeriesCard 음표 아이콘 조건 확장 — volume has_audio + 오디오북 시리즈 유지 (#305)

### DIFF
--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -171,6 +171,72 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     expect(images[0]).toHaveAttribute("alt", "볼륨 2");
   });
 
+  it("오디오북 시리즈는 메타 영역에 음표 아이콘을 유지한다", () => {
+    const { container } = render(
+      <SeriesCard
+        type="series"
+        item={{
+          id: "series-audio-icon",
+          library_id: "library-1",
+          title: "오디오북 시리즈",
+          path: "/audio/series",
+          library_type: "audiobook",
+          has_audio: true,
+          created_at: "2026-03-21T00:00:00Z",
+          updated_at: "2026-03-21T00:00:00Z",
+        }}
+      />,
+    );
+
+    const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
+    expect(meta?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("일반 도서 볼륨은 has_audio=true 이면 음표 아이콘을 표시한다", () => {
+    const { container } = render(
+      <SeriesCard
+        type="volume"
+        item={{
+          id: "volume-audio-icon",
+          series_id: "series-1",
+          title: "배경음 볼륨",
+          volume_number: 3,
+          path: "/books/volume-3.zip",
+          has_audio: true,
+          library_type: "book",
+          chapter_count: 6,
+          created_at: "2026-03-21T00:00:00Z",
+          updated_at: "2026-03-21T00:00:00Z",
+        }}
+      />,
+    );
+
+    const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
+    expect(meta?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("일반 시리즈는 has_audio=true 여도 음표 아이콘을 표시하지 않는다", () => {
+    const { container } = render(
+      <SeriesCard
+        type="series"
+        item={{
+          id: "series-book-audio",
+          library_id: "library-1",
+          title: "배경음 포함 시리즈",
+          path: "/books/series-audio",
+          library_type: "book",
+          has_audio: true,
+          chapter_count: 12,
+          created_at: "2026-03-21T00:00:00Z",
+          updated_at: "2026-03-21T00:00:00Z",
+        }}
+      />,
+    );
+
+    const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
+    expect(meta?.querySelector("svg")).toBeNull();
+  });
+
   it("시리즈 display_unit이 volume이면 볼륨 개수를 우선 표시한다", () => {
     render(
       <SeriesCard

--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -189,7 +189,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     );
 
     const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
-    expect(meta?.querySelector("svg")).not.toBeNull();
+    expect(meta?.querySelector('[data-testid="series-card-audio-icon"]')).not.toBeNull();
   });
 
   it("일반 도서 볼륨은 has_audio=true 이면 음표 아이콘을 표시한다", () => {
@@ -212,7 +212,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     );
 
     const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
-    expect(meta?.querySelector("svg")).not.toBeNull();
+    expect(meta?.querySelector('[data-testid="series-card-audio-icon"]')).not.toBeNull();
   });
 
   it("일반 시리즈는 has_audio=true 여도 음표 아이콘을 표시하지 않는다", () => {
@@ -234,7 +234,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
     );
 
     const meta = container.querySelector("h3")?.nextElementSibling as HTMLElement | null;
-    expect(meta?.querySelector("svg")).toBeNull();
+    expect(meta?.querySelector('[data-testid="series-card-audio-icon"]')).toBeNull();
   });
 
   it("시리즈 display_unit이 volume이면 볼륨 개수를 우선 표시한다", () => {

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -409,6 +409,7 @@ export function SeriesCard({
   const showThumbnailExtensionBadge =
     shouldShowExtensionBadge && extensionBadgePlacement === "thumbnail" && !!extensionBadge;
   const isAudioLayout = isAudiobook;
+  const showAudioIcon = isAudiobook || (type === "volume" && item.has_audio === true);
   const showOverlayProgress =
     progressStyle === "overlay" && displayProgress !== null && (displayProgress > 0 || forceShowProgress);
   const thumbnailSrc = useMemo(() => {
@@ -660,14 +661,14 @@ export function SeriesCard({
         >
           {itemTitle}
         </h3>
-        {displaySubtitle || isAudioLayout || showMetaExtensionBadge ? (
+        {displaySubtitle || showAudioIcon || showMetaExtensionBadge ? (
           <div
-            className={`${styles.seriesMeta} ${!displaySubtitle && !isAudioLayout && showMetaExtensionBadge ? styles.seriesMetaOnlyBadge : ""}`}
+            className={`${styles.seriesMeta} ${!displaySubtitle && !showAudioIcon && showMetaExtensionBadge ? styles.seriesMetaOnlyBadge : ""}`}
           >
-            {(displaySubtitle || isAudioLayout) && (
+            {(displaySubtitle || showAudioIcon) && (
               <span className={styles.seriesMetaLeft}>
                 {displaySubtitle && <span>{displaySubtitle}</span>}
-                {isAudioLayout && (
+                {showAudioIcon && (
                   <Music
                     size={14}
                     className={styles.audioIcon}

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -670,6 +670,7 @@ export function SeriesCard({
                 {displaySubtitle && <span>{displaySubtitle}</span>}
                 {showAudioIcon && (
                   <Music
+                    data-testid="series-card-audio-icon"
                     size={14}
                     className={styles.audioIcon}
                     style={{ marginLeft: "4px", verticalAlign: "middle" }}


### PR DESCRIPTION
## 요약
- `SeriesCard` 음표 아이콘 조건을 `isAudiobook || (type === "volume" && item.has_audio === true)`로 확장했습니다.
- 시리즈 페이지에서 BGM이 포함된 일반 볼륨 카드에 음표가 보이지 않던 문제를 수정했습니다.
- 오디오북 시리즈 카드에서 기존 음표 표시가 사라지지 않도록 회귀를 방지했습니다.

## 해결 이슈
- Closes #305

## 테스트
- 8 tests passed

## 검증 케이스
- 오디오북 시리즈 카드 음표 유지
- 일반 볼륨 + has_audio=true 음표 표시
- 일반 시리즈 + has_audio=true 음표 미표시
