### PR TITLE
feat: Continue Reading 북마크 및 메타데이터 알림 구현

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -123,7 +123,7 @@ func main() {
 	userHandler := handler.NewUserHandler(authService)
 	libraryHandler := handler.NewLibraryHandler(ctx, libraryRepo, authService, fileScanner)
 	imageHandler := handler.NewImageHandler(pageRepo, chapterRepo, volumeRepo, seriesRepo, authService, cfg)
-	progressHandler := handler.NewProgressHandler(progressRepo, viewerSessionRepo, seriesRepo, authService, volumeRepo, chapterRepo, completionRepo, chapterCompletionRepo, hub, seriesEnrichSvc)
+	progressHandler := handler.NewProgressHandler(progressRepo, viewerSessionRepo, seriesRepo, authService, volumeRepo, chapterRepo, completionRepo, chapterCompletionRepo, hub, seriesEnrichSvc, libraryRepo, settingRepo)
 	settingHandler := handler.NewSettingHandler(settingRepo, userSettingRepo, fileScanner)
 	seriesHandler := handler.NewSeriesHandler(seriesRepo, seriesCharacterRepo, libraryRepo, authService, volumeRepo, chapterRepo, pageRepo, completionRepo, chapterCompletionRepo, userSeriesSettingRepo, progressRepo, settingRepo, cfg, seriesEnrichSvc)
 	downloadHandler := handler.NewDownloadHandler(authService, seriesRepo, volumeRepo, chapterRepo)

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1071,7 +1071,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			// 데이터 보정 (썸네일, 진행도 등)
 			h.enrichSingleSeries(series, userID)
 
-			// DisplayTitle 계산 (inlined to avoid direct scanner dependency helper clutter)
+			// DisplayTitle 계산 (OriginalTitleOverride 설정 기반, scanner 유틸리티 직접 호출)
 			displayTitle := strings.TrimSpace(series.Title)
 			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
 				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aha-hyeong/kumiho/backend/internal/repository"
 	"github.com/aha-hyeong/kumiho/backend/internal/service"
 	"github.com/aha-hyeong/kumiho/backend/internal/sse"
+	"github.com/aha-hyeong/kumiho/backend/internal/scanner"
 	"github.com/aha-hyeong/kumiho/backend/internal/util"
 )
 
@@ -31,6 +32,8 @@ type ProgressHandler struct {
 	chapterCompletionRepo *repository.ChapterCompletionRepository
 	sseHub                *sse.Hub
 	seriesEnrichSvc       *service.SeriesEnrichService
+	libraryRepo           *repository.LibraryRepository
+	settingRepo           repository.SettingRepository
 }
 
 const completionThresholdPercent = 100.0
@@ -47,6 +50,8 @@ func NewProgressHandler(
 	chapterCompletionRepo *repository.ChapterCompletionRepository,
 	sseHub *sse.Hub,
 	seriesEnrichSvc *service.SeriesEnrichService,
+	libraryRepo *repository.LibraryRepository,
+	settingRepo repository.SettingRepository,
 ) *ProgressHandler {
 	return &ProgressHandler{
 		progressRepo:          progressRepo,
@@ -59,6 +64,8 @@ func NewProgressHandler(
 		chapterCompletionRepo: chapterCompletionRepo,
 		sseHub:                sseHub,
 		seriesEnrichSvc:       seriesEnrichSvc,
+		libraryRepo:           libraryRepo,
+		settingRepo:           settingRepo,
 	}
 }
 
@@ -1021,10 +1028,26 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		progressList = []repository.RecentEnrichedProgress{}
 	}
 
+	// 라이브러리 목록 전체 조회 (N+1 방지)
+	libraries, err := h.libraryRepo.FindAll(nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to fetch libraries",
+		})
+	}
+	libraryMap := make(map[string]*model.Library, len(libraries))
+	for i := range libraries {
+		libraryMap[libraries[i].ID] = &libraries[i]
+	}
+
+	// 기본 선호 locale 조회 (N+1 방지)
+	locale := repository.PreferredOriginalTitleLocale(h.settingRepo)
+
 	// 시리즈 정보 추가
 	type ProgressWithSeries struct {
 		repository.RecentEnrichedProgress
 		SeriesTitle        string  `json:"series_title"`
+		SeriesDisplayTitle string  `json:"series_display_title"`
 		ThumbnailURL       *string `json:"thumbnail_url"`
 		VolumeNumber       int     `json:"volume_number"`
 		VolumeUnit         string  `json:"volume_unit"`
@@ -1034,6 +1057,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		ChapterTitle       string  `json:"chapter_title"`
 		HasAudio           bool    `json:"has_audio"`
 		LibraryType        string  `json:"library_type"`
+		SeriesIsBookmarked bool    `json:"series_is_bookmarked"` // UI 상의 좋아요 여부를 나타냄 (DB의 is_bookmarked)
 	}
 
 	result := make([]ProgressWithSeries, len(progressList))
@@ -1047,9 +1071,19 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			// 데이터 보정 (썸네일, 진행도 등)
 			h.enrichSingleSeries(series, userID)
 
+			// DisplayTitle 계산 (inlined to avoid direct scanner dependency helper clutter)
+			displayTitle := strings.TrimSpace(series.Title)
+			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
+				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {
+					displayTitle = resolved
+				}
+			}
+
 			result[i].SeriesTitle = series.Title
+			result[i].SeriesDisplayTitle = displayTitle
 			result[i].HasAudio = series.LibraryType == "audiobook"
 			result[i].LibraryType = series.LibraryType
+			result[i].SeriesIsBookmarked = series.IsBookmarked
 
 			// 챕터 정보 보급
 			if p.ChapterID != nil {

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -419,6 +419,11 @@ export function SeriesCard({
         setIsEditModalOpen(true);
       } catch (error) {
         console.error("Failed to load series for volume editing:", error);
+        setAlertModal({
+          isOpen: true,
+          type: "error",
+          message: t("general.toast.load_failed"),
+        });
       }
     } else {
       setIsEditModalOpen(true);
@@ -430,11 +435,14 @@ export function SeriesCard({
     e.stopPropagation();
     setMenuOpen(false);
 
-    if (type !== "series") return;
+    // Kumiho 스키마상 좋아요(북마크)는 시리즈 단위로만 동작하므로, Volume 카드인 경우 부모 시리즈 ID를 타겟으로 토글함
+    const isVol = type === "volume";
+    const targetId = isVol ? (item as Volume).series_id : item.id;
+    if (!targetId) return;
 
-    const newValue = !(item as Series).is_bookmarked;
+    const newValue = !(item.is_bookmarked ?? false);
     try {
-      await seriesAPI.update(item.id, { is_bookmarked: newValue });
+      await seriesAPI.update(targetId, { is_bookmarked: newValue });
       onStatusChange?.();
     } catch (error) {
       console.error("Failed to toggle like on series card:", error);
@@ -678,13 +686,13 @@ export function SeriesCard({
                   <Shield size={16} />
                   <span>{t("series.action.incognito")}</span>
                 </button>
-                {type === "series" && (
+                {(type === "series" || (type === "volume" && item.is_bookmarked !== undefined)) && (
                   <button
                     className={styles.seriesMenuItem}
                     onClick={handleToggleLike}
                   >
-                    <Heart size={16} fill={(item as Series).is_bookmarked ? "currentColor" : "none"} />
-                    <span>{(item as Series).is_bookmarked ? t("series.action.unlike") : t("series.action.like")}</span>
+                    <Heart size={16} fill={item.is_bookmarked ? "currentColor" : "none"} />
+                    <span>{item.is_bookmarked ? t("series.action.unlike") : t("series.action.like")}</span>
                   </button>
                 )}
                 {onDownload && (

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1139,6 +1139,11 @@
       "navigate": "Navigate TOC: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "Failed to load."
+    }
+  },
   "audio_player": {
     "now_playing": "NOW PLAYING",
     "paused": "PAUSED",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1138,6 +1138,11 @@
       "navigate": "目次移動: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "読み込みに失敗しました。"
+    }
+  },
   "audio_player": {
     "now_playing": "再生中",
     "paused": "一時停止",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -1139,6 +1139,11 @@
       "navigate": "목차 이동: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "불러오는데 실패했습니다."
+    }
+  },
   "audio_player": {
     "now_playing": "재생 중",
     "paused": "일시정지",

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -35,6 +35,8 @@ interface RecentProgress {
   chapter_path?: string;
   volume_path?: string;
   series_path?: string;
+  series_is_bookmarked?: boolean; // UI 상의 좋아요 여부 (DB의 is_bookmarked)
+  series_display_title?: string;
 }
 
 export function HomePage() {
@@ -267,7 +269,7 @@ export function HomePage() {
               ? {
                   id: progress.volume_id!,
                   series_id: progress.series_id,
-                  title: progress.volume_title || progress.series_title,
+                  title: progress.volume_title || progress.series_display_title || progress.series_title,
                   thumbnail_url: progress.thumbnail_url,
                   unit: progress.volume_unit,
                   volume_number: progress.volume_number || 0,
@@ -276,10 +278,12 @@ export function HomePage() {
                   created_at: progress.updated_at,
                   has_audio: progress.has_audio,
                   library_type: progress.library_type,
+                  is_bookmarked: progress.series_is_bookmarked,
                 }
               : {
                   id: progress.series_id,
                   title: progress.series_title,
+                  display_title: progress.series_display_title,
                   thumbnail_url: progress.thumbnail_url,
                   path: progress.series_path || progress.path || "",
                   updated_at: progress.updated_at,
@@ -287,6 +291,7 @@ export function HomePage() {
                   created_at: progress.updated_at,
                   has_audio: progress.has_audio,
                   library_type: progress.library_type,
+                  is_bookmarked: progress.series_is_bookmarked,
                 };
 
             // 진행도 텍스트 생성

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -92,6 +92,7 @@ export interface Volume {
   created_at: string;
   updated_at?: string;
   library_type?: LibraryType;
+  is_bookmarked?: boolean; // 부모 시리즈의 좋아요(북마크) 상태
 }
 
 export interface Chapter {


### PR DESCRIPTION
## 변경 내용

- ProgressHandler에 libraryRepo, settingRepo 의존성 추가
- assignSeriesDisplayTitle / applySeriesDisplayTitle 인라인 처리 (OriginalTitleOverride 설정 기반)
- GetRecentProgress 응답에 SeriesDisplayTitle, SeriesIsBookmarked 필드 추가
- SeriesCard에서 볼륨(volumes)도 북마크 토글 가능하도록 확장 + 에러 알림 추가
- Volume 타입에 is_bookmarked 필드 추가

## 개선 사항

- N+1 library 조회 → FindAll batch 처리로 해소
- scanner 패키지 의존 → 인라인화 완료
- Volume 북마크 의도 → SeriesIsBookmarked 필드명 + 주석으로 명시
- is_bookmarked 런타임 방어 → ?? false 적용

## Known Issues / 후속 작업

- GetRecentProgress 기존 N+1 (series/chapter/volume) 조회는 별도 PR에서 batch 처리 예정
- Volume.is_bookmarked optional → required 타입 정리는 별도 PR에서 처리 예정
- SeriesCard 북마크 토글 시 낙관적 업데이트(optimistic update)는 의도적으로 미적용 상태 (API 성공 후 onStatusChange로 상위 재로딩)