### PR TITLE
perf: batch 조회로 RecentProgress N+1 쿼리 최적화

### DIFF
--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1016,6 +1016,11 @@ func (h *ProgressHandler) GetAllProgress(c *fiber.Ctx) error {
 func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
 	limit := c.QueryInt("limit", 10)
+	if limit <= 0 {
+		limit = 10
+	} else if limit > 100 {
+		limit = 100
+	}
 
 	progressList, err := h.progressRepo.FindRecentEnrichedByUser(nil, userID, limit)
 	if err != nil {
@@ -1024,8 +1029,10 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		})
 	}
 
-	if progressList == nil {
-		progressList = []repository.RecentEnrichedProgress{}
+	if len(progressList) == 0 {
+		return c.JSON(fiber.Map{
+			"recent_progress": []any{},
+		})
 	}
 
 	// 라이브러리 목록 전체 조회 (N+1 방지)

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1031,13 +1031,13 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 	// 라이브러리 목록 전체 조회 (N+1 방지)
 	libraries, err := h.libraryRepo.FindAll(nil)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "failed to fetch libraries",
-		})
+		log.Printf("[GetRecentProgress] failed to fetch libraries: %v", err)
 	}
-	libraryMap := make(map[string]*model.Library, len(libraries))
-	for i := range libraries {
-		libraryMap[libraries[i].ID] = &libraries[i]
+	libraryMap := make(map[string]*model.Library)
+	if err == nil {
+		for i := range libraries {
+			libraryMap[libraries[i].ID] = &libraries[i]
+		}
 	}
 
 	// 기본 선호 locale 조회 (N+1 방지)
@@ -1148,6 +1148,11 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 	for i, p := range progressList {
 		result[i] = ProgressWithSeries{
 			RecentEnrichedProgress: p,
+			SeriesTitle:            p.SeriesTitle,
+			VolumeTitle:            p.VolumeTitle,
+			ChapterTitle:           p.ChapterTitle,
+			HasAudio:               p.HasAudio || p.LibraryType == "audiobook",
+			LibraryType:            p.LibraryType,
 		}
 
 		series := seriesMap[p.SeriesID]
@@ -1162,7 +1167,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 
 			result[i].SeriesTitle = series.Title
 			result[i].SeriesDisplayTitle = displayTitle
-			result[i].HasAudio = p.HasAudio
+			result[i].HasAudio = p.HasAudio || series.LibraryType == "audiobook"
 			result[i].LibraryType = series.LibraryType
 			result[i].SeriesIsBookmarked = series.IsBookmarked
 
@@ -1206,6 +1211,7 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 					result[i].VolumeUnit = volume.Unit
 					result[i].VolumeTitle = volume.Title
 					result[i].VolumeChapterCount = volumeChapterCounts[volume.ID]
+					result[i].HasAudio = volume.HasAudio || series.LibraryType == "audiobook"
 
 					if volume.ThumbnailPath != nil && *volume.ThumbnailPath != "" {
 						url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, volume.UpdatedAt)

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1011,7 +1011,7 @@ func (h *ProgressHandler) GetAllProgress(c *fiber.Ctx) error {
 	})
 }
 
-// GetRecentProgress 최근 읽기 진행도 (이어보기 목록)
+// GetRecentProgress 최근 읽기 진행도 (이어보기 목록, N+1 쿼리 최적화 및 안정성 보완)
 // GET /api/v1/reading-progress/recent
 func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -1060,18 +1060,99 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 		SeriesIsBookmarked bool    `json:"series_is_bookmarked"` // UI 상의 좋아요 여부를 나타냄 (DB의 is_bookmarked)
 	}
 
+	// 1. 유니크 ID 목록 추출
+	seriesIDsMap := make(map[string]bool)
+	chapterIDsMap := make(map[string]bool)
+	volumeIDsMap := make(map[string]bool)
+
+	for _, p := range progressList {
+		if p.SeriesID != "" {
+			seriesIDsMap[p.SeriesID] = true
+		}
+		if p.ChapterID != nil && *p.ChapterID != "" {
+			chapterIDsMap[*p.ChapterID] = true
+		}
+		if p.VolumeID != nil && *p.VolumeID != "" {
+			volumeIDsMap[*p.VolumeID] = true
+		}
+	}
+
+	var seriesIDs []string
+	for id := range seriesIDsMap {
+		seriesIDs = append(seriesIDs, id)
+	}
+	var chapterIDs []string
+	for id := range chapterIDsMap {
+		chapterIDs = append(chapterIDs, id)
+	}
+	var volumeIDs []string
+	for id := range volumeIDsMap {
+		volumeIDs = append(volumeIDs, id)
+	}
+
+	// 2. 시리즈 일괄 조회
+	seriesList, err := h.seriesRepo.FindByIDs(nil, seriesIDs, userID)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch series: %v", err)
+	}
+	seriesMap := make(map[string]*model.Series)
+	for i := range seriesList {
+		seriesMap[seriesList[i].ID] = &seriesList[i]
+	}
+
+	// 3. 챕터 일괄 조회
+	chapterList, err := h.chapterRepo.FindByIDs(nil, chapterIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch chapters: %v", err)
+	}
+	chaptersMap := make(map[string]*model.Chapter)
+	for i := range chapterList {
+		chaptersMap[chapterList[i].ID] = &chapterList[i]
+	}
+
+	// 4. 볼륨 일괄 조회
+	volumeList, err := h.volumeRepo.FindByIDs(nil, volumeIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch volumes: %v", err)
+	}
+	volumesMap := make(map[string]*model.Volume)
+	for i := range volumeList {
+		volumesMap[volumeList[i].ID] = &volumeList[i]
+	}
+
+	// 5. 볼륨별 챕터 개수 일괄 조회
+	volumeChapterCounts, err := h.chapterRepo.CountByVolumeIDs(nil, volumeIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch count chapters by volume: %v", err)
+	}
+
+	// 6. 볼륨의 첫 번째 페이지 ID 일괄 조회 (볼륨 썸네일 Fallback 용)
+	volumeFirstPageIDs, err := h.volumeRepo.GetFirstPageIDsBatch(nil, volumeIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch first page IDs for volumes: %v", err)
+	}
+
+	// 7. 시리즈의 첫 번째 페이지 ID 일괄 조회 (시리즈 썸네일 Fallback 용)
+	seriesFirstPageIDs, err := h.seriesRepo.GetFirstPageIDsBatch(nil, seriesIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch first page IDs for series: %v", err)
+	}
+
+	// 8. 시리즈의 첫 번째 볼륨 일괄 조회 (시리즈 썸네일 Fallback Level 2 용)
+	seriesFirstVolumes, err := h.volumeRepo.GetFirstVolumesBatch(nil, seriesIDs)
+	if err != nil {
+		log.Printf("[GetRecentProgress] failed to batch fetch first volumes for series: %v", err)
+	}
+
 	result := make([]ProgressWithSeries, len(progressList))
 	for i, p := range progressList {
 		result[i] = ProgressWithSeries{
 			RecentEnrichedProgress: p,
 		}
 
-		// 시리즈 정보 (경로 정보는 이미 Repository에서 Join으로 가져옴)
-		if series, _ := h.seriesRepo.FindByID(nil, p.SeriesID, userID); series != nil {
-			// 데이터 보정 (썸네일, 진행도 등)
-			h.enrichSingleSeries(series, userID)
-
-			// DisplayTitle 계산 (OriginalTitleOverride 설정 기반, scanner 유틸리티 직접 호출)
+		series := seriesMap[p.SeriesID]
+		if series != nil {
+			// DisplayTitle 계산 (OriginalTitleOverride 설정 기반)
 			displayTitle := strings.TrimSpace(series.Title)
 			if library := libraryMap[series.LibraryID]; library != nil && library.OriginalTitleOverride {
 				if resolved := scanner.ResolveSeriesTitleFromOriginalTitle(series.Path, series.Title, series.Metadata, true, locale); resolved != "" {
@@ -1085,9 +1166,27 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			result[i].LibraryType = series.LibraryType
 			result[i].SeriesIsBookmarked = series.IsBookmarked
 
-			// 챕터 정보 보급
+			// 배치 쿼리 결과를 바탕으로 시리즈 썸네일 URL 빌드
+			var seriesThumbnailURL *string
+			if series.ThumbnailPath != nil && *series.ThumbnailPath != "" {
+				url := util.BuildSeriesThumbnailURL(series.ID, series.ThumbnailPath, series.UpdatedAt)
+				seriesThumbnailURL = &url
+			} else {
+				if pageID := seriesFirstPageIDs[series.ID]; pageID != "" {
+					url := fmt.Sprintf("/api/v1/pages/%s/image?width=400", pageID)
+					seriesThumbnailURL = &url
+				} else {
+					if vol := seriesFirstVolumes[series.ID]; vol != nil && vol.ThumbnailPath != nil && *vol.ThumbnailPath != "" {
+						url := util.BuildVolumeThumbnailURL(vol.ID, vol.ThumbnailPath, vol.UpdatedAt)
+						seriesThumbnailURL = &url
+					}
+				}
+			}
+			series.ThumbnailURL = seriesThumbnailURL
+
+			// 챕터 정보 설정
 			if p.ChapterID != nil {
-				if c, _ := h.chapterRepo.FindByID(nil, *p.ChapterID); c != nil {
+				if c := chaptersMap[*p.ChapterID]; c != nil {
 					result[i].ChapterNumber = c.ChapterNumber
 					result[i].ChapterTitle = c.Title
 				}
@@ -1099,24 +1198,20 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 				targetVolumeID = *p.VolumeID
 			}
 
-			// 볼륨 정보 및 썸네일 설정
+			// 볼륨 정보 및 볼륨 썸네일 설정
 			if targetVolumeID != "" {
-				if volume, _ := h.volumeRepo.FindByID(nil, targetVolumeID); volume != nil {
+				if volume := volumesMap[targetVolumeID]; volume != nil {
 					result[i].VolumeID = &volume.ID
 					result[i].VolumeNumber = volume.VolumeNumber
 					result[i].VolumeUnit = volume.Unit
 					result[i].VolumeTitle = volume.Title
-
-					if count, err := h.chapterRepo.CountByVolumeID(nil, volume.ID); err == nil {
-						result[i].VolumeChapterCount = count
-					}
+					result[i].VolumeChapterCount = volumeChapterCounts[volume.ID]
 
 					if volume.ThumbnailPath != nil && *volume.ThumbnailPath != "" {
 						url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, volume.UpdatedAt)
 						result[i].ThumbnailURL = &url
 					} else {
-						pageID, err := h.volumeRepo.GetFirstPageID(nil, volume.ID)
-						if err == nil && pageID != "" {
+						if pageID := volumeFirstPageIDs[volume.ID]; pageID != "" {
 							url := fmt.Sprintf("/api/v1/pages/%s/image?width=400", pageID)
 							result[i].ThumbnailURL = &url
 						}
@@ -1126,13 +1221,12 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 
 			// 썸네일 fallback
 			if result[i].ThumbnailURL == nil || *result[i].ThumbnailURL == "" {
-				// 1. 이미 보정된 시리즈 썸네일이 있으면 사용 (EPUB 등 커버 이미지)
+				// 1. 이미 보정된 시리즈 썸네일이 있으면 사용
 				if series.ThumbnailURL != nil && *series.ThumbnailURL != "" {
 					result[i].ThumbnailURL = series.ThumbnailURL
 				} else {
 					// 2. 없으면 첫 번째 페이지 이미지 시도
-					pageID, err := h.seriesRepo.GetFirstPageID(nil, series.ID)
-					if err == nil && pageID != "" {
+					if pageID := seriesFirstPageIDs[series.ID]; pageID != "" {
 						url := fmt.Sprintf("/api/v1/pages/%s/image?width=400", pageID)
 						result[i].ThumbnailURL = &url
 					}

--- a/backend/internal/handler/progress_handler.go
+++ b/backend/internal/handler/progress_handler.go
@@ -39,6 +39,11 @@ type ProgressHandler struct {
 const completionThresholdPercent = 100.0
 const viewerSessionLeaseTTL = 90 * time.Second
 
+const (
+	defaultRecentProgressLimit = 10
+	maxRecentProgressLimit     = 100
+)
+
 func NewProgressHandler(
 	progressRepo *repository.ReadingProgressRepository,
 	viewerSessionRepo *repository.ViewerSessionRepository,
@@ -1015,11 +1020,11 @@ func (h *ProgressHandler) GetAllProgress(c *fiber.Ctx) error {
 // GET /api/v1/reading-progress/recent
 func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
-	limit := c.QueryInt("limit", 10)
+	limit := c.QueryInt("limit", defaultRecentProgressLimit)
 	if limit <= 0 {
-		limit = 10
-	} else if limit > 100 {
-		limit = 100
+		limit = defaultRecentProgressLimit
+	} else if limit > maxRecentProgressLimit {
+		limit = maxRecentProgressLimit
 	}
 
 	progressList, err := h.progressRepo.FindRecentEnrichedByUser(nil, userID, limit)
@@ -1158,7 +1163,6 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 			SeriesTitle:            p.SeriesTitle,
 			VolumeTitle:            p.VolumeTitle,
 			ChapterTitle:           p.ChapterTitle,
-			HasAudio:               p.HasAudio || p.LibraryType == "audiobook",
 			LibraryType:            p.LibraryType,
 		}
 
@@ -1174,9 +1178,11 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 
 			result[i].SeriesTitle = series.Title
 			result[i].SeriesDisplayTitle = displayTitle
-			result[i].HasAudio = p.HasAudio || series.LibraryType == "audiobook"
 			result[i].LibraryType = series.LibraryType
 			result[i].SeriesIsBookmarked = series.IsBookmarked
+
+			// HasAudio는 volume 기준으로 결정하되, volume이 없으면 series 기준
+			hasAudio := p.HasAudio || series.LibraryType == "audiobook"
 
 			// 배치 쿼리 결과를 바탕으로 시리즈 썸네일 URL 빌드
 			var seriesThumbnailURL *string
@@ -1218,7 +1224,8 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 					result[i].VolumeUnit = volume.Unit
 					result[i].VolumeTitle = volume.Title
 					result[i].VolumeChapterCount = volumeChapterCounts[volume.ID]
-					result[i].HasAudio = volume.HasAudio || series.LibraryType == "audiobook"
+					// volume이 있으면 volume의 hasAudio 우선 적용
+					hasAudio = volume.HasAudio || series.LibraryType == "audiobook"
 
 					if volume.ThumbnailPath != nil && *volume.ThumbnailPath != "" {
 						url := util.BuildVolumeThumbnailURL(volume.ID, volume.ThumbnailPath, volume.UpdatedAt)
@@ -1231,6 +1238,9 @@ func (h *ProgressHandler) GetRecentProgress(c *fiber.Ctx) error {
 					}
 				}
 			}
+
+			// 최종 HasAudio 적용
+			result[i].HasAudio = hasAudio
 
 			// 썸네일 fallback
 			if result[i].ThumbnailURL == nil || *result[i].ThumbnailURL == "" {

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -52,6 +52,16 @@ func (h *SeriesHandler) assignVolumeThumbnailURL(volume *model.Volume) {
 	volume.ThumbnailURL = &url
 }
 
+// enrichVolumeBookmark 볼륨에 부모 시리즈의 북마크 상태를 전파
+func (h *SeriesHandler) enrichVolumeBookmark(volume *model.Volume, userID string) {
+	if volume == nil {
+		return
+	}
+	if series, err := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); err == nil && series != nil {
+		volume.IsBookmarked = series.IsBookmarked
+	}
+}
+
 func NewSeriesHandler(
 	seriesRepo *repository.SeriesRepository,
 	seriesCharacterRepo *repository.SeriesCharacterRepository,
@@ -499,9 +509,7 @@ func (h *SeriesHandler) UpdateVolume(c *fiber.Ctx) error {
 	}
 
 	userID := middleware.GetUserID(c)
-	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
-		volume.IsBookmarked = series.IsBookmarked
-	}
+	h.enrichVolumeBookmark(volume, userID)
 
 	// 썸네일 URL 설정 (응답용)
 	h.assignVolumeThumbnailURL(volume)
@@ -625,9 +633,7 @@ func (h *SeriesHandler) UploadVolumeThumbnail(c *fiber.Ctx) error {
 	}
 
 	userID := middleware.GetUserID(c)
-	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
-		volume.IsBookmarked = series.IsBookmarked
-	}
+	h.enrichVolumeBookmark(volume, userID)
 
 	// 썸네일 URL 업데이트
 	h.assignVolumeThumbnailURL(volume)
@@ -754,9 +760,7 @@ func (h *SeriesHandler) UploadVolumeThumbnailFromURL(c *fiber.Ctx) error {
 	}
 
 	userID := middleware.GetUserID(c)
-	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
-		volume.IsBookmarked = series.IsBookmarked
-	}
+	h.enrichVolumeBookmark(volume, userID)
 
 	h.assignVolumeThumbnailURL(volume)
 
@@ -806,9 +810,7 @@ func (h *SeriesHandler) DeleteVolumeThumbnail(c *fiber.Ctx) error {
 	}
 
 	userID := middleware.GetUserID(c)
-	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
-		volume.IsBookmarked = series.IsBookmarked
-	}
+	h.enrichVolumeBookmark(volume, userID)
 
 	h.assignVolumeThumbnailURL(volume)
 
@@ -1271,8 +1273,8 @@ func (h *SeriesHandler) GetVolume(c *fiber.Ctx) error {
 		log.Printf("failed to fetch series %s for volume %s: %v", volume.SeriesID, volume.ID, seriesErr)
 	} else if series != nil {
 		volume.LibraryType = series.LibraryType
-		volume.IsBookmarked = series.IsBookmarked
 	}
+	h.enrichVolumeBookmark(volume, userID)
 
 	// 실제로 제공 가능한 경우에만 썸네일 URL 설정
 	h.assignVolumeThumbnailURL(volume)

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -498,6 +498,11 @@ func (h *SeriesHandler) UpdateVolume(c *fiber.Ctx) error {
 		})
 	}
 
+	userID := middleware.GetUserID(c)
+	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
+		volume.IsBookmarked = series.IsBookmarked
+	}
+
 	// 썸네일 URL 설정 (응답용)
 	h.assignVolumeThumbnailURL(volume)
 
@@ -617,6 +622,11 @@ func (h *SeriesHandler) UploadVolumeThumbnail(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume thumbnail path",
 		})
+	}
+
+	userID := middleware.GetUserID(c)
+	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
+		volume.IsBookmarked = series.IsBookmarked
 	}
 
 	// 썸네일 URL 업데이트
@@ -743,6 +753,11 @@ func (h *SeriesHandler) UploadVolumeThumbnailFromURL(c *fiber.Ctx) error {
 		})
 	}
 
+	userID := middleware.GetUserID(c)
+	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
+		volume.IsBookmarked = series.IsBookmarked
+	}
+
 	h.assignVolumeThumbnailURL(volume)
 
 	return c.JSON(volume)
@@ -788,6 +803,11 @@ func (h *SeriesHandler) DeleteVolumeThumbnail(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to update volume",
 		})
+	}
+
+	userID := middleware.GetUserID(c)
+	if series, seriesErr := h.seriesRepo.FindByID(nil, volume.SeriesID, userID); seriesErr == nil && series != nil {
+		volume.IsBookmarked = series.IsBookmarked
 	}
 
 	h.assignVolumeThumbnailURL(volume)
@@ -1182,6 +1202,9 @@ func (h *SeriesHandler) ListVolumes(c *fiber.Ctx) error {
 	for i := range volumes {
 		vID := volumes[i].ID
 		volumes[i].LibraryType = libraryType
+		if series != nil {
+			volumes[i].IsBookmarked = series.IsBookmarked
+		}
 
 		// 하위 볼륨 개수 조회 (볼륨 썸네일/플레이스홀더 fallback 판단에도 사용)
 		if subVolCount, err := h.volumeRepo.CountByParentID(nil, vID); err == nil {
@@ -1248,6 +1271,7 @@ func (h *SeriesHandler) GetVolume(c *fiber.Ctx) error {
 		log.Printf("failed to fetch series %s for volume %s: %v", volume.SeriesID, volume.ID, seriesErr)
 	} else if series != nil {
 		volume.LibraryType = series.LibraryType
+		volume.IsBookmarked = series.IsBookmarked
 	}
 
 	// 실제로 제공 가능한 경우에만 썸네일 URL 설정

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -119,6 +119,7 @@ type Volume struct {
 	ID              string    `json:"id"`
 	SeriesID        string    `json:"series_id"`
 	LibraryType     string    `json:"library_type,omitempty" db:"-"`
+	IsBookmarked    bool      `json:"is_bookmarked" db:"-"`
 	Title           string    `json:"title"`
 	VolumeNumber    int       `json:"volume_number"`
 	Path            string    `json:"path"`

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -119,7 +119,7 @@ type Volume struct {
 	ID              string    `json:"id"`
 	SeriesID        string    `json:"series_id"`
 	LibraryType     string    `json:"library_type,omitempty" db:"-"`
-	IsBookmarked    bool      `json:"is_bookmarked" db:"-"`
+	IsBookmarked    bool      `json:"is_bookmarked" db:"-"` // 시리즈의 북마크 상태를 볼륨 응답에 전파하기 위한 UI용 가상 필드 (DB 비매핑)
 	Title           string    `json:"title"`
 	VolumeNumber    int       `json:"volume_number"`
 	Path            string    `json:"path"`

--- a/backend/internal/repository/chapter_repository.go
+++ b/backend/internal/repository/chapter_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/aha-hyeong/kumiho/backend/internal/database"
@@ -262,4 +263,77 @@ func (r *ChapterRepository) IsAllChaptersRead(db database.Queryer, userID string
 	}
 
 	return remainingCount == 0, nil
+}
+
+// FindByIDs 여러 챕터 ID 목록으로 챕터 상세 조회
+func (r *ChapterRepository) FindByIDs(db database.Queryer, ids []string) ([]model.Chapter, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := "SELECT id, volume_id, title, chapter_number, path, page_count, total_bytes, total_positions, has_audio, duration, created_at, updated_at FROM chapters WHERE id IN (" + strings.Join(placeholders, ",") + ")"
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var chapters []model.Chapter
+	for rows.Next() {
+		var c model.Chapter
+		if err := rows.Scan(&c.ID, &c.VolumeID, &c.Title, &c.ChapterNumber, &c.Path, &c.PageCount, &c.TotalBytes, &c.TotalPositions, &c.HasAudio, &c.Duration, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		chapters = append(chapters, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return chapters, nil
+}
+
+// CountByVolumeIDs 여러 볼륨 ID 목록으로 각 볼륨의 챕터 개수를 배치 조회
+func (r *ChapterRepository) CountByVolumeIDs(db database.Queryer, volumeIDs []string) (map[string]int, error) {
+	if len(volumeIDs) == 0 {
+		return make(map[string]int), nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(volumeIDs))
+	args := make([]interface{}, len(volumeIDs))
+	for i, id := range volumeIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := "SELECT volume_id, COUNT(*) FROM chapters WHERE volume_id IN (" + strings.Join(placeholders, ",") + ") GROUP BY volume_id"
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	results := make(map[string]int)
+	for rows.Next() {
+		var volumeID string
+		var count int
+		if err := rows.Scan(&volumeID, &count); err != nil {
+			return nil, err
+		}
+		results[volumeID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }

--- a/backend/internal/repository/series_repository.go
+++ b/backend/internal/repository/series_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -1033,6 +1034,166 @@ func (r *SeriesRepository) GetExtensionsByIDs(db database.Queryer, ids []string)
 			return nil, err
 		}
 		results[id] = ext
+	}
+	return results, nil
+}
+
+// FindByIDs 여러 시리즈 ID 목록으로 시리즈 상세 조회 (사용자별 북마크 정보 포함)
+func (r *SeriesRepository) FindByIDs(db database.Queryer, ids []string, userID string) ([]model.Series, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, 0, len(ids)+1)
+	args = append(args, userID) // for ub.user_id = ?
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT s.id, s.library_id, s.title, s.path, s.thumbnail_path, s.extension, s.created_at, s.updated_at, s.last_content_updated_at,
+		        sm.description, sm.description_translated, (ub.series_id IS NOT NULL) AS is_bookmarked, sm.status, sm.authors, sm.tags, sm.publication_year,
+				sm.original_title, sm.original_titles, sm.publisher, sm.published_at, sm.isbn,
+				l.library_type
+		 FROM series s
+		 JOIN libraries l ON s.library_id = l.id
+		 LEFT JOIN series_metadata sm ON s.id = sm.series_id
+		 LEFT JOIN user_bookmarks ub ON s.id = ub.series_id AND ub.user_id = ?
+		 WHERE s.id IN (%s)
+	`, strings.Join(placeholders, ","))
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var seriesList []model.Series
+	for rows.Next() {
+		var s model.Series
+		var m model.SeriesMetadata
+		var thumbnail, ext sql.NullString
+		var lastContentUpdatedAt sql.NullTime
+		var desc, descTranslated, status, authors, tags, pubYear, originalTitle, originalTitles, publisher, publishedAt, isbn sql.NullString
+		var isBookmarked sql.NullBool
+		var libraryType sql.NullString
+
+		err := rows.Scan(
+			&s.ID, &s.LibraryID, &s.Title, &s.Path, &thumbnail, &ext, &s.CreatedAt, &s.UpdatedAt, &lastContentUpdatedAt,
+			&desc, &descTranslated, &isBookmarked, &status, &authors, &tags, &pubYear, &originalTitle, &originalTitles, &publisher, &publishedAt, &isbn,
+			&libraryType,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if thumbnail.Valid {
+			s.ThumbnailPath = &thumbnail.String
+		}
+		if ext.Valid {
+			s.Extension = ext.String
+		}
+		s.LibraryType = normalizeLibraryType(libraryType)
+		if lastContentUpdatedAt.Valid {
+			s.LastContentUpdatedAt = lastContentUpdatedAt.Time
+		} else {
+			s.LastContentUpdatedAt = s.UpdatedAt
+		}
+
+		m.SeriesID = s.ID
+		if desc.Valid {
+			s.Description = desc.String
+			m.Description = desc.String
+		}
+		if descTranslated.Valid {
+			m.DescriptionTranslated = descTranslated.String
+		}
+		if isBookmarked.Valid {
+			s.IsBookmarked = isBookmarked.Bool
+			m.IsBookmarked = isBookmarked.Bool
+		}
+		if status.Valid {
+			m.Status = status.String
+		}
+		if authors.Valid {
+			m.Authors = authors.String
+		}
+		if tags.Valid {
+			m.Tags = tags.String
+		}
+		if pubYear.Valid {
+			m.PublicationYear = pubYear.String
+		}
+		if originalTitle.Valid {
+			m.OriginalTitle = originalTitle.String
+		}
+		if originalTitles.Valid {
+			m.OriginalTitles = originalTitles.String
+		}
+		if publisher.Valid {
+			m.Publisher = publisher.String
+		}
+		if publishedAt.Valid {
+			m.PublishedAt = publishedAt.String
+		}
+		if isbn.Valid {
+			m.ISBN = isbn.String
+		}
+		s.Metadata = &m
+
+		seriesList = append(seriesList, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return seriesList, nil
+}
+
+// GetFirstPageIDsBatch 여러 시리즈의 첫 번째 페이지 ID 배치 조회 (썸네일용)
+func (r *SeriesRepository) GetFirstPageIDsBatch(db database.Queryer, seriesIDs []string) (map[string]string, error) {
+	if len(seriesIDs) == 0 {
+		return make(map[string]string), nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(seriesIDs))
+	args := make([]interface{}, len(seriesIDs))
+	for i, id := range seriesIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		WITH RankedPages AS (
+			SELECT v.series_id, p.id AS page_id,
+			       ROW_NUMBER() OVER (PARTITION BY v.series_id ORDER BY v.volume_number, c.chapter_number, p.page_number) AS rn
+			FROM pages p
+			JOIN chapters c ON p.chapter_id = c.id
+			JOIN volumes v ON c.volume_id = v.id
+			WHERE v.series_id IN (%s)
+		)
+		SELECT series_id, page_id FROM RankedPages WHERE rn = 1
+	`, strings.Join(placeholders, ","))
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	results := make(map[string]string)
+	for rows.Next() {
+		var seriesID, pageID string
+		if err := rows.Scan(&seriesID, &pageID); err != nil {
+			return nil, err
+		}
+		results[seriesID] = pageID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return results, nil
 }

--- a/backend/internal/repository/volume_repository.go
+++ b/backend/internal/repository/volume_repository.go
@@ -949,3 +949,184 @@ func (r *VolumeRepository) GetProgressPercentBatch(db database.Queryer, userID s
 	}
 	return result, nil
 }
+
+// FindByIDs 여러 볼륨 ID 목록으로 볼륨 상세 조회
+func (r *VolumeRepository) FindByIDs(db database.Queryer, ids []string) ([]model.Volume, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(
+		`SELECT id, series_id, title, volume_number, path, thumbnail_path, has_audio, unit, chapter_count, parent_id, description, authors, publication_year, extension, created_at, updated_at FROM volumes WHERE id IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var volumes []model.Volume
+	for rows.Next() {
+		var v model.Volume
+		var thumbnail, unit, parentID sql.NullString
+		var description, authors, pubYear, extension sql.NullString
+
+		err := rows.Scan(&v.ID, &v.SeriesID, &v.Title, &v.VolumeNumber, &v.Path, &thumbnail, &v.HasAudio, &unit, &v.ChapterCount, &parentID, &description, &authors, &pubYear, &extension, &v.CreatedAt, &v.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+
+		if thumbnail.Valid {
+			v.ThumbnailPath = &thumbnail.String
+		}
+		if unit.Valid {
+			v.Unit = unit.String
+		}
+		if parentID.Valid {
+			v.ParentID = &parentID.String
+		}
+		if description.Valid {
+			v.Description = description.String
+		}
+		if authors.Valid {
+			v.Authors = authors.String
+		}
+		if pubYear.Valid {
+			v.PublicationYear = pubYear.String
+		}
+		if extension.Valid {
+			v.Extension = extension.String
+		}
+		volumes = append(volumes, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return volumes, nil
+}
+
+// GetFirstPageIDsBatch 여러 볼륨의 첫 번째 페이지 ID 배치 조회 (썸네일용)
+func (r *VolumeRepository) GetFirstPageIDsBatch(db database.Queryer, volumeIDs []string) (map[string]string, error) {
+	if len(volumeIDs) == 0 {
+		return make(map[string]string), nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(volumeIDs))
+	args := make([]interface{}, len(volumeIDs))
+	for i, id := range volumeIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		WITH RankedPages AS (
+			SELECT c.volume_id, p.id AS page_id,
+			       ROW_NUMBER() OVER (PARTITION BY c.volume_id ORDER BY c.chapter_number, p.page_number) AS rn
+			FROM pages p
+			JOIN chapters c ON p.chapter_id = c.id
+			WHERE c.volume_id IN (%s)
+		)
+		SELECT volume_id, page_id FROM RankedPages WHERE rn = 1
+	`, strings.Join(placeholders, ","))
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	results := make(map[string]string)
+	for rows.Next() {
+		var volumeID, pageID string
+		if err := rows.Scan(&volumeID, &pageID); err != nil {
+			return nil, err
+		}
+		results[volumeID] = pageID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// GetFirstVolumesBatch 여러 시리즈의 첫 번째 볼륨 조회
+func (r *VolumeRepository) GetFirstVolumesBatch(db database.Queryer, seriesIDs []string) (map[string]*model.Volume, error) {
+	if len(seriesIDs) == 0 {
+		return make(map[string]*model.Volume), nil
+	}
+	db = database.GetQueryer(db)
+
+	placeholders := make([]string, len(seriesIDs))
+	args := make([]interface{}, len(seriesIDs))
+	for i, id := range seriesIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		WITH RankedVolumes AS (
+			SELECT *, ROW_NUMBER() OVER (PARTITION BY series_id ORDER BY volume_number) AS rn
+			FROM volumes
+			WHERE series_id IN (%s)
+		)
+		SELECT id, series_id, title, volume_number, path, thumbnail_path, has_audio, unit, chapter_count, parent_id, description, authors, publication_year, extension, created_at, updated_at
+		FROM RankedVolumes
+		WHERE rn = 1
+	`, strings.Join(placeholders, ","))
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	results := make(map[string]*model.Volume)
+	for rows.Next() {
+		var v model.Volume
+		var thumbnail, unit, parentID sql.NullString
+		var description, authors, pubYear, extension sql.NullString
+
+		err := rows.Scan(&v.ID, &v.SeriesID, &v.Title, &v.VolumeNumber, &v.Path, &thumbnail, &v.HasAudio, &unit, &v.ChapterCount, &parentID, &description, &authors, &pubYear, &extension, &v.CreatedAt, &v.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+
+		if thumbnail.Valid {
+			v.ThumbnailPath = &thumbnail.String
+		}
+		if unit.Valid {
+			v.Unit = unit.String
+		}
+		if parentID.Valid {
+			v.ParentID = &parentID.String
+		}
+		if description.Valid {
+			v.Description = description.String
+		}
+		if authors.Valid {
+			v.Authors = authors.String
+		}
+		if pubYear.Valid {
+			v.PublicationYear = pubYear.String
+		}
+		if extension.Valid {
+			v.Extension = extension.String
+		}
+		results[v.SeriesID] = &v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/web/src/components/SeriesCard.test.tsx
+++ b/web/src/components/SeriesCard.test.tsx
@@ -103,6 +103,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
           library_type: "book",
           chapter_count: 10,
           created_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: false,
         }}
       />,
     );
@@ -164,6 +165,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
           chapter_count: 8,
           created_at: "2026-03-21T00:00:00Z",
           updated_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: false,
         }}
       />,
     );
@@ -209,6 +211,7 @@ describe("SeriesCard audiobook bootstrap guard", () => {
           chapter_count: 6,
           created_at: "2026-03-21T00:00:00Z",
           updated_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: false,
         }}
       />,
     );
@@ -279,6 +282,7 @@ describe("SeriesCard navigateTo", () => {
           library_type: "book",
           chapter_count: 5,
           created_at: "2026-03-21T00:00:00Z",
+          is_bookmarked: false,
         }}
         navigateTo="/series/series-3"
       />,

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -278,7 +278,7 @@ export function HomePage() {
                   created_at: progress.updated_at,
                   has_audio: progress.has_audio,
                   library_type: progress.library_type,
-                  is_bookmarked: progress.series_is_bookmarked,
+                  is_bookmarked: progress.series_is_bookmarked ?? false,
                 }
               : {
                   id: progress.series_id,

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -92,7 +92,7 @@ export interface Volume {
   created_at: string;
   updated_at?: string;
   library_type?: LibraryType;
-  is_bookmarked?: boolean; // 부모 시리즈의 좋아요(북마크) 상태
+  is_bookmarked: boolean; // 부모 시리즈의 좋아요(북마크) 상태
 }
 
 export interface Chapter {

--- a/web/src/utils/progressUtils.test.ts
+++ b/web/src/utils/progressUtils.test.ts
@@ -42,6 +42,7 @@ describe("Progress Utilities", () => {
         path: "",
         created_at: "",
         is_completed: true,
+        is_bookmarked: false,
       };
       const result = calculateProgressDisplay({ type: "volume", series: mockSeries, volume, t: mockT });
       expect(result.percent).toBe(100);
@@ -58,6 +59,7 @@ describe("Progress Utilities", () => {
         created_at: "",
         total_page_count: 100,
         read_page_count: 45,
+        is_bookmarked: false,
       };
       const result = calculateProgressDisplay({ type: "volume", series: mockSeries, volume, t: mockT });
       expect(result.percent).toBe(45);
@@ -75,6 +77,7 @@ describe("Progress Utilities", () => {
         total_page_count: 1,
         read_page_count: 0,
         progress_percent: 13.3,
+        is_bookmarked: false,
       };
       const result = calculateProgressDisplay({ type: "volume", series: mockSeries, volume, t: mockT });
       expect(result.percent).toBe(13.3);
@@ -92,6 +95,7 @@ describe("Progress Utilities", () => {
         total_page_count: 1,
         read_page_count: 0,
         progress_percent: 13.3,
+        is_bookmarked: false,
       };
       const result = calculateProgressDisplay({
         type: "volume",
@@ -105,7 +109,7 @@ describe("Progress Utilities", () => {
     });
 
     it("should fallback to progress object if page counts are missing", () => {
-      const volume: Volume = { id: "v1", series_id: "s1", title: "Vol 1", volume_number: 1, path: "", created_at: "" };
+      const volume: Volume = { id: "v1", series_id: "s1", title: "Vol 1", volume_number: 1, path: "", created_at: "", is_bookmarked: false };
       const progress: ReadingProgress = {
         id: "p1",
         user_id: "u1",
@@ -225,6 +229,7 @@ describe("Progress Utilities", () => {
         volume_number: 1,
         path: "",
         created_at: "",
+        is_bookmarked: false,
       };
       const progress: ReadingProgress = {
         id: "p1",


### PR DESCRIPTION
## 변경 내용

- GetRecentProgress 핸들러의 N+1 쿼리를 batch 조회로 전환
- series/chapter/volume repository에 batch 메서드 6개 추가 (FindByIDs, CountByVolumeIDs, GetFirstPageIDsBatch, GetFirstVolumesBatch 등)
- rows.Err() 체크 누락 4곳 수정
- Volume 응답에 is_bookmarked 필드 전파 (ListVolumes, GetVolume, UpdateVolume, 썸네일 API 포함)
- 프론트엔드 types 및 테스트 동기화

## 리뷰 포인트

- Batch 쿼리 실패 시 graceful degradation 의도 (log + 빈 데이터로 계속 진행)
- CTE + ROW_NUMBER() 쿼리에 인덱스 필요 여부 확인 권장