### PR TITLE
fix: epub 뷰어 전체화면 단축키 연결

### DIFF
--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -808,7 +808,13 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         if (tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable))
           return;
 
-        if (event.key === "f" || event.key === "F" || event.key === "ㄹ") {
+        if (
+          (event.key === "f" || event.key === "F" || event.key === "ㄹ") &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.repeat
+        ) {
           event.preventDefault();
           event.stopPropagation();
           onToggleFullscreenRef.current?.();

--- a/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubChapterViewer/index.tsx
@@ -92,6 +92,7 @@ interface EpubChapterViewerProps {
     atEnd?: boolean;
   }) => void;
   onViewerClick?: () => void;
+  onToggleFullscreen?: () => void;
   onInitializationComplete?: () => void;
   onPageNext?: () => void;
   onPagePrev?: () => void;
@@ -134,6 +135,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
       onTOCLoad,
       onLocationChange,
       onViewerClick,
+      onToggleFullscreen,
       onInitializationComplete,
       onPageNext,
       onPagePrev,
@@ -156,6 +158,7 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
 
     // 최신 콜백을 ref로 유지 (stale closure 방지)
     const onViewerClickRef = useRef(onViewerClick);
+    const onToggleFullscreenRef = useRef(onToggleFullscreen);
     const onLocationChangeRef = useRef(onLocationChange);
     const onReadyRef = useRef(onReady);
     const onTOCLoadRef = useRef(onTOCLoad);
@@ -207,6 +210,9 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
     useEffect(() => {
       onViewerClickRef.current = onViewerClick;
     }, [onViewerClick]);
+    useEffect(() => {
+      onToggleFullscreenRef.current = onToggleFullscreen;
+    }, [onToggleFullscreen]);
     useEffect(() => {
       onLocationChangeRef.current = onLocationChange;
     }, [onLocationChange]);
@@ -801,6 +807,14 @@ const EpubChapterViewer = forwardRef<EpubChapterViewerHandles, EpubChapterViewer
         const tagName = target?.tagName?.toLowerCase();
         if (tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable))
           return;
+
+        if (event.key === "f" || event.key === "F" || event.key === "ㄹ") {
+          event.preventDefault();
+          event.stopPropagation();
+          onToggleFullscreenRef.current?.();
+          return;
+        }
+
         if (currentSettings.flow === "scrolled") return;
 
         const nextArrowKey = currentSettings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";

--- a/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
@@ -579,6 +579,24 @@ describe("EpubViewer UI", () => {
     expect(viewerPrevSpy).not.toHaveBeenCalled();
   });
 
+  it("should toggle fullscreen on plain f key only", () => {
+    const props = createDefaultProps();
+
+    render(
+      <MemoryRouter>
+        <EpubViewer {...props} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(window, { key: "f" });
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    fireEvent.keyDown(window, { key: "f", altKey: true });
+    fireEvent.keyDown(window, { key: "f", repeat: true });
+
+    expect(props.onToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+
   it("should call onReachedEndNext when viewer.next reports no movement", async () => {
     const props = createDefaultProps();
     const onReachedEndNext = vi.fn();

--- a/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
+++ b/web/src/features/epub-viewer/components/EpubViewer_UI.test.tsx
@@ -579,7 +579,7 @@ describe("EpubViewer UI", () => {
     expect(viewerPrevSpy).not.toHaveBeenCalled();
   });
 
-  it("should toggle fullscreen on plain f key only", () => {
+  it("should toggle fullscreen on f, F, and ㄹ", () => {
     const props = createDefaultProps();
 
     render(
@@ -589,10 +589,42 @@ describe("EpubViewer UI", () => {
     );
 
     fireEvent.keyDown(window, { key: "f" });
+    fireEvent.keyDown(window, { key: "F" });
+    fireEvent.keyDown(window, { key: "ㄹ" });
+
+    expect(props.onToggleFullscreen).toHaveBeenCalledTimes(3);
+  });
+
+  it("should ignore fullscreen shortcut when modifier keys or repeat are present", () => {
+    const props = createDefaultProps();
+
+    render(
+      <MemoryRouter>
+        <EpubViewer {...props} />
+      </MemoryRouter>,
+    );
+
     fireEvent.keyDown(window, { key: "f", ctrlKey: true });
     fireEvent.keyDown(window, { key: "f", metaKey: true });
     fireEvent.keyDown(window, { key: "f", altKey: true });
     fireEvent.keyDown(window, { key: "f", repeat: true });
+
+    expect(props.onToggleFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("should toggle fullscreen shortcut even in scrolled mode", () => {
+    const props = createDefaultProps();
+
+    render(
+      <MemoryRouter>
+        <EpubViewer
+          {...props}
+          settings={{ ...props.settings, flow: "scrolled" }}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(window, { key: "F" });
 
     expect(props.onToggleFullscreen).toHaveBeenCalledTimes(1);
   });

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -117,6 +117,45 @@ describe("useViewerNavigation fullscreen switching", () => {
   });
 });
 
+describe("useViewerNavigation fullscreen shortcut", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggles fullscreen on plain f key only", () => {
+    const handleToggleFullscreen = vi.fn();
+
+    renderHook(() =>
+      useViewerNavigation({
+        currentPage: 3,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen,
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f" }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", metaKey: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", altKey: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", repeat: true }));
+
+    expect(handleToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("useViewerNavigation split-page flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -185,34 +185,6 @@ describe("useViewerNavigation fullscreen shortcut", () => {
     expect(handleToggleFullscreen).not.toHaveBeenCalled();
   });
 
-  it("toggles fullscreen shortcut even in scrolled mode", () => {
-    const handleToggleFullscreen = vi.fn();
-
-    renderHook(() =>
-      useViewerNavigation({
-        currentPage: 3,
-        totalPages: 10,
-        readingMode: "single",
-        readingDirection: "ltr",
-        keyboardDirection: "ltr",
-        pageOffset: 0,
-        pageMetaMap: new Map(),
-        subPage: null,
-        setSubPage: vi.fn(),
-        nextChapterId: null,
-        prevChapterId: null,
-        saveProgress: mocks.saveProgressMock,
-        isSettingsOpen: false,
-        closeSettings: vi.fn(),
-        handleToggleFullscreen,
-        currentChapterId: "chapter-1",
-      }),
-    );
-
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "F" }));
-
-    expect(handleToggleFullscreen).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe("useViewerNavigation split-page flow", () => {

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -122,7 +122,7 @@ describe("useViewerNavigation fullscreen shortcut", () => {
     vi.clearAllMocks();
   });
 
-  it("toggles fullscreen on plain f key only", () => {
+  it("toggles fullscreen on f, F, and ㄹ", () => {
     const handleToggleFullscreen = vi.fn();
 
     renderHook(() =>
@@ -147,10 +147,69 @@ describe("useViewerNavigation fullscreen shortcut", () => {
     );
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "f" }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "F" }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ㄹ" }));
+
+    expect(handleToggleFullscreen).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores fullscreen shortcut when modifier keys or repeat are present", () => {
+    const handleToggleFullscreen = vi.fn();
+
+    renderHook(() =>
+      useViewerNavigation({
+        currentPage: 3,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen,
+        currentChapterId: "chapter-1",
+      }),
+    );
+
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", metaKey: true }));
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", altKey: true }));
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", repeat: true }));
+
+    expect(handleToggleFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("toggles fullscreen shortcut even in scrolled mode", () => {
+    const handleToggleFullscreen = vi.fn();
+
+    renderHook(() =>
+      useViewerNavigation({
+        currentPage: 3,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen,
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "F" }));
 
     expect(handleToggleFullscreen).toHaveBeenCalledTimes(1);
   });

--- a/web/src/features/viewer/hooks/useViewerNavigation.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.ts
@@ -324,6 +324,7 @@ export function useViewerNavigation({
         case "f":
         case "F":
         case "ㄹ": // 한글 입력 상태 대비
+          if (e.ctrlKey || e.metaKey || e.altKey || e.repeat) break;
           e.preventDefault();
           handleToggleFullscreen();
           break;

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -612,6 +612,13 @@ export function EpubViewer({
       const isEditable =
         tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable);
       if (isEditable) return;
+
+      if (event.key === "f" || event.key === "F" || event.key === "ㄹ") {
+        event.preventDefault();
+        onToggleFullscreen();
+        return;
+      }
+
       if (settings.flow === "scrolled") return;
 
       const nextArrowKey = settings.keyboardDirection === "right" ? "ArrowRight" : "ArrowLeft";
@@ -628,7 +635,7 @@ export function EpubViewer({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [settings.flow, settings.keyboardDirection, handleNext, handlePrev]);
+  }, [settings.flow, settings.keyboardDirection, handleNext, handlePrev, onToggleFullscreen]);
 
   // === 구형 iOS Safari: <main>에 터치 이벤트 핸들러 등록 ===
   // iframe pointer-events:none으로 터치가 관통하므로 부모에서 처리한다.
@@ -908,6 +915,7 @@ export function EpubViewer({
           onTOCLoad={onTOCLoad}
           onLocationChange={wrappedLocationChange}
           onViewerClick={onViewerClick}
+          onToggleFullscreen={onToggleFullscreen}
           onInitializationComplete={onInitializationComplete}
           onPageNext={handleNext}
           onPagePrev={handlePrev}

--- a/web/src/pages/EpubViewer.tsx
+++ b/web/src/pages/EpubViewer.tsx
@@ -613,7 +613,13 @@ export function EpubViewer({
         tagName === "input" || tagName === "textarea" || tagName === "select" || Boolean(target?.isContentEditable);
       if (isEditable) return;
 
-      if (event.key === "f" || event.key === "F" || event.key === "ㄹ") {
+      if (
+        (event.key === "f" || event.key === "F" || event.key === "ㄹ") &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.repeat
+      ) {
         event.preventDefault();
         onToggleFullscreen();
         return;


### PR DESCRIPTION
fix: epub 뷰어 전체화면 단축키 연결

## 변경 사항
- epub 뷰어에서 F 키 전체화면 단축키가 동작하지 않던 문제를 수정했습니다.
- 원인은 전역 keydown 핸들러와 iframe 내부 keydown 핸들러에 전체화면 토글 분기가 빠져 있던 점이었습니다.
- `EpubViewer.tsx`와 `EpubChapterViewer/index.tsx` 양쪽에 `f/F/ㄹ` 전체화면 토글 분기를 추가했습니다.
- scrolled 모드에서도 단축키가 동작하도록 분기를 scrolled 가드보다 위에 배치했습니다.
- iframe 쪽에는 `stopPropagation()`을 적용해 window 핸들러와의 이중 토글을 방지했습니다.
- iframe 컴포넌트가 fullscreen 콜백을 직접 받도록 prop 연결과 ref 패턴을 추가했습니다.

## 테스트
- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npx vitest run` (40개 파일 / 267개 테스트 통과)

## 관련 이슈
Closes #311