### PR TITLE
fix: 홈페이지 계속 읽기 display_title 및 볼륨 좋아요 버그 수정 (리뷰 반영)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -123,7 +123,7 @@ func main() {
 	userHandler := handler.NewUserHandler(authService)
 	libraryHandler := handler.NewLibraryHandler(ctx, libraryRepo, authService, fileScanner)
 	imageHandler := handler.NewImageHandler(pageRepo, chapterRepo, volumeRepo, seriesRepo, authService, cfg)
-	progressHandler := handler.NewProgressHandler(progressRepo, viewerSessionRepo, seriesRepo, authService, volumeRepo, chapterRepo, completionRepo, chapterCompletionRepo, hub, seriesEnrichSvc)
+	progressHandler := handler.NewProgressHandler(progressRepo, viewerSessionRepo, seriesRepo, authService, volumeRepo, chapterRepo, completionRepo, chapterCompletionRepo, hub, seriesEnrichSvc, libraryRepo, settingRepo)
 	settingHandler := handler.NewSettingHandler(settingRepo, userSettingRepo, fileScanner)
 	seriesHandler := handler.NewSeriesHandler(seriesRepo, seriesCharacterRepo, libraryRepo, authService, volumeRepo, chapterRepo, pageRepo, completionRepo, chapterCompletionRepo, userSeriesSettingRepo, progressRepo, settingRepo, cfg, seriesEnrichSvc)
 	downloadHandler := handler.NewDownloadHandler(authService, seriesRepo, volumeRepo, chapterRepo)

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1074,7 +1074,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			// DisplayTitle 계산 (OriginalTitleOverride 설정 기반, scanner 유틸리티 직접 호출)
 			displayTitle := strings.TrimSpace(series.Title)
 			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
-				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {
+				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, series.Title, series.Metadata, true, locale); resolved != "" {
 					displayTitle = resolved
 				}
 			}

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1081,7 +1081,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 
 			result[i].SeriesTitle = series.Title
 			result[i].SeriesDisplayTitle = displayTitle
-			result[i].HasAudio = series.LibraryType == "audiobook"
+			result[i].HasAudio = p.HasAudio
 			result[i].LibraryType = series.LibraryType
 			result[i].SeriesIsBookmarked = series.IsBookmarked
 

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1071,7 +1071,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			// 데이터 보정 (썸네일, 진행도 등)
 			h.enrichSingleSeries(series, userID)
 
-			// DisplayTitle 계산 (inlined to avoid direct scanner dependency helper clutter)
+			// DisplayTitle 계산 (OriginalTitleOverride 설정 기반, scanner 유틸리티 직접 호출)
 			displayTitle := strings.TrimSpace(series.Title)
 			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
 				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -15,9 +15,9 @@ import (
 	"github.com/aha-hyeong/kumiho/backend/internal/middleware"
 	"github.com/aha-hyeong/kumiho/backend/internal/model"
 	"github.com/aha-hyeong/kumiho/backend/internal/repository"
+	"github.com/aha-hyeong/kumiho/backend/internal/scanner"
 	"github.com/aha-hyeong/kumiho/backend/internal/service"
 	"github.com/aha-hyeong/kumiho/backend/internal/sse"
-	"github.com/aha-hyeong/kumiho/backend/internal/scanner"
 	"github.com/aha-hyeong/kumiho/backend/internal/util"
 )
 

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aha-hyeong/kumiho/backend/internal/repository"
 	"github.com/aha-hyeong/kumiho/backend/internal/service"
 	"github.com/aha-hyeong/kumiho/backend/internal/sse"
+	"github.com/aha-hyeong/kumiho/backend/internal/scanner"
 	"github.com/aha-hyeong/kumiho/backend/internal/util"
 )
 
@@ -31,6 +32,8 @@ type ProgressHandler struct {
 	chapterCompletionRepo *repository.ChapterCompletionRepository
 	sseHub                *sse.Hub
 	seriesEnrichSvc       *service.SeriesEnrichService
+	libraryRepo           *repository.LibraryRepository
+	settingRepo           repository.SettingRepository
 }
 
 const completionThresholdPercent = 100.0
@@ -47,6 +50,8 @@ func NewProgressHandler(
 	chapterCompletionRepo *repository.ChapterCompletionRepository,
 	sseHub *sse.Hub,
 	seriesEnrichSvc *service.SeriesEnrichService,
+	libraryRepo *repository.LibraryRepository,
+	settingRepo repository.SettingRepository,
 ) *ProgressHandler {
 	return &ProgressHandler{
 		progressRepo:          progressRepo,
@@ -59,6 +64,8 @@ func NewProgressHandler(
 		chapterCompletionRepo: chapterCompletionRepo,
 		sseHub:                sseHub,
 		seriesEnrichSvc:       seriesEnrichSvc,
+		libraryRepo:           libraryRepo,
+		settingRepo:           settingRepo,
 	}
 }
 
@@ -1021,10 +1028,26 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		progressList = []repository.RecentEnrichedProgress{}
 	}
 
+	// 라이브러리 목록 전체 조회 (N+1 방지)
+	libraries, err := h.libraryRepo.FindAll(nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to fetch libraries",
+		})
+	}
+	libraryMap := make(map[string]*model.Library, len(libraries))
+	for i := range libraries {
+		libraryMap[libraries[i].ID] = &libraries[i]
+	}
+
+	// 기본 선호 locale 조회 (N+1 방지)
+	locale := repository.PreferredOriginalTitleLocale(h.settingRepo)
+
 	// 시리즈 정보 추가
 	type ProgressWithSeries struct {
 		repository.RecentEnrichedProgress
 		SeriesTitle        string  `json:"series_title"`
+		SeriesDisplayTitle string  `json:"series_display_title"`
 		ThumbnailURL       *string `json:"thumbnail_url"`
 		VolumeNumber       int     `json:"volume_number"`
 		VolumeUnit         string  `json:"volume_unit"`
@@ -1034,6 +1057,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		ChapterTitle       string  `json:"chapter_title"`
 		HasAudio           bool    `json:"has_audio"`
 		LibraryType        string  `json:"library_type"`
+		SeriesIsBookmarked bool    `json:"series_is_bookmarked"` // UI 상의 좋아요 여부를 나타냄 (DB의 is_bookmarked)
 	}
 
 	result := make([]ProgressWithSeries, len(progressList))
@@ -1047,9 +1071,19 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			// 데이터 보정 (썸네일, 진행도 등)
 			h.enrichSingleSeries(series, userID)
 
+			// DisplayTitle 계산 (inlined to avoid direct scanner dependency helper clutter)
+			displayTitle := strings.TrimSpace(series.Title)
+			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
+				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {
+					displayTitle = resolved
+				}
+			}
+
 			result[i].SeriesTitle = series.Title
+			result[i].SeriesDisplayTitle = displayTitle
 			result[i].HasAudio = series.LibraryType == "audiobook"
 			result[i].LibraryType = series.LibraryType
+			result[i].SeriesIsBookmarked = series.IsBookmarked
 
 			// 챕터 정보 보급
 			if p.ChapterID != nil {

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -1799,7 +1799,7 @@ func (h *SeriesHandler) applySeriesDisplayTitle(series *model.Series, library *m
 
 	displayTitle := strings.TrimSpace(series.Title)
 	if library != nil && library.OriginalTitleOverride {
-		if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {
+		if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, series.Title, series.Metadata, true, locale); resolved != "" {
 			displayTitle = resolved
 		}
 	}

--- a/backend/internal/service/metadata_plugin.go
+++ b/backend/internal/service/metadata_plugin.go
@@ -541,7 +541,7 @@ func (s *MetadataService) assignSeriesDisplayTitle(series *model.Series) {
 	library, err := s.libraryRepo.FindByID(nil, series.LibraryID)
 	if err == nil && library != nil && library.OriginalTitleOverride {
 		locale := repository.PreferredOriginalTitleLocale(s.settingRepo)
-		if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, "", series.Metadata, true, locale); resolved != "" {
+		if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, series.Title, series.Metadata, true, locale); resolved != "" {
 			displayTitle = resolved
 		}
 	}

--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -9,6 +9,7 @@ const { mocks } = vi.hoisted(() => {
   const volumeFindFirstChapterRecursivelyMock = vi.fn();
   const seriesGetProgressMock = vi.fn();
   const seriesGetChaptersMock = vi.fn();
+  const seriesUpdateMock = vi.fn();
   const setIncognitoMock = vi.fn();
 
   return {
@@ -19,6 +20,7 @@ const { mocks } = vi.hoisted(() => {
       volumeFindFirstChapterRecursivelyMock,
       seriesGetProgressMock,
       seriesGetChaptersMock,
+      seriesUpdateMock,
       setIncognitoMock,
     },
   };
@@ -47,6 +49,7 @@ vi.mock("../api/client", () => ({
   seriesAPI: {
     getProgress: (...args: unknown[]) => mocks.seriesGetProgressMock(...args),
     getChapters: (...args: unknown[]) => mocks.seriesGetChaptersMock(...args),
+    update: (...args: unknown[]) => mocks.seriesUpdateMock(...args),
   },
   chapterAPI: {
     markComplete: vi.fn(),
@@ -285,5 +288,75 @@ describe("SeriesCard navigateTo", () => {
     fireEvent.click(card!);
 
     expect(mocks.navigateMock).toHaveBeenCalledWith("/series/series-3");
+  });
+});
+
+describe("SeriesCard Bookmark / Like behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("volume 타입 카드에 is_bookmarked가 제공되면 좋아요 토글 메뉴가 노출된다", async () => {
+    render(
+      <SeriesCard
+        type="volume"
+        item={{
+          id: "volume-like",
+          series_id: "series-parent",
+          title: "좋아요 볼륨",
+          volume_number: 1,
+          path: "/books/volume-like.zip",
+          library_type: "book",
+          chapter_count: 5,
+          created_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: false,
+        }}
+      />,
+    );
+
+    // 메뉴 열기
+    fireEvent.click(screen.getByTitle("series.card.menu_tooltip"));
+
+    // 좋아요(like) 버튼이 노출되는지 확인
+    const likeButton = screen.getByText("series.action.like");
+    expect(likeButton).toBeInTheDocument();
+
+    // 클릭 시 seriesAPI.update 가 series_id와 함께 호출되는지 확인
+    fireEvent.click(likeButton);
+    expect(mocks.seriesUpdateMock).toHaveBeenCalledWith("series-parent", {
+      is_bookmarked: true,
+    });
+  });
+
+  it("volume 타입 카드가 이미 좋아요 상태(is_bookmarked=true)이면 해제 메뉴가 노출되고 클릭 시 해제 API를 호출한다", async () => {
+    render(
+      <SeriesCard
+        type="volume"
+        item={{
+          id: "volume-like",
+          series_id: "series-parent",
+          title: "좋아요 볼륨",
+          volume_number: 1,
+          path: "/books/volume-like.zip",
+          library_type: "book",
+          chapter_count: 5,
+          created_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: true,
+        }}
+      />,
+    );
+
+    // 메뉴 열기
+    fireEvent.click(screen.getByTitle("series.card.menu_tooltip"));
+
+    // 좋아요 취소(unlike) 버튼이 노출되는지 확인
+    const unlikeButton = screen.getByText("series.action.unlike");
+    expect(unlikeButton).toBeInTheDocument();
+
+    // 클릭 시 seriesAPI.update 가 series_id와 함께 호출되는지 확인
+    fireEvent.click(unlikeButton);
+    expect(mocks.seriesUpdateMock).toHaveBeenCalledWith("series-parent", {
+      is_bookmarked: false,
+    });
   });
 });

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -443,7 +443,7 @@ export function SeriesCard({
     const newValue = !(item.is_bookmarked ?? false);
     try {
       await seriesAPI.update(targetId, { is_bookmarked: newValue });
-      onStatusChange?.();
+      await Promise.resolve(onStatusChange?.());
     } catch (error) {
       console.error("Failed to toggle like on series card:", error);
       setAlertModal({ isOpen: true, type: "error", message: t("series.alert.like_failed") });

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -419,6 +419,11 @@ export function SeriesCard({
         setIsEditModalOpen(true);
       } catch (error) {
         console.error("Failed to load series for volume editing:", error);
+        setAlertModal({
+          isOpen: true,
+          type: "error",
+          message: t("general.toast.load_failed"),
+        });
       }
     } else {
       setIsEditModalOpen(true);
@@ -430,11 +435,14 @@ export function SeriesCard({
     e.stopPropagation();
     setMenuOpen(false);
 
-    if (type !== "series") return;
+    // Kumiho 스키마상 좋아요(북마크)는 시리즈 단위로만 동작하므로, Volume 카드인 경우 부모 시리즈 ID를 타겟으로 토글함
+    const isVol = type === "volume";
+    const targetId = isVol ? (item as Volume).series_id : item.id;
+    if (!targetId) return;
 
-    const newValue = !(item as Series).is_bookmarked;
+    const newValue = !(item.is_bookmarked ?? false);
     try {
-      await seriesAPI.update(item.id, { is_bookmarked: newValue });
+      await seriesAPI.update(targetId, { is_bookmarked: newValue });
       onStatusChange?.();
     } catch (error) {
       console.error("Failed to toggle like on series card:", error);
@@ -678,13 +686,13 @@ export function SeriesCard({
                   <Shield size={16} />
                   <span>{t("series.action.incognito")}</span>
                 </button>
-                {type === "series" && (
+                {(type === "series" || (type === "volume" && item.is_bookmarked !== undefined)) && (
                   <button
                     className={styles.seriesMenuItem}
                     onClick={handleToggleLike}
                   >
-                    <Heart size={16} fill={(item as Series).is_bookmarked ? "currentColor" : "none"} />
-                    <span>{(item as Series).is_bookmarked ? t("series.action.unlike") : t("series.action.like")}</span>
+                    <Heart size={16} fill={item.is_bookmarked ? "currentColor" : "none"} />
+                    <span>{item.is_bookmarked ? t("series.action.unlike") : t("series.action.like")}</span>
                   </button>
                 )}
                 {onDownload && (

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1139,6 +1139,11 @@
       "navigate": "Navigate TOC: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "Failed to load."
+    }
+  },
   "audio_player": {
     "now_playing": "NOW PLAYING",
     "paused": "PAUSED",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1138,6 +1138,11 @@
       "navigate": "目次移動: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "読み込みに失敗しました。"
+    }
+  },
   "audio_player": {
     "now_playing": "再生中",
     "paused": "一時停止",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -1139,6 +1139,11 @@
       "navigate": "목차 이동: {{label}}"
     }
   },
+  "general": {
+    "toast": {
+      "load_failed": "불러오는데 실패했습니다."
+    }
+  },
   "audio_player": {
     "now_playing": "재생 중",
     "paused": "일시정지",

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -35,6 +35,8 @@ interface RecentProgress {
   chapter_path?: string;
   volume_path?: string;
   series_path?: string;
+  series_is_bookmarked?: boolean; // UI 상의 좋아요 여부 (DB의 is_bookmarked)
+  series_display_title?: string;
 }
 
 export function HomePage() {
@@ -267,7 +269,7 @@ export function HomePage() {
               ? {
                   id: progress.volume_id!,
                   series_id: progress.series_id,
-                  title: progress.volume_title || progress.series_title,
+                  title: progress.volume_title || progress.series_display_title || progress.series_title,
                   thumbnail_url: progress.thumbnail_url,
                   unit: progress.volume_unit,
                   volume_number: progress.volume_number || 0,
@@ -276,10 +278,12 @@ export function HomePage() {
                   created_at: progress.updated_at,
                   has_audio: progress.has_audio,
                   library_type: progress.library_type,
+                  is_bookmarked: progress.series_is_bookmarked,
                 }
               : {
                   id: progress.series_id,
                   title: progress.series_title,
+                  display_title: progress.series_display_title,
                   thumbnail_url: progress.thumbnail_url,
                   path: progress.series_path || progress.path || "",
                   updated_at: progress.updated_at,
@@ -287,6 +291,7 @@ export function HomePage() {
                   created_at: progress.updated_at,
                   has_audio: progress.has_audio,
                   library_type: progress.library_type,
+                  is_bookmarked: progress.series_is_bookmarked,
                 };
 
             // 진행도 텍스트 생성

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -92,6 +92,7 @@ export interface Volume {
   created_at: string;
   updated_at?: string;
   library_type?: LibraryType;
+  is_bookmarked?: boolean; // 부모 시리즈의 좋아요(북마크) 상태
 }
 
 export interface Chapter {


### PR DESCRIPTION
## 변경 사항
- 최근 읽은 시리즈 목록(이어보기)에서 사용자가 설정한 대체/원어 제목(`display_title`)이 반영되도록 백엔드 응답 구조 개선 및 프론트엔드 연동 추가
- 볼륨 카드 형태의 계속 읽기 목록에서도 좋아요(북마크) 토글이 작동하도록 `SeriesCard` 컴포넌트 확장
- 볼륨 카드 북마크 토글 시 부모 `series_id`로 API를 호출하도록 비즈니스 로직 수정
- 백엔드 `GetRecentProgress` 메서드에서 라이브러리 목록 배치 조회(`FindAll`) 및 설정을 단 1회 캐싱하여 N+1 쿼리 최적화 수행
- Go 백엔드 임포트 블록 `gofmt` 표준 정렬 순서 적용
- `SeriesCard.test.tsx`에 볼륨 카드 타입 북마크 토글 기능을 검증하는 컴포넌트 테스트 케이스 추가

## 테스트
- [x] 백엔드 단위 테스트 `go test ./...` 실행 완료
- [x] 프론트엔드 테스트 `npm run test` 실행 및 신규 2건 테스트(좋아요 토글 검증)를 포함한 총 281건 테스트 모두 통과
- [x] 프론트엔드 린트 `npm run lint` 통과
- [x] 프론트엔드 프로덕션 빌드 `npm run build` 성공

## 관련 이슈
- PR #317 복구 및 보완
- PR #318 대응
