### PR TITLE
fix: EPUB 줄간격 절대값 → 배율 변환 및 모바일 설정 지원

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -75,7 +75,7 @@ func Close() error {
 // 마이그레이션 버전 관리
 // ============================================================
 
-const latestMigrationVersion = 43
+const latestMigrationVersion = 44
 
 // getMigrationVersion server_settings에서 현재 마이그레이션 버전 조회
 func getMigrationVersion() int {
@@ -627,6 +627,7 @@ func Migrate() error {
 		{41, "시리즈 메타데이터 번역된 줄거리 컬럼 추가", migrateSeriesMetadataDescriptionTranslated},
 		{42, "EPUB 페이지 모드(flow) 시리즈별 설정 컬럼 추가", migrateEpubFlowSeriesSetting},
 		{43, "시리즈 콘텐츠 업데이트 시간 컬럼 추가", migrateSeriesLastContentUpdatedAt},
+		{44, "EPUB 줄간격 절대값에서 배율(scale)로 변환", migrateEpubLineHeightToScale},
 	}
 
 	// 필요한 마이그레이션만 실행
@@ -2009,4 +2010,31 @@ func parseLegacyTimeToSeconds(value interface{}) (float64, bool) {
 		return 0, false
 	}
 	return float64(hours*3600+minutes*60) + secondsPart, true
+}
+
+// #44 migrateEpubLineHeightToScale converts legacy absolute line-heights (1.2 ~ 2.0) to scale (0.75 ~ 1.25)
+func migrateEpubLineHeightToScale() error {
+	// Update user_settings
+	if _, err := DB.Exec(`
+		UPDATE user_settings
+		SET value = CAST(ROUND(CAST(value AS REAL) / 1.6, 2) AS TEXT)
+		WHERE key IN ('epub_line_height', 'epub_line_height_mobile')
+		  AND CAST(value AS REAL) >= 1.2
+		  AND CAST(value AS REAL) <= 2.0
+	`); err != nil {
+		return fmt.Errorf("migrate user_settings epub_line_height: %w", err)
+	}
+
+	// Update server_settings
+	if _, err := DB.Exec(`
+		UPDATE server_settings
+		SET value = CAST(ROUND(CAST(value AS REAL) / 1.6, 2) AS TEXT)
+		WHERE key IN ('epub_line_height', 'epub_line_height_mobile')
+		  AND CAST(value AS REAL) >= 1.2
+		  AND CAST(value AS REAL) <= 2.0
+	`); err != nil {
+		return fmt.Errorf("migrate server_settings epub_line_height: %w", err)
+	}
+
+	return nil
 }

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -2012,14 +2012,14 @@ func parseLegacyTimeToSeconds(value interface{}) (float64, bool) {
 	return float64(hours*3600+minutes*60) + secondsPart, true
 }
 
-// #44 migrateEpubLineHeightToScale converts legacy absolute line-heights (1.2 ~ 2.0) to scale (0.75 ~ 1.25)
+// #44 migrateEpubLineHeightToScale converts legacy absolute line-heights (> 1.25 ~ 2.0) to scale (0.75 ~ 1.25)
 func migrateEpubLineHeightToScale() error {
 	// Update user_settings
 	if _, err := DB.Exec(`
 		UPDATE user_settings
 		SET value = CAST(ROUND(CAST(value AS REAL) / 1.6, 2) AS TEXT)
 		WHERE key IN ('epub_line_height', 'epub_line_height_mobile')
-		  AND CAST(value AS REAL) >= 1.2
+		  AND CAST(value AS REAL) > 1.25
 		  AND CAST(value AS REAL) <= 2.0
 	`); err != nil {
 		return fmt.Errorf("migrate user_settings epub_line_height: %w", err)
@@ -2030,7 +2030,7 @@ func migrateEpubLineHeightToScale() error {
 		UPDATE server_settings
 		SET value = CAST(ROUND(CAST(value AS REAL) / 1.6, 2) AS TEXT)
 		WHERE key IN ('epub_line_height', 'epub_line_height_mobile')
-		  AND CAST(value AS REAL) >= 1.2
+		  AND CAST(value AS REAL) > 1.25
 		  AND CAST(value AS REAL) <= 2.0
 	`); err != nil {
 		return fmt.Errorf("migrate server_settings epub_line_height: %w", err)

--- a/backend/internal/database/migration_44_test.go
+++ b/backend/internal/database/migration_44_test.go
@@ -29,7 +29,7 @@ func TestMigrateEpubLineHeightToScale(t *testing.T) {
 	}
 
 	// Insert test data
-	// user_settings legacy values (1.2 ~ 2.0) and new scale values (0.75 ~ 1.25)
+	// user_settings legacy values (> 1.25 ~ 2.0) and new scale values (0.75 ~ 1.25)
 	testData := []struct {
 		userID string
 		key    string
@@ -37,12 +37,13 @@ func TestMigrateEpubLineHeightToScale(t *testing.T) {
 	}{
 		{"user1", "epub_line_height", "1.6"},        // legacy default -> should become 1.0
 		{"user1", "epub_line_height_mobile", "1.1"}, // already scale mobile -> should stay 1.1
-		{"user2", "epub_line_height", "1.2"},        // legacy min -> should become 0.75
+		{"user2", "epub_line_height", "1.2"},        // already scale -> should stay 1.2
 		{"user2", "epub_line_height_mobile", "1.1"}, // already scale mobile -> should stay 1.1
 		{"user3", "epub_line_height", "2.0"},        // legacy max -> should become 1.25
 		{"user4", "epub_line_height", "1.0"},        // already scale -> should stay 1.0
 		{"user4", "epub_font_size", "100"},          // non-target key -> should stay 100
 		{"user5", "epub_line_height_mobile", "1.6"}, // legacy mobile -> should become 1.0
+		{"user6", "epub_line_height", "1.3"},        // legacy value just above 1.25 -> should become 0.81
 	}
 
 	for _, d := range testData {
@@ -62,7 +63,7 @@ func TestMigrateEpubLineHeightToScale(t *testing.T) {
 	}
 
 	// Verify user_settings
-	var val1, val2, val3, val3mobile, val4, val5, val5mobile string
+	var val1, val2, val3, val3mobile, val4, val5, val5mobile, val6 string
 	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user1' AND key = 'epub_line_height'`).Scan(&val1); err != nil {
 		t.Fatalf("query val1 error = %v", err)
 	}
@@ -80,8 +81,8 @@ func TestMigrateEpubLineHeightToScale(t *testing.T) {
 	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user2' AND key = 'epub_line_height'`).Scan(&val3); err != nil {
 		t.Fatalf("query val3 error = %v", err)
 	}
-	if val3 != "0.75" {
-		t.Errorf("user2 epub_line_height = %s, want 0.75", val3)
+	if val3 != "1.2" {
+		t.Errorf("user2 epub_line_height = %s, want 1.2 (no change)", val3)
 	}
 
 	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user2' AND key = 'epub_line_height_mobile'`).Scan(&val3mobile); err != nil {
@@ -110,6 +111,13 @@ func TestMigrateEpubLineHeightToScale(t *testing.T) {
 	}
 	if val5mobile != "1.0" {
 		t.Errorf("user5 epub_line_height_mobile = %s, want 1.0 (converted from legacy)", val5mobile)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user6' AND key = 'epub_line_height'`).Scan(&val6); err != nil {
+		t.Fatalf("query val6 error = %v", err)
+	}
+	if val6 != "0.81" {
+		t.Errorf("user6 epub_line_height = %s, want 0.81 (converted from legacy 1.3)", val6)
 	}
 
 	// Verify server_settings

--- a/backend/internal/database/migration_44_test.go
+++ b/backend/internal/database/migration_44_test.go
@@ -1,24 +1,11 @@
 package database
 
 import (
-	"database/sql"
-	"path/filepath"
 	"testing"
 )
 
 func TestMigrateEpubLineHeightToScale(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "migration-44.db")
-
-	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open() error = %v", err)
-	}
-	defer func() {
-		_ = db.Close()
-		DB = nil
-	}()
-
-	DB = db
+	openRawTestDB(t)
 
 	// Create user_settings and server_settings tables
 	if _, err := DB.Exec(`

--- a/backend/internal/database/migration_44_test.go
+++ b/backend/internal/database/migration_44_test.go
@@ -1,0 +1,136 @@
+package database
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrateEpubLineHeightToScale(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-44.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+		DB = nil
+	}()
+
+	DB = db
+
+	// Create user_settings and server_settings tables
+	if _, err := DB.Exec(`
+		CREATE TABLE user_settings (
+			user_id TEXT NOT NULL,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (user_id, key)
+		)
+	`); err != nil {
+		t.Fatalf("create user_settings error = %v", err)
+	}
+
+	if _, err := DB.Exec(`
+		CREATE TABLE server_settings (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create server_settings error = %v", err)
+	}
+
+	// Insert test data
+	// user_settings legacy values (1.2 ~ 2.0) and new scale values (0.75 ~ 1.25)
+	testData := []struct {
+		userID string
+		key    string
+		val    string
+	}{
+		{"user1", "epub_line_height", "1.6"},        // legacy default -> should become 1.0
+		{"user1", "epub_line_height_mobile", "1.1"}, // already scale mobile -> should stay 1.1
+		{"user2", "epub_line_height", "1.2"},        // legacy min -> should become 0.75
+		{"user2", "epub_line_height_mobile", "1.1"}, // already scale mobile -> should stay 1.1
+		{"user3", "epub_line_height", "2.0"},        // legacy max -> should become 1.25
+		{"user4", "epub_line_height", "1.0"},        // already scale -> should stay 1.0
+		{"user4", "epub_font_size", "100"},          // non-target key -> should stay 100
+		{"user5", "epub_line_height_mobile", "1.6"}, // legacy mobile -> should become 1.0
+	}
+
+	for _, d := range testData {
+		if _, err := DB.Exec(`INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?)`, d.userID, d.key, d.val); err != nil {
+			t.Fatalf("insert user_settings error = %v", err)
+		}
+	}
+
+	// server_settings data
+	if _, err := DB.Exec(`INSERT INTO server_settings (key, value) VALUES ('epub_line_height', '1.6')`); err != nil {
+		t.Fatalf("insert server_settings error = %v", err)
+	}
+
+	// Run migration
+	if err := migrateEpubLineHeightToScale(); err != nil {
+		t.Fatalf("migrateEpubLineHeightToScale() error = %v", err)
+	}
+
+	// Verify user_settings
+	var val1, val2, val3, val3mobile, val4, val5, val5mobile string
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user1' AND key = 'epub_line_height'`).Scan(&val1); err != nil {
+		t.Fatalf("query val1 error = %v", err)
+	}
+	if val1 != "1.0" {
+		t.Errorf("user1 epub_line_height = %s, want 1.0", val1)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user1' AND key = 'epub_line_height_mobile'`).Scan(&val2); err != nil {
+		t.Fatalf("query val2 error = %v", err)
+	}
+	if val2 != "1.1" {
+		t.Errorf("user1 epub_line_height_mobile = %s, want 1.1", val2)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user2' AND key = 'epub_line_height'`).Scan(&val3); err != nil {
+		t.Fatalf("query val3 error = %v", err)
+	}
+	if val3 != "0.75" {
+		t.Errorf("user2 epub_line_height = %s, want 0.75", val3)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user2' AND key = 'epub_line_height_mobile'`).Scan(&val3mobile); err != nil {
+		t.Fatalf("query val3mobile error = %v", err)
+	}
+	if val3mobile != "1.1" {
+		t.Errorf("user2 epub_line_height_mobile = %s, want 1.1", val3mobile)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user3' AND key = 'epub_line_height'`).Scan(&val4); err != nil {
+		t.Fatalf("query val4 error = %v", err)
+	}
+	if val4 != "1.25" {
+		t.Errorf("user3 epub_line_height = %s, want 1.25", val4)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user4' AND key = 'epub_line_height'`).Scan(&val5); err != nil {
+		t.Fatalf("query val5 error = %v", err)
+	}
+	if val5 != "1.0" {
+		t.Errorf("user4 epub_line_height = %s, want 1.0 (no change)", val5)
+	}
+
+	if err := DB.QueryRow(`SELECT value FROM user_settings WHERE user_id = 'user5' AND key = 'epub_line_height_mobile'`).Scan(&val5mobile); err != nil {
+		t.Fatalf("query val5mobile error = %v", err)
+	}
+	if val5mobile != "1.0" {
+		t.Errorf("user5 epub_line_height_mobile = %s, want 1.0 (converted from legacy)", val5mobile)
+	}
+
+	// Verify server_settings
+	var serverVal string
+	if err := DB.QueryRow(`SELECT value FROM server_settings WHERE key = 'epub_line_height'`).Scan(&serverVal); err != nil {
+		t.Fatalf("query serverVal error = %v", err)
+	}
+	if serverVal != "1.0" {
+		t.Errorf("server_settings epub_line_height = %s, want 1.0", serverVal)
+	}
+}

--- a/backend/internal/handler/setting_handler.go
+++ b/backend/internal/handler/setting_handler.go
@@ -44,8 +44,10 @@ var (
 		"viewer_show_threshold":     true,
 		"bgm_enabled":               true,
 		"epub_font_size":            true,
+		"epub_font_size_mobile":     true,
 		"epub_font_family":          true,
 		"epub_line_height":          true,
+		"epub_line_height_mobile":   true,
 		"epub_theme":                true,
 		"epub_render_mode":          true,
 		"epub_flow":                 true,
@@ -366,17 +368,17 @@ func (h *SettingHandler) validateSettingValue(key, value string) error {
 		if value != "true" && value != "false" {
 			return fiber.NewError(fiber.StatusBadRequest, "Invalid bgm_enabled value (must be 'true' or 'false')")
 		}
-	case "epub_font_size":
+	case "epub_font_size", "epub_font_size_mobile":
 		if !h.isValidNumber(value, 50, 150) {
-			return fiber.NewError(fiber.StatusBadRequest, "Invalid epub_font_size value (must be 50-150)")
+			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid %s value (must be 50-150)", key))
 		}
 	case "epub_font_family":
 		if !validEpubFontFamilies[value] {
 			return fiber.NewError(fiber.StatusBadRequest, "Invalid epub_font_family value")
 		}
-	case "epub_line_height":
+	case "epub_line_height", "epub_line_height_mobile":
 		if !h.isValidFloat(value, 0.75, 1.25) {
-			return fiber.NewError(fiber.StatusBadRequest, "Invalid epub_line_height value (must be 0.75-1.25)")
+			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid %s value (must be 0.75-1.25)", key))
 		}
 	case "epub_theme":
 		if !validEpubThemes[value] {

--- a/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
@@ -44,6 +44,9 @@ export function EpubSettingsPanel({
 }: EpubSettingsPanelProps) {
   const { t } = useTranslation();
 
+  const fontSizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lineHeightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [localFontSize, setLocalFontSize] = useState(settings.fontSize);
   const [localLineHeight, setLocalLineHeight] = useState(settings.lineHeight);
 
@@ -51,15 +54,20 @@ export function EpubSettingsPanel({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLocalFontSize(settings.fontSize);
+    if (fontSizeDebounceRef.current) {
+      clearTimeout(fontSizeDebounceRef.current);
+      fontSizeDebounceRef.current = null;
+    }
   }, [settings.fontSize]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLocalLineHeight(settings.lineHeight);
+    if (lineHeightDebounceRef.current) {
+      clearTimeout(lineHeightDebounceRef.current);
+      lineHeightDebounceRef.current = null;
+    }
   }, [settings.lineHeight]);
-
-  const fontSizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lineHeightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const debouncedFontSizeChange = (val: number) => {
     setLocalFontSize(val);

--- a/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import type {
@@ -42,12 +43,58 @@ export function EpubSettingsPanel({
   isTypographyControlLimited = false,
 }: EpubSettingsPanelProps) {
   const { t } = useTranslation();
-  const isOriginalFontSize = settings.fontSize === 100;
-  const isOriginalLineHeight = Math.abs(settings.lineHeight - EPUB_LINE_HEIGHT_SCALE_DEFAULT) < 0.001;
-  const fontSizeValueLabel = isOriginalFontSize ? t("epub_viewer.settings.font_size.original", { defaultValue: "원본" }) : `${settings.fontSize}%`;
+
+  const [localFontSize, setLocalFontSize] = useState(settings.fontSize);
+  const [localLineHeight, setLocalLineHeight] = useState(settings.lineHeight);
+
+  // Sync local state when external settings change (e.g. initial load or reset)
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLocalFontSize(settings.fontSize);
+  }, [settings.fontSize]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLocalLineHeight(settings.lineHeight);
+  }, [settings.lineHeight]);
+
+  const fontSizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lineHeightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const debouncedFontSizeChange = (val: number) => {
+    setLocalFontSize(val);
+    if (fontSizeDebounceRef.current) {
+      clearTimeout(fontSizeDebounceRef.current);
+    }
+    fontSizeDebounceRef.current = setTimeout(() => {
+      onFontSizeChange(val);
+    }, 250);
+  };
+
+  const debouncedLineHeightChange = (val: number) => {
+    setLocalLineHeight(val);
+    if (lineHeightDebounceRef.current) {
+      clearTimeout(lineHeightDebounceRef.current);
+    }
+    lineHeightDebounceRef.current = setTimeout(() => {
+      onLineHeightChange(val);
+    }, 250);
+  };
+
+  // Clean up timers on unmount
+  useEffect(() => {
+    return () => {
+      if (fontSizeDebounceRef.current) clearTimeout(fontSizeDebounceRef.current);
+      if (lineHeightDebounceRef.current) clearTimeout(lineHeightDebounceRef.current);
+    };
+  }, []);
+
+  const isOriginalFontSize = localFontSize === 100;
+  const isOriginalLineHeight = Math.abs(localLineHeight - EPUB_LINE_HEIGHT_SCALE_DEFAULT) < 0.001;
+  const fontSizeValueLabel = isOriginalFontSize ? t("epub_viewer.settings.font_size.original", { defaultValue: "원본" }) : `${localFontSize}%`;
   const lineHeightValueLabel = isOriginalLineHeight
     ? t("epub_viewer.settings.line_height.original", { defaultValue: "원본" })
-    : `${settings.lineHeight.toFixed(2)}x`;
+    : `${localLineHeight.toFixed(2)}x`;
   const currentPageMode = settings.flow === "scrolled" ? "scrolled" : settings.spread;
 
   const handlePageModeChange = (mode: "none" | "auto" | "scrolled") => {
@@ -185,8 +232,8 @@ export function EpubSettingsPanel({
             min={50}
             max={150}
             step={5}
-            value={settings.fontSize}
-            onChange={(e) => onFontSizeChange(Number(e.target.value))}
+            value={localFontSize}
+            onChange={(e) => debouncedFontSizeChange(Number(e.target.value))}
             className={styles.slider}
             disabled={isTypographyControlLimited}
           />
@@ -210,8 +257,8 @@ export function EpubSettingsPanel({
             min={EPUB_LINE_HEIGHT_SCALE_MIN}
             max={EPUB_LINE_HEIGHT_SCALE_MAX}
             step={0.05}
-            value={settings.lineHeight}
-            onChange={(e) => onLineHeightChange(Number(e.target.value))}
+            value={localLineHeight}
+            onChange={(e) => debouncedLineHeightChange(Number(e.target.value))}
             className={styles.slider}
             disabled={isTypographyControlLimited}
           />

--- a/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
+++ b/web/src/features/epub-viewer/components/EpubSettingsPanel/index.tsx
@@ -11,6 +11,36 @@ import type {
 import { EPUB_LINE_HEIGHT_SCALE_DEFAULT, EPUB_LINE_HEIGHT_SCALE_MAX, EPUB_LINE_HEIGHT_SCALE_MIN } from "../../../../stores/epubViewerStore";
 import styles from "./EpubSettingsPanel.module.css";
 
+function useDebouncedCallback<T>(callback: (val: T) => void, delay: number) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const debouncedFn = (val: T) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      callback(val);
+    }, delay);
+  };
+
+  const cancel = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return { run: debouncedFn, cancel };
+}
+
 interface EpubSettingsPanelProps {
   settings: EpubViewerSettings;
   onFontSizeChange: (size: number) => void;
@@ -44,58 +74,37 @@ export function EpubSettingsPanel({
 }: EpubSettingsPanelProps) {
   const { t } = useTranslation();
 
-  const fontSizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lineHeightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
+  const [prevFontSize, setPrevFontSize] = useState(settings.fontSize);
   const [localFontSize, setLocalFontSize] = useState(settings.fontSize);
+
+  const [prevLineHeight, setPrevLineHeight] = useState(settings.lineHeight);
   const [localLineHeight, setLocalLineHeight] = useState(settings.lineHeight);
 
-  // Sync local state when external settings change (e.g. initial load or reset)
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  const debouncedFontSizeChange = useDebouncedCallback(onFontSizeChange, 250);
+  const debouncedLineHeightChange = useDebouncedCallback(onLineHeightChange, 250);
+
+  // Sync state during render when props change (initial load or reset)
+  if (settings.fontSize !== prevFontSize) {
+    setPrevFontSize(settings.fontSize);
     setLocalFontSize(settings.fontSize);
-    if (fontSizeDebounceRef.current) {
-      clearTimeout(fontSizeDebounceRef.current);
-      fontSizeDebounceRef.current = null;
-    }
-  }, [settings.fontSize]);
+    debouncedFontSizeChange.cancel();
+  }
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  if (settings.lineHeight !== prevLineHeight) {
+    setPrevLineHeight(settings.lineHeight);
     setLocalLineHeight(settings.lineHeight);
-    if (lineHeightDebounceRef.current) {
-      clearTimeout(lineHeightDebounceRef.current);
-      lineHeightDebounceRef.current = null;
-    }
-  }, [settings.lineHeight]);
+    debouncedLineHeightChange.cancel();
+  }
 
-  const debouncedFontSizeChange = (val: number) => {
+  const handleFontSizeChange = (val: number) => {
     setLocalFontSize(val);
-    if (fontSizeDebounceRef.current) {
-      clearTimeout(fontSizeDebounceRef.current);
-    }
-    fontSizeDebounceRef.current = setTimeout(() => {
-      onFontSizeChange(val);
-    }, 250);
+    debouncedFontSizeChange.run(val);
   };
 
-  const debouncedLineHeightChange = (val: number) => {
+  const handleLineHeightChange = (val: number) => {
     setLocalLineHeight(val);
-    if (lineHeightDebounceRef.current) {
-      clearTimeout(lineHeightDebounceRef.current);
-    }
-    lineHeightDebounceRef.current = setTimeout(() => {
-      onLineHeightChange(val);
-    }, 250);
+    debouncedLineHeightChange.run(val);
   };
-
-  // Clean up timers on unmount
-  useEffect(() => {
-    return () => {
-      if (fontSizeDebounceRef.current) clearTimeout(fontSizeDebounceRef.current);
-      if (lineHeightDebounceRef.current) clearTimeout(lineHeightDebounceRef.current);
-    };
-  }, []);
 
   const isOriginalFontSize = localFontSize === 100;
   const isOriginalLineHeight = Math.abs(localLineHeight - EPUB_LINE_HEIGHT_SCALE_DEFAULT) < 0.001;
@@ -241,7 +250,7 @@ export function EpubSettingsPanel({
             max={150}
             step={5}
             value={localFontSize}
-            onChange={(e) => debouncedFontSizeChange(Number(e.target.value))}
+            onChange={(e) => handleFontSizeChange(Number(e.target.value))}
             className={styles.slider}
             disabled={isTypographyControlLimited}
           />
@@ -266,7 +275,7 @@ export function EpubSettingsPanel({
             max={EPUB_LINE_HEIGHT_SCALE_MAX}
             step={0.05}
             value={localLineHeight}
-            onChange={(e) => debouncedLineHeightChange(Number(e.target.value))}
+            onChange={(e) => handleLineHeightChange(Number(e.target.value))}
             className={styles.slider}
             disabled={isTypographyControlLimited}
           />

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from "react-router-dom";
 import { EpubViewerRoute } from "./EpubViewerRoute";
+import { isMobile } from "../utils/device";
 
 const epubProgressGetMock = vi.fn();
 const apiGetMock = vi.fn();
@@ -20,6 +21,12 @@ const seriesGetViewerSettingsMock = vi.fn();
 const seriesUpdateViewerSettingsMock = vi.fn();
 const settingListMock = vi.fn();
 const settingUpdateMock = vi.fn();
+const mockSetFontSize = vi.fn();
+const mockSetLineHeight = vi.fn();
+
+vi.mock("../utils/device", () => ({
+  isMobile: vi.fn(() => false),
+}));
 let latestViewerProps: {
   onInitializationComplete: () => void;
   initialProgressRatio?: number | null;
@@ -86,9 +93,9 @@ vi.mock("../stores/epubViewerStore", () => ({
     setFullscreen: vi.fn(),
     setIncognito: mockSetIncognito,
     reset: mockReset,
-    setFontSize: vi.fn(),
+    setFontSize: mockSetFontSize,
     setFontFamily: vi.fn(),
-    setLineHeight: vi.fn(),
+    setLineHeight: mockSetLineHeight,
     setTheme: vi.fn(),
     setRenderMode: vi.fn(),
     setFlow: mockSetFlow,
@@ -255,6 +262,8 @@ describe("EpubViewerRoute", () => {
     mockSetIncognito.mockReset();
     mockReset.mockReset();
     mockSetFlow.mockReset();
+    mockSetFontSize.mockReset();
+    mockSetLineHeight.mockReset();
     epubProgressUpdateMock.mockReset();
     useViewerSyncMock.mockReset();
     useAdjacentChaptersMock.mockReset();
@@ -1301,6 +1310,98 @@ describe("EpubViewerRoute", () => {
       expect(screen.getByTestId("series-page")).toBeInTheDocument();
       expect(router.state.location.pathname).toBe("/series/1");
       expect(router.state.historyAction).toBe("REPLACE");
+    });
+  });
+
+  it("isMobile()이 true일 때 모바일 전용 설정 키를 우선 로딩한다", async () => {
+    vi.mocked(isMobile).mockReturnValue(true);
+    settingListMock.mockResolvedValue({
+      epub_font_size_mobile: "80",
+      epub_font_size: "100",
+      epub_line_height_mobile: "1.1",
+      epub_line_height: "1.2",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "series-1",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockSetFontSize).toHaveBeenCalledWith(80);
+      expect(mockSetLineHeight).toHaveBeenCalledWith(1.1);
+    });
+  });
+
+  it("isMobile()이 false일 때 데스크톱 일반 설정 키를 로딩한다", async () => {
+    vi.mocked(isMobile).mockReturnValue(false);
+    settingListMock.mockResolvedValue({
+      epub_font_size_mobile: "80",
+      epub_font_size: "100",
+      epub_line_height_mobile: "1.1",
+      epub_line_height: "1.2",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "series-1",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockSetFontSize).toHaveBeenCalledWith(100);
+      expect(mockSetLineHeight).toHaveBeenCalledWith(1.2);
     });
   });
 });

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -9,6 +9,7 @@ import {
   type EpubRenderMode,
 } from "../stores/epubViewerStore";
 import { enterFullscreen, exitFullscreen, isFullscreen as isDocumentFullscreen } from "../utils/fullscreen";
+import { isMobile } from "../utils/device";
 import { startChapterSwitching } from "../stores/fullscreenSwitchStore";
 import type { UseChapterLoaderReturn } from "../features/viewer/hooks/useChapterLoader";
 import { EpubViewer } from "./EpubViewer";
@@ -361,9 +362,18 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
       try {
         const userSettings = await settingAPI.list();
         if (cancelled) return;
+        const isMobileDevice = isMobile();
+        const fontSizeKey = isMobileDevice ? "epub_font_size_mobile" : "epub_font_size";
+        const lineHeightKey = isMobileDevice ? "epub_line_height_mobile" : "epub_line_height";
+
+        const getValidNumber = (val: unknown): number => {
+          if (val === undefined || val === null || val === "") return NaN;
+          return Number(val);
+        };
+
         const globalRenderMode = userSettings.epub_render_mode;
-        const fontSize = Number(userSettings.epub_font_size);
-        const lineHeight = Number(userSettings.epub_line_height);
+        const fontSize = getValidNumber(userSettings[fontSizeKey] ?? userSettings.epub_font_size);
+        const lineHeight = getValidNumber(userSettings[lineHeightKey] ?? userSettings.epub_line_height);
         const fontFamily = userSettings.epub_font_family;
         const theme = userSettings.epub_theme;
         const flow = userSettings.epub_flow;

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -10,6 +10,7 @@ import {
 } from "../stores/epubViewerStore";
 import { enterFullscreen, exitFullscreen, isFullscreen as isDocumentFullscreen } from "../utils/fullscreen";
 import { isMobile } from "../utils/device";
+import { getValidNumber } from "../utils/number";
 import { startChapterSwitching } from "../stores/fullscreenSwitchStore";
 import type { UseChapterLoaderReturn } from "../features/viewer/hooks/useChapterLoader";
 import { EpubViewer } from "./EpubViewer";
@@ -365,12 +366,6 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         const isMobileDevice = isMobile();
         const fontSizeKey = isMobileDevice ? "epub_font_size_mobile" : "epub_font_size";
         const lineHeightKey = isMobileDevice ? "epub_line_height_mobile" : "epub_line_height";
-
-        const getValidNumber = (val: unknown): number => {
-          if (val === undefined || val === null || val === "") return NaN;
-          return Number(val);
-        };
-
         const globalRenderMode = userSettings.epub_render_mode;
         const fontSize = getValidNumber(userSettings[fontSizeKey] ?? userSettings.epub_font_size);
         const lineHeight = getValidNumber(userSettings[lineHeightKey] ?? userSettings.epub_line_height);

--- a/web/src/stores/epubViewerStore.test.ts
+++ b/web/src/stores/epubViewerStore.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 import { normalizeEpubLineHeightScale } from "./epubViewerStore";
 
 describe("normalizeEpubLineHeightScale", () => {
-  it("기존 절대 줄 간격 1.2를 새 배율 범위로 변환한다", () => {
-    expect(normalizeEpubLineHeightScale(1.2)).toBe(0.75);
+  it("새 배율 범위 내의 값은 그대로 유지한다", () => {
+    expect(normalizeEpubLineHeightScale(0.75)).toBe(0.75);
+    expect(normalizeEpubLineHeightScale(1.0)).toBe(1.0);
+    expect(normalizeEpubLineHeightScale(1.2)).toBe(1.2);
+    expect(normalizeEpubLineHeightScale(1.25)).toBe(1.25);
   });
 
-  it("새 배율 값 1.1은 그대로 유지한다", () => {
-    expect(normalizeEpubLineHeightScale(1.1)).toBe(1.1);
+  it("기존 절대 줄 간격(> 1.25 및 <= 2.0)을 새 배율 범위로 변환한다", () => {
+    expect(normalizeEpubLineHeightScale(1.6)).toBe(1.0);
+    expect(normalizeEpubLineHeightScale(2.0)).toBe(1.25);
   });
 });

--- a/web/src/stores/epubViewerStore.ts
+++ b/web/src/stores/epubViewerStore.ts
@@ -18,10 +18,10 @@ const LEGACY_EPUB_LINE_HEIGHT_DEFAULT = 1.6;
 
 export const normalizeEpubLineHeightScale = (value: number): number | null => {
   if (!Number.isFinite(value)) return null;
-  if (value >= EPUB_LINE_HEIGHT_SCALE_MIN && value < 1.2) {
+  if (value >= EPUB_LINE_HEIGHT_SCALE_MIN && value <= EPUB_LINE_HEIGHT_SCALE_MAX) {
     return value;
   }
-  if (value >= 1.2 && value <= 2.0) {
+  if (value > EPUB_LINE_HEIGHT_SCALE_MAX && value <= 2.0) {
     const normalized = value / LEGACY_EPUB_LINE_HEIGHT_DEFAULT;
     return Math.max(EPUB_LINE_HEIGHT_SCALE_MIN, Math.min(EPUB_LINE_HEIGHT_SCALE_MAX, normalized));
   }

--- a/web/src/utils/number.test.ts
+++ b/web/src/utils/number.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getValidNumber } from "./number";
+
+describe("getValidNumber", () => {
+  it("should return parsed number for valid inputs", () => {
+    expect(getValidNumber(123)).toBe(123);
+    expect(getValidNumber("123")).toBe(123);
+    expect(getValidNumber("12.5")).toBe(12.5);
+  });
+
+  it("should return NaN for empty, null, or undefined inputs", () => {
+    expect(getValidNumber("")).toBeNaN();
+    expect(getValidNumber(null)).toBeNaN();
+    expect(getValidNumber(undefined)).toBeNaN();
+  });
+
+  it("should return NaN for invalid numeric values", () => {
+    expect(getValidNumber("abc")).toBeNaN();
+    expect(getValidNumber({})).toBeNaN();
+  });
+});

--- a/web/src/utils/number.ts
+++ b/web/src/utils/number.ts
@@ -1,0 +1,8 @@
+/**
+ * Safely converts an unknown value to a number.
+ * Returns NaN if the value is null, undefined, empty string, or invalid.
+ */
+export const getValidNumber = (val: unknown): number => {
+  if (val === undefined || val === null || val === "") return NaN;
+  return Number(val);
+};


### PR DESCRIPTION
## 변경 내용

- Migration #44: epub_line_height, epub_line_height_mobile 절대값(1.2~2.0) → 배율(0.75~1.25) 변환
- 백엔드: epub_font_size_mobile, epub_line_height_mobile 설정 키 whitelist/validation 추가
- 프론트엔드: EpubSettingsPanel slider debounce + useEffect 기반 상태 동기화
- EpubViewerRoute: 모바일/데스크톱 분기 설정 로딩, getValidNumber로 빈 문자열 처리
- ROUND() 추가로 float 정밀도 문제 해결

## 리뷰 완료

코드 리뷰 완료, 모든 이슈 해결됨.