### PR TITLE
feat: EPUB/TXT 뷰어 개별 설정 기능 추가 및 UI 개선

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -2053,4 +2053,3 @@ func migrateEpubFontSeriesSettings() error {
 	}
 	return addColumn("user_series_settings", "epub_line_height", "REAL")
 }
-

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -75,7 +75,7 @@ func Close() error {
 // 마이그레이션 버전 관리
 // ============================================================
 
-const latestMigrationVersion = 44
+const latestMigrationVersion = 45
 
 // getMigrationVersion server_settings에서 현재 마이그레이션 버전 조회
 func getMigrationVersion() int {
@@ -427,6 +427,9 @@ func Migrate() error {
 		epub_wheel_direction TEXT,
 		epub_keyboard_direction TEXT,
 		epub_click_direction TEXT,
+		epub_font_size INTEGER,
+		epub_font_family TEXT,
+		epub_line_height REAL,
 		reading_direction TEXT,
 		wheel_direction TEXT,
 		swipe_direction TEXT,
@@ -628,6 +631,7 @@ func Migrate() error {
 		{42, "EPUB 페이지 모드(flow) 시리즈별 설정 컬럼 추가", migrateEpubFlowSeriesSetting},
 		{43, "시리즈 콘텐츠 업데이트 시간 컬럼 추가", migrateSeriesLastContentUpdatedAt},
 		{44, "EPUB 줄간격 절대값에서 배율(scale)로 변환", migrateEpubLineHeightToScale},
+		{45, "EPUB 폰트 관련 설정 시리즈별 설정 컬럼 추가", migrateEpubFontSeriesSettings},
 	}
 
 	// 필요한 마이그레이션만 실행
@@ -2038,3 +2042,15 @@ func migrateEpubLineHeightToScale() error {
 
 	return nil
 }
+
+// #45 migrateEpubFontSeriesSettings adds epub_font_size, epub_font_family, epub_line_height columns to user_series_settings
+func migrateEpubFontSeriesSettings() error {
+	if err := addColumn("user_series_settings", "epub_font_size", "INTEGER"); err != nil {
+		return err
+	}
+	if err := addColumn("user_series_settings", "epub_font_family", "TEXT"); err != nil {
+		return err
+	}
+	return addColumn("user_series_settings", "epub_line_height", "REAL")
+}
+

--- a/backend/internal/database/migration_45_test.go
+++ b/backend/internal/database/migration_45_test.go
@@ -1,0 +1,107 @@
+package database
+
+import (
+	"testing"
+)
+
+func TestMigrateEpubFontSeriesSettings(t *testing.T) {
+	openRawTestDB(t)
+
+	// Create users and series tables first to satisfy foreign keys
+	if _, err := DB.Exec(`
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY
+		)
+	`); err != nil {
+		t.Fatalf("create users error = %v", err)
+	}
+
+	if _, err := DB.Exec(`
+		CREATE TABLE series (
+			id TEXT PRIMARY KEY
+		)
+	`); err != nil {
+		t.Fatalf("create series error = %v", err)
+	}
+
+	// Create user_series_settings without the new epub_font_size, epub_font_family, epub_line_height columns
+	if _, err := DB.Exec(`
+		CREATE TABLE user_series_settings (
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			series_id TEXT NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+			reading_mode TEXT,
+			epub_render_mode TEXT,
+			epub_theme TEXT,
+			epub_flow TEXT,
+			epub_spread TEXT,
+			epub_wheel_direction TEXT,
+			epub_keyboard_direction TEXT,
+			epub_click_direction TEXT,
+			PRIMARY KEY (user_id, series_id)
+		)
+	`); err != nil {
+		t.Fatalf("create user_series_settings error = %v", err)
+	}
+
+	// Insert dummy data
+	if _, err := DB.Exec(`INSERT INTO users (id) VALUES ('user-1')`); err != nil {
+		t.Fatalf("insert user error = %v", err)
+	}
+	if _, err := DB.Exec(`INSERT INTO series (id) VALUES ('series-1')`); err != nil {
+		t.Fatalf("insert series error = %v", err)
+	}
+	if _, err := DB.Exec(`
+		INSERT INTO user_series_settings (user_id, series_id, reading_mode)
+		VALUES ('user-1', 'series-1', 'vertical')
+	`); err != nil {
+		t.Fatalf("insert user_series_settings error = %v", err)
+	}
+
+	// Run migration
+	if err := migrateEpubFontSeriesSettings(); err != nil {
+		t.Fatalf("migrateEpubFontSeriesSettings() error = %v", err)
+	}
+
+	// Check if the new columns exist
+	if !columnExists("user_series_settings", "epub_font_size") {
+		t.Error("epub_font_size column does not exist")
+	}
+	if !columnExists("user_series_settings", "epub_font_family") {
+		t.Error("epub_font_family column does not exist")
+	}
+	if !columnExists("user_series_settings", "epub_line_height") {
+		t.Error("epub_line_height column does not exist")
+	}
+
+	// Verify that the existing data was preserved and new columns are NULL
+	var readingMode string
+	var fontSize interface{}
+	var fontFamily interface{}
+	var lineHeight interface{}
+	err := DB.QueryRow(`
+		SELECT reading_mode, epub_font_size, epub_font_family, epub_line_height
+		FROM user_series_settings
+		WHERE user_id = 'user-1' AND series_id = 'series-1'
+	`).Scan(&readingMode, &fontSize, &fontFamily, &lineHeight)
+	if err != nil {
+		t.Fatalf("query user_series_settings error = %v", err)
+	}
+
+	if readingMode != "vertical" {
+		t.Errorf("reading_mode = %s, want vertical", readingMode)
+	}
+	if fontSize != nil {
+		t.Errorf("epub_font_size = %v, want nil", fontSize)
+	}
+	if fontFamily != nil {
+		t.Errorf("epub_font_family = %v, want nil", fontFamily)
+	}
+	if lineHeight != nil {
+		t.Errorf("epub_line_height = %v, want nil", lineHeight)
+	}
+
+	// Run migration again to verify idempotency (should not error or crash)
+	if err := migrateEpubFontSeriesSettings(); err != nil {
+		t.Fatalf("second migrateEpubFontSeriesSettings() error = %v", err)
+	}
+}

--- a/backend/internal/handler/series_handler.go
+++ b/backend/internal/handler/series_handler.go
@@ -1742,6 +1742,15 @@ func (h *SeriesHandler) UpdateViewerSettings(c *fiber.Ctx) error {
 	if req.EpubClickDirection != nil && *req.EpubClickDirection != "" && !h.isValidSetting("viewer_epub_click_direction", *req.EpubClickDirection) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_click_direction"})
 	}
+	if req.EpubFontSize != nil && (*req.EpubFontSize < 50 || *req.EpubFontSize > 150) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_font_size"})
+	}
+	if req.EpubFontFamily != nil && *req.EpubFontFamily != "" && *req.EpubFontFamily != "original" && *req.EpubFontFamily != "serif" && *req.EpubFontFamily != "sans-serif" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_font_family"})
+	}
+	if req.EpubLineHeight != nil && (*req.EpubLineHeight < 0.75 || *req.EpubLineHeight > 1.25) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid epub_line_height"})
+	}
 	if req.ReadingDirection != nil && *req.ReadingDirection != "" && !h.isValidSetting("viewer_reading_direction", *req.ReadingDirection) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid reading_direction"})
 	}

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -272,6 +272,9 @@ type UserSeriesSetting struct {
 	EpubWheelDirection    *string   `json:"epub_wheel_direction,omitempty"`    // "down" | "up"
 	EpubKeyboardDirection *string   `json:"epub_keyboard_direction,omitempty"` // "right" | "left"
 	EpubClickDirection    *string   `json:"epub_click_direction,omitempty"`    // "right" | "left"
+	EpubFontSize          *int      `json:"epub_font_size,omitempty"`
+	EpubFontFamily        *string   `json:"epub_font_family,omitempty"`
+	EpubLineHeight        *float64  `json:"epub_line_height,omitempty"`
 	ReadingDirection      *string   `json:"reading_direction,omitempty"`
 	WheelDirection        *string   `json:"wheel_direction,omitempty"` // "down" | "up"
 	SwipeDirection        *string   `json:"swipe_direction,omitempty"`

--- a/backend/internal/repository/user_series_setting_repository.go
+++ b/backend/internal/repository/user_series_setting_repository.go
@@ -25,12 +25,14 @@ func (r *userSeriesSettingRepository) Get(q database.Queryer, userID, seriesID s
 	s := &model.UserSeriesSetting{}
 	query := `
 		SELECT user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_flow, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
+		       epub_font_size, epub_font_family, epub_line_height,
 		       reading_direction, wheel_direction, swipe_direction, click_direction, keyboard_direction, fit_mode, background_color, updated_at
 		FROM user_series_settings
 		WHERE user_id = ? AND series_id = ?
 	`
 	err := q.QueryRow(query, userID, seriesID).Scan(
 		&s.UserID, &s.SeriesID, &s.ReadingMode, &s.EpubRenderMode, &s.EpubTheme, &s.EpubFlow, &s.EpubSpread, &s.EpubWheelDirection, &s.EpubKeyboardDirection, &s.EpubClickDirection,
+		&s.EpubFontSize, &s.EpubFontFamily, &s.EpubLineHeight,
 		&s.ReadingDirection, &s.WheelDirection, &s.SwipeDirection, &s.ClickDirection,
 		&s.KeyboardDirection, &s.FitMode, &s.BackgroundColor, &s.UpdatedAt,
 	)
@@ -48,9 +50,10 @@ func (r *userSeriesSettingRepository) Upsert(q database.Queryer, s *model.UserSe
 	query := `
 		INSERT INTO user_series_settings (
 			user_id, series_id, reading_mode, epub_render_mode, epub_theme, epub_flow, epub_spread, epub_wheel_direction, epub_keyboard_direction, epub_click_direction,
+			epub_font_size, epub_font_family, epub_line_height,
 			reading_direction, wheel_direction, swipe_direction, click_direction, keyboard_direction, fit_mode, background_color, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id, series_id) DO UPDATE SET
 			reading_mode = COALESCE(excluded.reading_mode, user_series_settings.reading_mode),
 			epub_render_mode = COALESCE(excluded.epub_render_mode, user_series_settings.epub_render_mode),
@@ -60,6 +63,9 @@ func (r *userSeriesSettingRepository) Upsert(q database.Queryer, s *model.UserSe
 			epub_wheel_direction = COALESCE(excluded.epub_wheel_direction, user_series_settings.epub_wheel_direction),
 			epub_keyboard_direction = COALESCE(excluded.epub_keyboard_direction, user_series_settings.epub_keyboard_direction),
 			epub_click_direction = COALESCE(excluded.epub_click_direction, user_series_settings.epub_click_direction),
+			epub_font_size = COALESCE(excluded.epub_font_size, user_series_settings.epub_font_size),
+			epub_font_family = COALESCE(excluded.epub_font_family, user_series_settings.epub_font_family),
+			epub_line_height = COALESCE(excluded.epub_line_height, user_series_settings.epub_line_height),
 			reading_direction = COALESCE(excluded.reading_direction, user_series_settings.reading_direction),
 			wheel_direction = COALESCE(excluded.wheel_direction, user_series_settings.wheel_direction),
 			swipe_direction = COALESCE(excluded.swipe_direction, user_series_settings.swipe_direction),
@@ -71,6 +77,7 @@ func (r *userSeriesSettingRepository) Upsert(q database.Queryer, s *model.UserSe
 	`
 	_, err := q.Exec(query,
 		s.UserID, s.SeriesID, s.ReadingMode, s.EpubRenderMode, s.EpubTheme, s.EpubFlow, s.EpubSpread, s.EpubWheelDirection, s.EpubKeyboardDirection, s.EpubClickDirection,
+		s.EpubFontSize, s.EpubFontFamily, s.EpubLineHeight,
 		s.ReadingDirection, s.WheelDirection, s.SwipeDirection, s.ClickDirection,
 		s.KeyboardDirection, s.FitMode, s.BackgroundColor, time.Now(),
 	)

--- a/web/src/components/settings/SettingsComponents.module.css
+++ b/web/src/components/settings/SettingsComponents.module.css
@@ -513,6 +513,11 @@
   cursor: pointer;
 }
 
+.settingsSlider:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.45);
+}
+
 .settingsSlider::-webkit-slider-runnable-track {
   width: 100%;
   height: 6px;

--- a/web/src/components/settings/SettingsComponents.module.css
+++ b/web/src/components/settings/SettingsComponents.module.css
@@ -500,7 +500,88 @@
   min-width: 200px;
 }
 
-/* 폼 요소 공통 */
+.settingsSlider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  outline: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settingsSlider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 6px;
+  cursor: pointer;
+  background: transparent;
+  border-radius: 3px;
+  border: none;
+}
+
+.settingsSlider::-webkit-slider-thumb {
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: #667eea;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-top: -5px; /* (track_height - thumb_height) / 2 */
+  border: 2px solid #0a1628; /* matches the component's dark background */
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.settingsSlider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+  background: #7c8ffc;
+}
+
+.settingsSlider::-moz-range-track {
+  width: 100%;
+  height: 6px;
+  cursor: pointer;
+  background: transparent;
+  border-radius: 3px;
+  border: none;
+}
+
+.settingsSlider::-moz-range-thumb {
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  background: #667eea;
+  cursor: pointer;
+  border: 2px solid #0a1628;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.settingsSlider::-moz-range-thumb:hover {
+  transform: scale(1.2);
+  background: #7c8ffc;
+}
+
+.sliderControl {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 200px;
+  height: 38px; /* aligns vertically with input heights */
+}
+
+.sliderValue {
+  font-size: 0.9rem;
+  color: #e2e8f0;
+  min-width: 48px;
+  text-align: right;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums; /* prevents layout shift when numbers change */
+}
+
 .settingsSelect,
 .settingsInput {
   width: 100%;

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -23,6 +23,10 @@ interface SettingsData {
   epub_render_mode?: string;
   epub_theme?: string;
   epub_spread?: string;
+  epub_flow?: string;
+  epub_font_size?: string;
+  epub_font_family?: string;
+  epub_line_height?: string;
   epub_wheel_direction?: string;
   epub_keyboard_direction?: string;
   epub_click_direction?: string;
@@ -85,6 +89,10 @@ export function ViewerTab() {
   const [epubRenderMode, setEpubRenderMode] = useState<"auto" | "book" | "comic">("auto");
   const [epubTheme, setEpubTheme] = useState<"light" | "dark" | "sepia">("light");
   const [epubSpread, setEpubSpread] = useState<"auto" | "none">("auto");
+  const [epubFlow, setEpubFlow] = useState<"paginated" | "scrolled">("paginated");
+  const [epubFontSize, setEpubFontSize] = useState<number>(100);
+  const [epubFontFamily, setEpubFontFamily] = useState<"original" | "serif" | "sans-serif">("original");
+  const [epubLineHeight, setEpubLineHeight] = useState<number>(1);
   const [epubWheelDirection, setEpubWheelDirection] = useState<"down" | "up">("down");
   const [epubKeyboardDirection, setEpubKeyboardDirection] = useState<"right" | "left">("right");
   const [epubClickDirection, setEpubClickDirection] = useState<"right" | "left">("right");
@@ -127,6 +135,20 @@ export function ViewerTab() {
         if (data.epub_spread === "auto" || data.epub_spread === "none") {
           setEpubSpread(data.epub_spread);
         }
+        if (data.epub_flow === "paginated" || data.epub_flow === "scrolled") {
+          setEpubFlow(data.epub_flow);
+        }
+        const parsedFontSize = Number(data.epub_font_size);
+        if (Number.isFinite(parsedFontSize) && parsedFontSize >= 50 && parsedFontSize <= 150) {
+          setEpubFontSize(parsedFontSize);
+        }
+        if (data.epub_font_family === "original" || data.epub_font_family === "serif" || data.epub_font_family === "sans-serif") {
+          setEpubFontFamily(data.epub_font_family);
+        }
+        const parsedLineHeight = Number(data.epub_line_height);
+        if (Number.isFinite(parsedLineHeight) && parsedLineHeight >= 0.75 && parsedLineHeight <= 1.25) {
+          setEpubLineHeight(parsedLineHeight);
+        }
         if (data.epub_wheel_direction === "down" || data.epub_wheel_direction === "up") {
           setEpubWheelDirection(data.epub_wheel_direction);
         }
@@ -163,6 +185,16 @@ export function ViewerTab() {
     setShowThreshold,
     setPageTransition,
     setSwipeDirection,
+    setEpubRenderMode,
+    setEpubTheme,
+    setEpubSpread,
+    setEpubFlow,
+    setEpubFontSize,
+    setEpubFontFamily,
+    setEpubLineHeight,
+    setEpubWheelDirection,
+    setEpubKeyboardDirection,
+    setEpubClickDirection,
     t,
   ]);
 
@@ -183,6 +215,16 @@ export function ViewerTab() {
       console.error(`Failed to update setting ${key}:`, error);
       setStatus({ type: "error", message: t("settings.viewer.toast.save_failed") });
     }
+  };
+
+  const handleFontSizeCommit = (e: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {
+    handleSettingChange("epub_font_size", e.currentTarget.value, (v) => setEpubFontSize(Number(v)));
+  };
+
+  const handleLineHeightCommit = (e: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {
+    const val = Number(e.currentTarget.value);
+    const normalizedVal = Math.round(val * 100) / 100;
+    handleSettingChange("epub_line_height", String(normalizedVal), (v) => setEpubLineHeight(Number(v)));
   };
 
   const executeImagePdfReset = async () => {
@@ -232,6 +274,10 @@ export function ViewerTab() {
         settingAPI.update("epub_render_mode", { value: "auto" }),
         settingAPI.update("epub_theme", { value: "light" }),
         settingAPI.update("epub_spread", { value: "auto" }),
+        settingAPI.update("epub_flow", { value: "paginated" }),
+        settingAPI.update("epub_font_size", { value: "100" }),
+        settingAPI.update("epub_font_family", { value: "original" }),
+        settingAPI.update("epub_line_height", { value: "1" }),
         settingAPI.update("epub_wheel_direction", { value: "down" }),
         settingAPI.update("epub_keyboard_direction", { value: "right" }),
         settingAPI.update("epub_click_direction", { value: "right" }),
@@ -240,6 +286,10 @@ export function ViewerTab() {
       setEpubRenderMode("auto");
       setEpubTheme("light");
       setEpubSpread("auto");
+      setEpubFlow("paginated");
+      setEpubFontSize(100);
+      setEpubFontFamily("original");
+      setEpubLineHeight(1);
       setEpubWheelDirection("down");
       setEpubKeyboardDirection("right");
       setEpubClickDirection("right");
@@ -511,7 +561,7 @@ export function ViewerTab() {
           <div className={`${styles.sectionTitle} ${localStyles.sectionTitleWithAction}`}>
             <div className={localStyles.sectionTitleLeft}>
               <BookOpen size={18} />
-              <h3>{t("settings.viewer.epub.title")}</h3>
+              <h3>{t("settings.viewer.epub_txt.title", { defaultValue: "EPUB/TXT 뷰어 전역 기본값" })}</h3>
             </div>
             <button
               type="button"
@@ -571,6 +621,26 @@ export function ViewerTab() {
 
               <div className={styles.settingsItem}>
                 <div className={styles.itemInfo}>
+                  <label htmlFor="epub_flow">{t("settings.viewer.epub.flow_label", { defaultValue: "레이아웃" })}</label>
+                  <p>{t("settings.viewer.epub.flow_desc", { defaultValue: "페이지를 넘기거나 스크롤 방식으로 표시합니다." })}</p>
+                </div>
+                <div className={styles.itemControl}>
+                  <select
+                    id="epub_flow"
+                    value={epubFlow}
+                    onChange={(e) =>
+                      handleSettingChange("epub_flow", e.target.value, (v) => setEpubFlow(v as "paginated" | "scrolled"))
+                    }
+                    className={styles.settingsSelect}
+                  >
+                    <option value="paginated">{t("epub_viewer.settings.flow.paginated", { defaultValue: "페이지 넘김" })}</option>
+                    <option value="scrolled">{t("epub_viewer.settings.flow.scrolled", { defaultValue: "세로 스크롤" })}</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className={styles.settingsItem}>
+                <div className={styles.itemInfo}>
                   <label htmlFor="epub_theme">{t("settings.viewer.epub.theme_label")}</label>
                   <p>{t("settings.viewer.epub.theme_desc")}</p>
                 </div>
@@ -589,6 +659,83 @@ export function ViewerTab() {
                     <option value="dark">{t("epub_viewer.settings.theme.dark")}</option>
                     <option value="sepia">{t("epub_viewer.settings.theme.sepia")}</option>
                   </select>
+                </div>
+              </div>
+
+              <div className={styles.settingsItem}>
+                <div className={styles.itemInfo}>
+                  <label htmlFor="epub_font_family">{t("epub_viewer.settings.font_family.label")}</label>
+                  <p>{t("settings.viewer.epub.font_family_desc", { defaultValue: "기본 글꼴을 선택합니다." })}</p>
+                </div>
+                <div className={styles.itemControl}>
+                  <select
+                    id="epub_font_family"
+                    value={epubFontFamily}
+                    onChange={(e) =>
+                      handleSettingChange("epub_font_family", e.target.value, (v) =>
+                        setEpubFontFamily(v as "original" | "serif" | "sans-serif"),
+                      )
+                    }
+                    className={styles.settingsSelect}
+                  >
+                    <option value="original">{t("epub_viewer.settings.font_family.original")}</option>
+                    <option value="serif">{t("epub_viewer.settings.font_family.serif")}</option>
+                    <option value="sans-serif">{t("epub_viewer.settings.font_family.sans_serif")}</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className={styles.settingsItem}>
+                <div className={styles.itemInfo}>
+                  <label htmlFor="epub_font_size">{t("epub_viewer.settings.font_size.label")}</label>
+                  <p>{t("settings.viewer.epub.font_size_desc", { defaultValue: "글자 크기를 조절합니다. (원본 = 100%)" })}</p>
+                </div>
+                <div className={`${styles.itemControl} ${styles.sliderControl}`}>
+                  <input
+                    type="range"
+                    id="epub_font_size"
+                    min={50}
+                    max={150}
+                    step={5}
+                    value={epubFontSize}
+                    onChange={(e) => setEpubFontSize(Number(e.target.value))}
+                    onMouseUp={handleFontSizeCommit}
+                    onTouchEnd={handleFontSizeCommit}
+                    className={styles.settingsSlider}
+                    style={{
+                      background: `linear-gradient(to right, #667eea 0%, #667eea ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) 100%)`
+                    }}
+                  />
+                  <span className={styles.sliderValue}>{epubFontSize}%</span>
+                </div>
+              </div>
+
+              <div className={styles.settingsItem}>
+                <div className={styles.itemInfo}>
+                  <label htmlFor="epub_line_height">{t("epub_viewer.settings.line_height.label")}</label>
+                  <p>{t("settings.viewer.epub.line_height_desc", { defaultValue: "줄 간격을 조절합니다. (원본 = 1.0)" })}</p>
+                </div>
+                <div className={`${styles.itemControl} ${styles.sliderControl}`}>
+                  <input
+                    type="range"
+                    id="epub_line_height"
+                    min={0.75}
+                    max={1.25}
+                    step={0.05}
+                    value={epubLineHeight}
+                    onChange={(e) => {
+                      const val = Number(e.target.value);
+                      const normalizedVal = Math.round(val * 100) / 100;
+                      setEpubLineHeight(normalizedVal);
+                    }}
+                    onMouseUp={handleLineHeightCommit}
+                    onTouchEnd={handleLineHeightCommit}
+                    className={styles.settingsSlider}
+                    style={{
+                      background: `linear-gradient(to right, #667eea 0%, #667eea ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) 100%)`
+                    }}
+                  />
+                  <span className={styles.sliderValue}>{epubLineHeight.toFixed(2)}x</span>
                 </div>
               </div>
             </div>

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -748,7 +748,11 @@ export function ViewerTab() {
                     max={150}
                     step={5}
                     value={epubFontSize}
-                    onChange={(e) => setEpubFontSize(Number(e.target.value))}
+                    onChange={(e) => {
+                      const val = Number(e.target.value);
+                      setEpubFontSize(val);
+                      epubFontSizeRef.current = val;
+                    }}
                     onMouseUp={handleFontSizeCommit}
                     onTouchEnd={handleFontSizeCommit}
                     onBlur={handleFontSizeCommit}
@@ -778,6 +782,7 @@ export function ViewerTab() {
                       const val = Number(e.target.value);
                       const normalizedVal = Math.round(val * 100) / 100;
                       setEpubLineHeight(normalizedVal);
+                      epubLineHeightRef.current = normalizedVal;
                     }}
                     onMouseUp={handleLineHeightCommit}
                     onTouchEnd={handleLineHeightCommit}

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -143,7 +143,11 @@ export function ViewerTab() {
           setEpubFontSize(parsedFontSize);
           lastCommittedFontSizeRef.current = String(parsedFontSize);
         }
-        if (data.epub_font_family === "original" || data.epub_font_family === "serif" || data.epub_font_family === "sans-serif") {
+        if (
+          data.epub_font_family === "original" ||
+          data.epub_font_family === "serif" ||
+          data.epub_font_family === "sans-serif"
+        ) {
           setEpubFontFamily(data.epub_font_family);
         }
         const parsedLineHeight = Number(data.epub_line_height);
@@ -223,7 +227,8 @@ export function ViewerTab() {
     epubLineHeightRef.current = epubLineHeight;
   }, [epubLineHeight]);
 
-  const syncServerSettings = async () => {
+  // EPUB 폰트 관련 설정만 서버와 동기화 (ref 기반 가드 일관성 유지)
+  const syncEpubFontServerSettings = async () => {
     try {
       const response = await settingAPI.list();
       const data = response as SettingsData;
@@ -248,19 +253,21 @@ export function ViewerTab() {
     key: string,
     value: string,
     updateFn: (val: string) => void,
-    getCurrentValue?: () => string
+    getCurrentValue?: () => string,
   ) => {
     try {
       await settingAPI.update(key, { value });
+      // getCurrentValue가 제공되면, 커밋 시점과 동일할 때만 UI에 반영 (레이스 방지)
       if (!getCurrentValue || getCurrentValue() === value) {
         updateFn(value);
+        setStatus({ type: "success", message: t("settings.viewer.toast.saved") });
       }
-      setStatus({ type: "success", message: t("settings.viewer.toast.saved") });
     } catch (error) {
       console.error(`Failed to update setting ${key}:`, error);
       setStatus({ type: "error", message: t("settings.viewer.toast.save_failed") });
+      // 실패한 커밋 값이 아직 UI에 남아있을 때만 서버값으로 재동기화
       if (getCurrentValue && getCurrentValue() === value) {
-        await syncServerSettings();
+        await syncEpubFontServerSettings();
       }
     }
   };
@@ -275,7 +282,7 @@ export function ViewerTab() {
       "epub_font_size",
       commitVal,
       (v) => setEpubFontSize(Number(v)),
-      () => String(epubFontSizeRef.current)
+      () => String(epubFontSizeRef.current),
     );
   };
 
@@ -291,7 +298,7 @@ export function ViewerTab() {
       "epub_line_height",
       commitVal,
       (v) => setEpubLineHeight(Number(v)),
-      () => String(epubLineHeightRef.current)
+      () => String(epubLineHeightRef.current),
     );
   };
 
@@ -689,20 +696,32 @@ export function ViewerTab() {
 
               <div className={styles.settingsItem}>
                 <div className={styles.itemInfo}>
-                  <label htmlFor="epub_flow">{t("settings.viewer.epub.flow_label", { defaultValue: "레이아웃" })}</label>
-                  <p>{t("settings.viewer.epub.flow_desc", { defaultValue: "페이지를 넘기거나 스크롤 방식으로 표시합니다." })}</p>
+                  <label htmlFor="epub_flow">
+                    {t("settings.viewer.epub.flow_label", { defaultValue: "레이아웃" })}
+                  </label>
+                  <p>
+                    {t("settings.viewer.epub.flow_desc", {
+                      defaultValue: "페이지를 넘기거나 스크롤 방식으로 표시합니다.",
+                    })}
+                  </p>
                 </div>
                 <div className={styles.itemControl}>
                   <select
                     id="epub_flow"
                     value={epubFlow}
                     onChange={(e) =>
-                      handleSettingChange("epub_flow", e.target.value, (v) => setEpubFlow(v as "paginated" | "scrolled"))
+                      handleSettingChange("epub_flow", e.target.value, (v) =>
+                        setEpubFlow(v as "paginated" | "scrolled"),
+                      )
                     }
                     className={styles.settingsSelect}
                   >
-                    <option value="paginated">{t("epub_viewer.settings.flow.paginated", { defaultValue: "페이지 넘김" })}</option>
-                    <option value="scrolled">{t("epub_viewer.settings.flow.scrolled", { defaultValue: "세로 스크롤" })}</option>
+                    <option value="paginated">
+                      {t("epub_viewer.settings.flow.paginated", { defaultValue: "페이지 넘김" })}
+                    </option>
+                    <option value="scrolled">
+                      {t("epub_viewer.settings.flow.scrolled", { defaultValue: "세로 스크롤" })}
+                    </option>
                   </select>
                 </div>
               </div>
@@ -756,7 +775,11 @@ export function ViewerTab() {
               <div className={styles.settingsItem}>
                 <div className={styles.itemInfo}>
                   <label htmlFor="epub_font_size">{t("epub_viewer.settings.font_size.label")}</label>
-                  <p>{t("settings.viewer.epub.font_size_desc", { defaultValue: "글자 크기를 조절합니다. (원본 = 100%)" })}</p>
+                  <p>
+                    {t("settings.viewer.epub.font_size_desc", {
+                      defaultValue: "글자 크기를 조절합니다. (원본 = 100%)",
+                    })}
+                  </p>
                 </div>
                 <div className={`${styles.itemControl} ${styles.sliderControl}`}>
                   <input
@@ -776,7 +799,7 @@ export function ViewerTab() {
                     onBlur={handleFontSizeCommit}
                     className={styles.settingsSlider}
                     style={{
-                      background: `linear-gradient(to right, #667eea 0%, #667eea ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) 100%)`
+                      background: `linear-gradient(to right, #667eea 0%, #667eea ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) 100%)`,
                     }}
                   />
                   <span className={styles.sliderValue}>{epubFontSize}%</span>
@@ -786,7 +809,9 @@ export function ViewerTab() {
               <div className={styles.settingsItem}>
                 <div className={styles.itemInfo}>
                   <label htmlFor="epub_line_height">{t("epub_viewer.settings.line_height.label")}</label>
-                  <p>{t("settings.viewer.epub.line_height_desc", { defaultValue: "줄 간격을 조절합니다. (원본 = 1.0)" })}</p>
+                  <p>
+                    {t("settings.viewer.epub.line_height_desc", { defaultValue: "줄 간격을 조절합니다. (원본 = 1.0)" })}
+                  </p>
                 </div>
                 <div className={`${styles.itemControl} ${styles.sliderControl}`}>
                   <input
@@ -807,7 +832,7 @@ export function ViewerTab() {
                     onBlur={handleLineHeightCommit}
                     className={styles.settingsSlider}
                     style={{
-                      background: `linear-gradient(to right, #667eea 0%, #667eea ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) 100%)`
+                      background: `linear-gradient(to right, #667eea 0%, #667eea ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) 100%)`,
                     }}
                   />
                   <span className={styles.sliderValue}>{epubLineHeight.toFixed(2)}x</span>
@@ -883,7 +908,6 @@ export function ViewerTab() {
                 </div>
               </div>
             </div>
-
           </div>
         </section>
 

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -219,13 +219,6 @@ export function ViewerTab() {
   const lastCommittedFontSizeRef = useRef<string | null>(null);
   const lastCommittedLineHeightRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    epubFontSizeRef.current = epubFontSize;
-  }, [epubFontSize]);
-
-  useEffect(() => {
-    epubLineHeightRef.current = epubLineHeight;
-  }, [epubLineHeight]);
 
   // EPUB 폰트 관련 설정만 서버와 동기화 (ref 기반 가드 일관성 유지)
   const syncEpubFontServerSettings = async () => {

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Monitor, Loader2, Cpu, RotateCcw, BookOpen } from "lucide-react";
 import { AlertModal } from "../modals/AlertModal";
@@ -205,8 +205,43 @@ export function ViewerTab() {
     }
   }, [settings.pullThreshold, settings.pullSensitivity]);
 
+  // Refs to track current UI values for safe rollback check
+  const epubFontSizeRef = useRef(epubFontSize);
+  const epubLineHeightRef = useRef(epubLineHeight);
+
+  useEffect(() => {
+    epubFontSizeRef.current = epubFontSize;
+  }, [epubFontSize]);
+
+  useEffect(() => {
+    epubLineHeightRef.current = epubLineHeight;
+  }, [epubLineHeight]);
+
+  const syncServerSettings = async () => {
+    try {
+      const response = await settingAPI.list();
+      const data = response as SettingsData;
+
+      const parsedFontSize = Number(data.epub_font_size);
+      if (Number.isFinite(parsedFontSize) && parsedFontSize >= 50 && parsedFontSize <= 150) {
+        setEpubFontSize(parsedFontSize);
+      }
+      const parsedLineHeight = Number(data.epub_line_height);
+      if (Number.isFinite(parsedLineHeight) && parsedLineHeight >= 0.75 && parsedLineHeight <= 1.25) {
+        setEpubLineHeight(parsedLineHeight);
+      }
+    } catch (error) {
+      console.error("Failed to sync settings from server:", error);
+    }
+  };
+
   // 설정 업데이트 핸들러
-  const handleSettingChange = async (key: string, value: string, updateFn: (val: string) => void) => {
+  const handleSettingChange = async (
+    key: string,
+    value: string,
+    updateFn: (val: string) => void,
+    getCurrentValue?: () => string
+  ) => {
     try {
       await settingAPI.update(key, { value });
       updateFn(value);
@@ -214,17 +249,32 @@ export function ViewerTab() {
     } catch (error) {
       console.error(`Failed to update setting ${key}:`, error);
       setStatus({ type: "error", message: t("settings.viewer.toast.save_failed") });
+      if (getCurrentValue && getCurrentValue() === value) {
+        await syncServerSettings();
+      }
     }
   };
 
   const handleFontSizeCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    handleSettingChange("epub_font_size", e.currentTarget.value, (v) => setEpubFontSize(Number(v)));
+    const commitVal = e.currentTarget.value;
+    handleSettingChange(
+      "epub_font_size",
+      commitVal,
+      (v) => setEpubFontSize(Number(v)),
+      () => String(epubFontSizeRef.current)
+    );
   };
 
   const handleLineHeightCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const val = Number(e.currentTarget.value);
     const normalizedVal = Math.round(val * 100) / 100;
-    handleSettingChange("epub_line_height", String(normalizedVal), (v) => setEpubLineHeight(Number(v)));
+    const commitVal = String(normalizedVal);
+    handleSettingChange(
+      "epub_line_height",
+      commitVal,
+      (v) => setEpubLineHeight(Number(v)),
+      () => String(epubLineHeightRef.current)
+    );
   };
 
   const executeImagePdfReset = async () => {

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -141,6 +141,7 @@ export function ViewerTab() {
         const parsedFontSize = Number(data.epub_font_size);
         if (Number.isFinite(parsedFontSize) && parsedFontSize >= 50 && parsedFontSize <= 150) {
           setEpubFontSize(parsedFontSize);
+          lastCommittedFontSizeRef.current = String(parsedFontSize);
         }
         if (data.epub_font_family === "original" || data.epub_font_family === "serif" || data.epub_font_family === "sans-serif") {
           setEpubFontFamily(data.epub_font_family);
@@ -148,6 +149,7 @@ export function ViewerTab() {
         const parsedLineHeight = Number(data.epub_line_height);
         if (Number.isFinite(parsedLineHeight) && parsedLineHeight >= 0.75 && parsedLineHeight <= 1.25) {
           setEpubLineHeight(parsedLineHeight);
+          lastCommittedLineHeightRef.current = String(parsedLineHeight);
         }
         if (data.epub_wheel_direction === "down" || data.epub_wheel_direction === "up") {
           setEpubWheelDirection(data.epub_wheel_direction);
@@ -209,6 +211,10 @@ export function ViewerTab() {
   const epubFontSizeRef = useRef(epubFontSize);
   const epubLineHeightRef = useRef(epubLineHeight);
 
+  // Refs to track last committed values to prevent duplicate commits (e.g. onBlur after mouseUp)
+  const lastCommittedFontSizeRef = useRef<string | null>(null);
+  const lastCommittedLineHeightRef = useRef<string | null>(null);
+
   useEffect(() => {
     epubFontSizeRef.current = epubFontSize;
   }, [epubFontSize]);
@@ -225,10 +231,12 @@ export function ViewerTab() {
       const parsedFontSize = Number(data.epub_font_size);
       if (Number.isFinite(parsedFontSize) && parsedFontSize >= 50 && parsedFontSize <= 150) {
         setEpubFontSize(parsedFontSize);
+        lastCommittedFontSizeRef.current = String(parsedFontSize);
       }
       const parsedLineHeight = Number(data.epub_line_height);
       if (Number.isFinite(parsedLineHeight) && parsedLineHeight >= 0.75 && parsedLineHeight <= 1.25) {
         setEpubLineHeight(parsedLineHeight);
+        lastCommittedLineHeightRef.current = String(parsedLineHeight);
       }
     } catch (error) {
       console.error("Failed to sync settings from server:", error);
@@ -259,6 +267,10 @@ export function ViewerTab() {
 
   const handleFontSizeCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const commitVal = e.currentTarget.value;
+    if (lastCommittedFontSizeRef.current === commitVal) {
+      return;
+    }
+    lastCommittedFontSizeRef.current = commitVal;
     handleSettingChange(
       "epub_font_size",
       commitVal,
@@ -271,6 +283,10 @@ export function ViewerTab() {
     const val = Number(e.currentTarget.value);
     const normalizedVal = Math.round(val * 100) / 100;
     const commitVal = String(normalizedVal);
+    if (lastCommittedLineHeightRef.current === commitVal) {
+      return;
+    }
+    lastCommittedLineHeightRef.current = commitVal;
     handleSettingChange(
       "epub_line_height",
       commitVal,

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -217,11 +217,11 @@ export function ViewerTab() {
     }
   };
 
-  const handleFontSizeCommit = (e: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {
+  const handleFontSizeCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
     handleSettingChange("epub_font_size", e.currentTarget.value, (v) => setEpubFontSize(Number(v)));
   };
 
-  const handleLineHeightCommit = (e: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {
+  const handleLineHeightCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const val = Number(e.currentTarget.value);
     const normalizedVal = Math.round(val * 100) / 100;
     handleSettingChange("epub_line_height", String(normalizedVal), (v) => setEpubLineHeight(Number(v)));
@@ -701,6 +701,7 @@ export function ViewerTab() {
                     onChange={(e) => setEpubFontSize(Number(e.target.value))}
                     onMouseUp={handleFontSizeCommit}
                     onTouchEnd={handleFontSizeCommit}
+                    onBlur={handleFontSizeCommit}
                     className={styles.settingsSlider}
                     style={{
                       background: `linear-gradient(to right, #667eea 0%, #667eea ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) ${epubFontSize - 50}%, rgba(255, 255, 255, 0.1) 100%)`
@@ -730,6 +731,7 @@ export function ViewerTab() {
                     }}
                     onMouseUp={handleLineHeightCommit}
                     onTouchEnd={handleLineHeightCommit}
+                    onBlur={handleLineHeightCommit}
                     className={styles.settingsSlider}
                     style={{
                       background: `linear-gradient(to right, #667eea 0%, #667eea ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) ${(epubLineHeight - 0.75) * 200}%, rgba(255, 255, 255, 0.1) 100%)`

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -244,7 +244,9 @@ export function ViewerTab() {
   ) => {
     try {
       await settingAPI.update(key, { value });
-      updateFn(value);
+      if (!getCurrentValue || getCurrentValue() === value) {
+        updateFn(value);
+      }
       setStatus({ type: "success", message: t("settings.viewer.toast.saved") });
     } catch (error) {
       console.error(`Failed to update setting ${key}:`, error);

--- a/web/src/components/settings/ViewerTab.tsx
+++ b/web/src/components/settings/ViewerTab.tsx
@@ -247,7 +247,7 @@ export function ViewerTab() {
     value: string,
     updateFn: (val: string) => void,
     getCurrentValue?: () => string,
-  ) => {
+  ): Promise<boolean> => {
     try {
       await settingAPI.update(key, { value });
       // getCurrentValue가 제공되면, 커밋 시점과 동일할 때만 UI에 반영 (레이스 방지)
@@ -255,6 +255,7 @@ export function ViewerTab() {
         updateFn(value);
         setStatus({ type: "success", message: t("settings.viewer.toast.saved") });
       }
+      return true;
     } catch (error) {
       console.error(`Failed to update setting ${key}:`, error);
       setStatus({ type: "error", message: t("settings.viewer.toast.save_failed") });
@@ -262,37 +263,46 @@ export function ViewerTab() {
       if (getCurrentValue && getCurrentValue() === value) {
         await syncEpubFontServerSettings();
       }
+      return false;
     }
   };
 
-  const handleFontSizeCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const handleFontSizeCommit = async (e: React.SyntheticEvent<HTMLInputElement>) => {
     const commitVal = e.currentTarget.value;
     if (lastCommittedFontSizeRef.current === commitVal) {
       return;
     }
+    const prevCommitted = lastCommittedFontSizeRef.current;
     lastCommittedFontSizeRef.current = commitVal;
-    handleSettingChange(
+    const success = await handleSettingChange(
       "epub_font_size",
       commitVal,
       (v) => setEpubFontSize(Number(v)),
       () => String(epubFontSizeRef.current),
     );
+    if (!success) {
+      lastCommittedFontSizeRef.current = prevCommitted;
+    }
   };
 
-  const handleLineHeightCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const handleLineHeightCommit = async (e: React.SyntheticEvent<HTMLInputElement>) => {
     const val = Number(e.currentTarget.value);
     const normalizedVal = Math.round(val * 100) / 100;
     const commitVal = String(normalizedVal);
     if (lastCommittedLineHeightRef.current === commitVal) {
       return;
     }
+    const prevCommitted = lastCommittedLineHeightRef.current;
     lastCommittedLineHeightRef.current = commitVal;
-    handleSettingChange(
+    const success = await handleSettingChange(
       "epub_line_height",
       commitVal,
       (v) => setEpubLineHeight(Number(v)),
       () => String(epubLineHeightRef.current),
     );
+    if (!success) {
+      lastCommittedLineHeightRef.current = prevCommitted;
+    }
   };
 
   const executeImagePdfReset = async () => {
@@ -344,8 +354,10 @@ export function ViewerTab() {
         settingAPI.update("epub_spread", { value: "auto" }),
         settingAPI.update("epub_flow", { value: "paginated" }),
         settingAPI.update("epub_font_size", { value: "100" }),
+        settingAPI.update("epub_font_size_mobile", { value: "100" }),
         settingAPI.update("epub_font_family", { value: "original" }),
         settingAPI.update("epub_line_height", { value: "1" }),
+        settingAPI.update("epub_line_height_mobile", { value: "1" }),
         settingAPI.update("epub_wheel_direction", { value: "down" }),
         settingAPI.update("epub_keyboard_direction", { value: "right" }),
         settingAPI.update("epub_click_direction", { value: "right" }),

--- a/web/src/features/viewer/hooks/useChapterLoader.ts
+++ b/web/src/features/viewer/hooks/useChapterLoader.ts
@@ -182,6 +182,11 @@ export function useChapterLoader({ chapterId }: UseChapterLoaderParams): UseChap
             if (!cancelled) setVolumeId(cachedChapter.volume_id);
           }
 
+          if (cachedNextData.seriesId) {
+            setSeriesId(cachedNextData.seriesId);
+            setCurrentSeriesId(cachedNextData.seriesId);
+          }
+
           let progress: ReadingProgress | null = null;
           if (!urlPage) {
             try {
@@ -233,21 +238,23 @@ export function useChapterLoader({ chapterId }: UseChapterLoaderParams): UseChap
           });
 
           // 부가 정보 로드 (비동기, 백그라운드 처리)
-          (async () => {
-            try {
-              if (cachedChapter.volume_id) {
-                const volumeRes = await volumeAPI.get(cachedChapter.volume_id);
-                if (cancelled) return;
-                const loadedSeriesId = volumeRes.data.series_id;
-                setSeriesId(loadedSeriesId);
-                if (loadedSeriesId) {
-                  setCurrentSeriesId(loadedSeriesId);
+          if (!cachedNextData.seriesId) {
+            (async () => {
+              try {
+                if (cachedChapter.volume_id) {
+                  const volumeRes = await volumeAPI.get(cachedChapter.volume_id);
+                  if (cancelled) return;
+                  const loadedSeriesId = volumeRes.data.series_id;
+                  setSeriesId(loadedSeriesId);
+                  if (loadedSeriesId) {
+                    setCurrentSeriesId(loadedSeriesId);
+                  }
                 }
+              } catch (e) {
+                console.warn("부가 정보 로드 실패", e);
               }
-            } catch (e) {
-              console.warn("부가 정보 로드 실패", e);
-            }
-          })();
+            })();
+          }
 
           return;
         }

--- a/web/src/features/viewer/hooks/useNextChapterPreloader.ts
+++ b/web/src/features/viewer/hooks/useNextChapterPreloader.ts
@@ -9,6 +9,7 @@ interface UseNextChapterPreloaderParams {
   currentChapterId: string | undefined; // 현재 챕터 ID (변경 시 상태 리셋용)
   isCurrentChapterLoaded: boolean;
   preloadCount?: number;
+  seriesId?: string | null;
 }
 
 /**
@@ -20,6 +21,7 @@ export function useNextChapterPreloader({
   currentChapterId,
   isCurrentChapterLoaded,
   preloadCount = 5,
+  seriesId,
 }: UseNextChapterPreloaderParams) {
   const { setNextChapterData } = useViewerStore();
   const [preloadedChapterId, setPreloadedChapterId] = useState<string | null>(null);
@@ -45,11 +47,11 @@ export function useNextChapterPreloader({
         const chapter = chapterRes.data;
 
         // 2. 시리즈 ID 가져오기
-        let seriesId: string | null = null;
-        if (chapter.volume_id) {
+        let finalSeriesId: string | null = seriesId || null;
+        if (!finalSeriesId && chapter.volume_id) {
           try {
             const volumeRes = await volumeAPI.get(chapter.volume_id);
-            seriesId = volumeRes.data.series_id || null;
+            finalSeriesId = volumeRes.data.series_id || null;
           } catch (e) {
             console.warn("[NextChapterPreloader] Failed to fetch volume for seriesId:", e);
           }
@@ -64,7 +66,7 @@ export function useNextChapterPreloader({
           chapterId: nextChapterId,
           chapter,
           pages,
-          seriesId,
+          seriesId: finalSeriesId,
         });
 
         // 5. 앞부분 이미지 브라우저 캐시 프리로드
@@ -87,7 +89,7 @@ export function useNextChapterPreloader({
     };
 
     preloadNextChapter();
-  }, [nextChapterId, isCurrentChapterLoaded, preloadedChapterId, preloadCount, setNextChapterData]);
+  }, [nextChapterId, isCurrentChapterLoaded, preloadedChapterId, preloadCount, seriesId, setNextChapterData]);
 
   return { isPreloaded: preloadedChapterId === nextChapterId };
 }

--- a/web/src/features/viewer/hooks/useNextChapterPreloader.ts
+++ b/web/src/features/viewer/hooks/useNextChapterPreloader.ts
@@ -67,7 +67,7 @@ export function useNextChapterPreloader({
           seriesId,
         });
 
-        // 4. 앞부분 이미지 브라우저 캐시 프리로드
+        // 5. 앞부분 이미지 브라우저 캐시 프리로드
         const count = Math.min(chapter.page_count, preloadCount);
         const images: HTMLImageElement[] = [];
 

--- a/web/src/features/viewer/hooks/useNextChapterPreloader.ts
+++ b/web/src/features/viewer/hooks/useNextChapterPreloader.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import { chapterAPI } from "../../../api/client";
+import { chapterAPI, volumeAPI } from "../../../api/client";
 import { getPageImageUrl } from "../utils/imageUrl";
 import { useViewerStore } from "../../../stores/viewerStore";
 import type { Page } from "../../../types/series";
@@ -44,15 +44,27 @@ export function useNextChapterPreloader({
         const chapterRes = await chapterAPI.get(nextChapterId);
         const chapter = chapterRes.data;
 
-        // 2. 페이지 목록 가져오기
+        // 2. 시리즈 ID 가져오기
+        let seriesId: string | null = null;
+        if (chapter.volume_id) {
+          try {
+            const volumeRes = await volumeAPI.get(chapter.volume_id);
+            seriesId = volumeRes.data.series_id || null;
+          } catch (e) {
+            console.warn("[NextChapterPreloader] Failed to fetch volume for seriesId:", e);
+          }
+        }
+
+        // 3. 페이지 목록 가져오기
         const pagesRes = await chapterAPI.getPages(nextChapterId);
         const pages: Page[] = pagesRes.data.pages || [];
 
-        // 3. 스토어에 캐시 데이터 저장 (useChapterLoader에서 즉시 로딩에 사용)
+        // 4. 스토어에 캐시 데이터 저장 (useChapterLoader에서 즉시 로딩에 사용)
         setNextChapterData({
           chapterId: nextChapterId,
           chapter,
           pages,
+          seriesId,
         });
 
         // 4. 앞부분 이미지 브라우저 캐시 프리로드

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -900,7 +900,9 @@ describe("EpubViewerRoute", () => {
       });
     });
 
-    expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    });
   });
 
   it("should not mark at last page when atEnd flag appears but progress is not at edge", async () => {
@@ -963,7 +965,9 @@ describe("EpubViewerRoute", () => {
       });
     });
 
-    expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    });
   });
 
   it("마지막 스프레드의 첫 위치에서는 마지막 페이지로 처리하지 않는다", async () => {
@@ -1027,7 +1031,9 @@ describe("EpubViewerRoute", () => {
       });
     });
 
-    expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(mockSetIsAtLastPage).toHaveBeenCalledWith(false);
+    });
   });
 
   it("locations 축이 끝까지 1이어도 pseudo page로 current_cfi를 저장한다", async () => {
@@ -1148,6 +1154,9 @@ describe("EpubViewerRoute", () => {
       });
     });
 
+    await waitFor(() => {
+      expect(mockSetCurrentCFI).toHaveBeenCalledWith("epubcfi(/6/2[chapter]!/4/8/10)");
+    });
     expect(epubProgressUpdateMock).not.toHaveBeenCalled();
   });
 

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -49,6 +49,8 @@ let latestViewerProps: {
   onBack?: () => void;
   onReachedStartPrev?: () => void;
   onFlowChange: (flow: "paginated" | "scrolled") => void;
+  onFontSizeChange?: (size: number) => void;
+  onLineHeightChange?: (height: number) => void;
 } | null = null;
 
 vi.mock("react-i18next", () => ({
@@ -57,10 +59,8 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-vi.mock("../stores/epubViewerStore", () => ({
-  normalizeEpubLineHeightScale: (value: number) => value,
-  EPUB_FONT_SIZE_DEFAULT: 100,
-  useEpubViewerStore: () => ({
+vi.mock("../stores/epubViewerStore", () => {
+  const getMockState = () => ({
     currentPage: 1,
     totalPages: 1,
     globalProgress: 0,
@@ -81,6 +81,8 @@ vi.mock("../stores/epubViewerStore", () => ({
       keyboardDirection: "ltr",
       clickDirection: "ltr",
     },
+    seriesSettings: {} as Record<string, unknown>,
+    updateSeriesSetting: vi.fn(),
     setCurrentCFI: mockSetCurrentCFI,
     setCurrentPage: vi.fn(),
     setTotalPages: vi.fn(),
@@ -109,8 +111,17 @@ vi.mock("../stores/epubViewerStore", () => ({
     setClickDirection: vi.fn(),
     isAtFirstPage: false,
     isAtLastPage: false,
-  }),
-}));
+  });
+
+  const useEpubViewerStoreMock = () => getMockState();
+  useEpubViewerStoreMock.getState = getMockState;
+
+  return {
+    normalizeEpubLineHeightScale: (value: number) => value,
+    EPUB_FONT_SIZE_DEFAULT: 100,
+    useEpubViewerStore: useEpubViewerStoreMock,
+  };
+});
 
 vi.mock("../components/modals/AlertModal", () => ({
   AlertModal: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) =>
@@ -138,6 +149,8 @@ vi.mock("./EpubViewer", () => ({
     onBack,
     onReachedStartPrev,
     onFlowChange,
+    onFontSizeChange,
+    onLineHeightChange,
   }: {
     onInitializationComplete: () => void;
     initialProgressRatio?: number | null;
@@ -160,6 +173,8 @@ vi.mock("./EpubViewer", () => ({
     onBack?: () => void;
     onReachedStartPrev?: () => void;
     onFlowChange: (flow: "paginated" | "scrolled") => void;
+    onFontSizeChange?: (size: number) => void;
+    onLineHeightChange?: (height: number) => void;
   }) => {
     latestViewerProps = {
       onInitializationComplete,
@@ -171,6 +186,8 @@ vi.mock("./EpubViewer", () => ({
       onBack,
       onReachedStartPrev,
       onFlowChange,
+      onFontSizeChange,
+      onLineHeightChange,
     };
     return (
       <div>
@@ -1407,5 +1424,101 @@ describe("EpubViewerRoute", () => {
       expect(mockSetFontSize).toHaveBeenCalledWith(100);
       expect(mockSetLineHeight).toHaveBeenCalledWith(1.2);
     });
+  });
+
+  it("isMobile()이 true일 때 모바일 전용 설정 키로 전역 글자 크기와 줄 간격을 저장한다", async () => {
+    vi.mocked(isMobile).mockReturnValue(true);
+    settingListMock.mockResolvedValue({});
+
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(latestViewerProps).not.toBeNull();
+    });
+
+    act(() => {
+      latestViewerProps?.onFontSizeChange?.(110);
+      latestViewerProps?.onLineHeightChange?.(1.15);
+    });
+
+    expect(settingUpdateMock).toHaveBeenCalledWith("epub_font_size_mobile", { value: "110" });
+    expect(settingUpdateMock).toHaveBeenCalledWith("epub_line_height_mobile", { value: "1.15" });
+  });
+
+  it("isMobile()이 false일 때 일반 설정 키로 전역 글자 크기와 줄 간격을 저장한다", async () => {
+    vi.mocked(isMobile).mockReturnValue(false);
+    settingListMock.mockResolvedValue({});
+
+    render(
+      <MemoryRouter initialEntries={["/viewer/chapter-1"]}>
+        <Routes>
+          <Route
+            path="/viewer/:chapterId"
+            element={
+              <EpubViewerRoute
+                loaderData={{
+                  chapter: {
+                    id: "chapter-1",
+                    volume_id: "volume-1",
+                    title: "EPUB 챕터",
+                    chapter_number: 1,
+                    page_count: 1,
+                  },
+                  isLoading: false,
+                  error: null,
+                  seriesId: "",
+                  volumeId: "volume-1",
+                  pageMeta: [],
+                  pageMetaMap: new Map(),
+                  isInitialScrollingRef: { current: false },
+                  setViewStatus: vi.fn(),
+                }}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(latestViewerProps).not.toBeNull();
+    });
+
+    act(() => {
+      latestViewerProps?.onFontSizeChange?.(110);
+      latestViewerProps?.onLineHeightChange?.(1.15);
+    });
+
+    expect(settingUpdateMock).toHaveBeenCalledWith("epub_font_size", { value: "110" });
+    expect(settingUpdateMock).toHaveBeenCalledWith("epub_line_height", { value: "1.15" });
   });
 });

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -59,6 +59,7 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("../stores/epubViewerStore", () => ({
   normalizeEpubLineHeightScale: (value: number) => value,
+  EPUB_FONT_SIZE_DEFAULT: 100,
   useEpubViewerStore: () => ({
     currentPage: 1,
     totalPages: 1,
@@ -93,6 +94,9 @@ vi.mock("../stores/epubViewerStore", () => ({
     setFullscreen: vi.fn(),
     setIncognito: mockSetIncognito,
     reset: mockReset,
+    setCurrentSeriesId: vi.fn(),
+    hideUI: vi.fn(),
+    showUI: vi.fn(),
     setFontSize: mockSetFontSize,
     setFontFamily: vi.fn(),
     setLineHeight: mockSetLineHeight,

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -930,7 +930,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         size,
         setFontSize,
         () => !seriesId
-          ? settingAPI.update("epub_font_size", { value: String(size) })
+          ? settingAPI.update(isMobile() ? "epub_font_size_mobile" : "epub_font_size", { value: String(size) })
           : seriesAPI.updateViewerSettings(seriesId, { epub_font_size: size })
       );
     },
@@ -958,7 +958,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         height,
         setLineHeight,
         () => !seriesId
-          ? settingAPI.update("epub_line_height", { value: String(height) })
+          ? settingAPI.update(isMobile() ? "epub_line_height_mobile" : "epub_line_height", { value: String(height) })
           : seriesAPI.updateViewerSettings(seriesId, { epub_line_height: height })
       );
     },

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -433,24 +433,21 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveRenderMode =
-          seriesSettings.epub_render_mode ||
-          libraryDefaults.default_epub_render_mode ||
-          globalRenderMode ||
-          "auto";
+          seriesSettings.epub_render_mode || libraryDefaults.default_epub_render_mode || globalRenderMode || "auto";
         if (effectiveRenderMode === "auto" || effectiveRenderMode === "book" || effectiveRenderMode === "comic") {
           setRenderMode(effectiveRenderMode);
         }
 
         const effectiveTheme =
-          seriesSettings.epub_theme || libraryDefaults.default_epub_theme || theme || (isTextFile ? TXT_DEFAULTS.theme : "light");
+          seriesSettings.epub_theme ||
+          libraryDefaults.default_epub_theme ||
+          theme ||
+          (isTextFile ? TXT_DEFAULTS.theme : "light");
         if (effectiveTheme === "light" || effectiveTheme === "dark" || effectiveTheme === "sepia") {
           setTheme(effectiveTheme);
         }
 
-        const effectiveFontSize =
-          seriesSettings.epub_font_size ||
-          fontSize ||
-          EPUB_FONT_SIZE_DEFAULT;
+        const effectiveFontSize = seriesSettings.epub_font_size || fontSize || EPUB_FONT_SIZE_DEFAULT;
         if (Number.isFinite(effectiveFontSize) && effectiveFontSize >= 50 && effectiveFontSize <= 150) {
           setFontSize(effectiveFontSize);
         }
@@ -462,24 +459,21 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveFontFamily =
-          seriesSettings.epub_font_family ||
-          fontFamily ||
-          (isTextFile ? TXT_DEFAULTS.fontFamily : "original");
-        if (effectiveFontFamily === "original" || effectiveFontFamily === "serif" || effectiveFontFamily === "sans-serif") {
+          seriesSettings.epub_font_family || fontFamily || (isTextFile ? TXT_DEFAULTS.fontFamily : "original");
+        if (
+          effectiveFontFamily === "original" ||
+          effectiveFontFamily === "serif" ||
+          effectiveFontFamily === "sans-serif"
+        ) {
           setFontFamily(effectiveFontFamily);
         }
 
-        const effectiveFlow =
-          seriesSettings.epub_flow || flow || "paginated";
+        const effectiveFlow = seriesSettings.epub_flow || flow || "paginated";
         if (effectiveFlow === "paginated" || effectiveFlow === "scrolled") {
           setFlow(effectiveFlow);
         }
 
-        const effectiveSpread =
-          seriesSettings.epub_spread ||
-          libraryDefaults.default_epub_spread ||
-          spread ||
-          "auto";
+        const effectiveSpread = seriesSettings.epub_spread || libraryDefaults.default_epub_spread || spread || "auto";
         if (effectiveSpread === "auto" || effectiveSpread === "none") {
           setSpread(effectiveSpread);
         }
@@ -518,7 +512,6 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         if (legacyKeyboardNavigation === "false") {
           setKeyboardDirection("right");
         }
-
       } catch (error) {
         if (cancelled) return;
         console.warn("[EpubViewerRoute] Failed to load EPUB user settings:", error);
@@ -889,24 +882,25 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
       setter: (v: EpubViewerSettings[K]) => void,
       apiCall: () => Promise<unknown>,
     ) => {
+      // 스토어에서 직접 최신값을 읽어 useCallback 의존성을 안정화한다
       const store = useEpubViewerStore.getState();
       const prev = store.settings[key];
-      const snapshotSeriesId = seriesId;
+      const snapshotSeriesId = store.currentSeriesId;
 
       setter(value);
 
       apiCall().catch((error) => {
         console.warn(`[EpubViewerRoute] Failed to save ${key}, rolling back:`, error);
-        
+
         const currentStore = useEpubViewerStore.getState();
-        
+
         if (snapshotSeriesId) {
           // Revert seriesSettings[snapshotSeriesId] if it hasn't been changed to a newer value
           const seriesConf = currentStore.seriesSettings[snapshotSeriesId];
           if (seriesConf && seriesConf[key] === value) {
             currentStore.updateSeriesSetting(snapshotSeriesId, { [key]: prev });
           }
-          
+
           // Revert active settings in the viewer if the user is still on the same series
           // and the current setting value hasn't been changed to a newer value
           if (currentStore.currentSeriesId === snapshotSeriesId && currentStore.settings[key] === value) {
@@ -920,18 +914,15 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
       });
     },
-    [seriesId],
+    [],
   );
 
   const handleFontSizeChange = useCallback(
     (size: number) => {
-      runOptimisticUpdate(
-        "fontSize",
-        size,
-        setFontSize,
-        () => !seriesId
+      runOptimisticUpdate("fontSize", size, setFontSize, () =>
+        !seriesId
           ? settingAPI.update(isMobile() ? "epub_font_size_mobile" : "epub_font_size", { value: String(size) })
-          : seriesAPI.updateViewerSettings(seriesId, { epub_font_size: size })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_font_size: size }),
       );
     },
     [seriesId, setFontSize, runOptimisticUpdate],
@@ -939,13 +930,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
 
   const handleFontFamilyChange = useCallback(
     (family: EpubFontFamily) => {
-      runOptimisticUpdate(
-        "fontFamily",
-        family,
-        setFontFamily,
-        () => !seriesId
+      runOptimisticUpdate("fontFamily", family, setFontFamily, () =>
+        !seriesId
           ? settingAPI.update("epub_font_family", { value: family })
-          : seriesAPI.updateViewerSettings(seriesId, { epub_font_family: family })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_font_family: family }),
       );
     },
     [seriesId, setFontFamily, runOptimisticUpdate],
@@ -953,13 +941,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
 
   const handleLineHeightChange = useCallback(
     (height: number) => {
-      runOptimisticUpdate(
-        "lineHeight",
-        height,
-        setLineHeight,
-        () => !seriesId
+      runOptimisticUpdate("lineHeight", height, setLineHeight, () =>
+        !seriesId
           ? settingAPI.update(isMobile() ? "epub_line_height_mobile" : "epub_line_height", { value: String(height) })
-          : seriesAPI.updateViewerSettings(seriesId, { epub_line_height: height })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_line_height: height }),
       );
     },
     [seriesId, setLineHeight, runOptimisticUpdate],
@@ -967,13 +952,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
 
   const handleThemeChange = useCallback(
     (themeVal: "light" | "dark" | "sepia") => {
-      runOptimisticUpdate(
-        "theme",
-        themeVal,
-        setTheme,
-        () => !seriesId
+      runOptimisticUpdate("theme", themeVal, setTheme, () =>
+        !seriesId
           ? settingAPI.update("epub_theme", { value: themeVal })
-          : seriesAPI.updateViewerSettings(seriesId, { epub_theme: themeVal })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_theme: themeVal }),
       );
     },
     [seriesId, setTheme, runOptimisticUpdate],

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -889,14 +889,38 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
       setter: (v: EpubViewerSettings[K]) => void,
       apiCall: () => Promise<unknown>,
     ) => {
-      const prev = useEpubViewerStore.getState().settings[key];
+      const store = useEpubViewerStore.getState();
+      const prev = store.settings[key];
+      const snapshotSeriesId = seriesId;
+
       setter(value);
+
       apiCall().catch((error) => {
         console.warn(`[EpubViewerRoute] Failed to save ${key}, rolling back:`, error);
-        setter(prev);
+        
+        const currentStore = useEpubViewerStore.getState();
+        
+        if (snapshotSeriesId) {
+          // Revert seriesSettings[snapshotSeriesId] if it hasn't been changed to a newer value
+          const seriesConf = currentStore.seriesSettings[snapshotSeriesId];
+          if (seriesConf && seriesConf[key] === value) {
+            currentStore.updateSeriesSetting(snapshotSeriesId, { [key]: prev });
+          }
+          
+          // Revert active settings in the viewer if the user is still on the same series
+          // and the current setting value hasn't been changed to a newer value
+          if (currentStore.currentSeriesId === snapshotSeriesId && currentStore.settings[key] === value) {
+            setter(prev);
+          }
+        } else {
+          // Global settings rollback: revert only if the active setting matches the optimistic value
+          if (currentStore.settings[key] === value) {
+            setter(prev);
+          }
+        }
       });
     },
-    [],
+    [seriesId],
   );
 
   const handleFontSizeChange = useCallback(

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from "react-i18next";
 import {
   normalizeEpubLineHeightScale,
   useEpubViewerStore,
+  EPUB_FONT_SIZE_DEFAULT,
   type EpubFontFamily,
   type EpubFlow,
   type EpubRenderMode,
+  type EpubViewerSettings,
 } from "../stores/epubViewerStore";
 import { enterFullscreen, exitFullscreen, isFullscreen as isDocumentFullscreen } from "../utils/fullscreen";
 import { isMobile } from "../utils/device";
@@ -129,6 +131,11 @@ function getGeneratedTextProgressRatio(
   return null;
 }
 
+const TXT_DEFAULTS = {
+  theme: "dark" as const,
+  fontFamily: "sans-serif" as const,
+};
+
 export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   const { chapterId: routeChapterId } = useParams<{ chapterId: string }>();
   const { t } = useTranslation();
@@ -171,6 +178,9 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
     setFullscreen,
 
     reset,
+    setCurrentSeriesId,
+    hideUI,
+    showUI,
     setFontSize,
     setFontFamily,
     setLineHeight,
@@ -354,13 +364,18 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   }, [chapterId, reset, scheduleObjectUrlRevoke, setCurrentCFI, setGlobalProgress, shouldOpenLastPage]);
 
   // EPUB 뷰어 사용자 설정 로드
+  const chapterPath = chapter?.path ?? "";
+
   useEffect(() => {
-    if (!chapterId) return;
+    if (!chapterId || loaderData.isLoading) return;
     let cancelled = false;
     setEpubSettingsLoaded(false);
 
     const loadEpubSettings = async () => {
       try {
+        // 시리즈 ID 설정 (이후 사용자 설정 변경 시 시리즈별로 추적)
+        setCurrentSeriesId(seriesId || null);
+
         const userSettings = await settingAPI.list();
         if (cancelled) return;
         const isMobileDevice = isMobile();
@@ -390,16 +405,9 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         } = {};
         let seriesSettings: Partial<UserSeriesSetting> = {};
 
-        if (Number.isFinite(fontSize) && fontSize >= 50 && fontSize <= 150) {
-          setFontSize(fontSize);
-        }
-        const normalizedLineHeight = normalizeEpubLineHeightScale(lineHeight);
-        if (normalizedLineHeight != null) {
-          setLineHeight(normalizedLineHeight);
-        }
-        if (fontFamily === "original" || fontFamily === "serif" || fontFamily === "sans-serif") {
-          setFontFamily(fontFamily);
-        }
+        // TXT 파일 여부 확인 (TXT 전용 기본값 적용용)
+        const isTextFile = chapterPath.toLowerCase().endsWith(".txt");
+
         if (seriesId) {
           try {
             const seriesRes = await seriesAPI.get(seriesId);
@@ -434,9 +442,31 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         }
 
         const effectiveTheme =
-          seriesSettings.epub_theme || libraryDefaults.default_epub_theme || theme || "light";
+          seriesSettings.epub_theme || libraryDefaults.default_epub_theme || theme || (isTextFile ? TXT_DEFAULTS.theme : "light");
         if (effectiveTheme === "light" || effectiveTheme === "dark" || effectiveTheme === "sepia") {
           setTheme(effectiveTheme);
+        }
+
+        const effectiveFontSize =
+          seriesSettings.epub_font_size ||
+          fontSize ||
+          EPUB_FONT_SIZE_DEFAULT;
+        if (Number.isFinite(effectiveFontSize) && effectiveFontSize >= 50 && effectiveFontSize <= 150) {
+          setFontSize(effectiveFontSize);
+        }
+
+        const rawLineHeight = seriesSettings.epub_line_height || lineHeight;
+        const normalizedLineHeight = normalizeEpubLineHeightScale(rawLineHeight);
+        if (normalizedLineHeight != null) {
+          setLineHeight(normalizedLineHeight);
+        }
+
+        const effectiveFontFamily =
+          seriesSettings.epub_font_family ||
+          fontFamily ||
+          (isTextFile ? TXT_DEFAULTS.fontFamily : "original");
+        if (effectiveFontFamily === "original" || effectiveFontFamily === "serif" || effectiveFontFamily === "sans-serif") {
+          setFontFamily(effectiveFontFamily);
         }
 
         const effectiveFlow =
@@ -488,6 +518,7 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
         if (legacyKeyboardNavigation === "false") {
           setKeyboardDirection("right");
         }
+
       } catch (error) {
         if (cancelled) return;
         console.warn("[EpubViewerRoute] Failed to load EPUB user settings:", error);
@@ -504,7 +535,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
     };
   }, [
     chapterId,
+    chapterPath,
     seriesId,
+    loaderData.isLoading,
+    setCurrentSeriesId,
     setFontFamily,
     setFontSize,
     setLineHeight,
@@ -516,6 +550,13 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
     setKeyboardDirection,
     setClickDirection,
   ]);
+
+  // 뷰어 종료 시 시리즈 ID 초기화
+  useEffect(() => {
+    return () => {
+      setCurrentSeriesId(null);
+    };
+  }, [setCurrentSeriesId]);
 
   // 전체화면 브라우저 이벤트 동기화
   useEffect(() => {
@@ -558,10 +599,10 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
     if (uiTimerRef.current) clearTimeout(uiTimerRef.current);
     if (!isSettingsOpen && !isInteractingRef.current) {
       uiTimerRef.current = window.setTimeout(() => {
-        useEpubViewerStore.getState().hideUI();
+        hideUI();
       }, 3000);
     }
-  }, [isSettingsOpen]);
+  }, [isSettingsOpen, hideUI]);
 
   const handleInteractionStart = useCallback(() => {
     isInteractingRef.current = true;
@@ -575,25 +616,24 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
       const elapsed = now - uiShownTimeRef.current;
       // UI_HIDE_DELAY (2000ms 또는 3000ms 등) 이상 이미 노출된 상태에서 호버가 끝났다면 즉시 숨김
       if (elapsed >= 3000) {
-        useEpubViewerStore.getState().hideUI();
+        hideUI();
       } else {
         resetUITimer();
       }
     }
-  }, [isUIVisible, resetUITimer]);
+  }, [isUIVisible, resetUITimer, hideUI]);
 
   // 클릭 시 UI 토글
   const toggleUIWithTimer = useCallback(() => {
-    const state = useEpubViewerStore.getState();
-    if (state.isUIVisible) {
+    if (isUIVisible) {
       if (uiTimerRef.current) clearTimeout(uiTimerRef.current);
-      state.hideUI();
+      hideUI();
     } else {
-      state.showUI();
+      showUI();
       uiShownTimeRef.current = Date.now();
       resetUITimer();
     }
-  }, [resetUITimer]);
+  }, [isUIVisible, resetUITimer, hideUI, showUI]);
 
   const handleViewerClick = useCallback(() => {
     toggleUIWithTimer();
@@ -842,50 +882,77 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
     setToc(loadedTOC);
   }, []);
 
-  const handleFontSizeChange = useCallback(
-    (size: number) => {
-      setFontSize(size);
-      void settingAPI.update("epub_font_size", { value: String(size) }).catch((error) => {
-        console.warn("[EpubViewerRoute] Failed to save epub_font_size:", error);
+  const runOptimisticUpdate = useCallback(
+    <K extends keyof EpubViewerSettings>(
+      key: K,
+      value: EpubViewerSettings[K],
+      setter: (v: EpubViewerSettings[K]) => void,
+      apiCall: () => Promise<unknown>,
+    ) => {
+      const prev = useEpubViewerStore.getState().settings[key];
+      setter(value);
+      apiCall().catch((error) => {
+        console.warn(`[EpubViewerRoute] Failed to save ${key}, rolling back:`, error);
+        setter(prev);
       });
     },
-    [setFontSize],
+    [],
+  );
+
+  const handleFontSizeChange = useCallback(
+    (size: number) => {
+      runOptimisticUpdate(
+        "fontSize",
+        size,
+        setFontSize,
+        () => !seriesId
+          ? settingAPI.update("epub_font_size", { value: String(size) })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_font_size: size })
+      );
+    },
+    [seriesId, setFontSize, runOptimisticUpdate],
   );
 
   const handleFontFamilyChange = useCallback(
     (family: EpubFontFamily) => {
-      setFontFamily(family);
-      void settingAPI.update("epub_font_family", { value: family }).catch((error) => {
-        console.warn("[EpubViewerRoute] Failed to save epub_font_family:", error);
-      });
+      runOptimisticUpdate(
+        "fontFamily",
+        family,
+        setFontFamily,
+        () => !seriesId
+          ? settingAPI.update("epub_font_family", { value: family })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_font_family: family })
+      );
     },
-    [setFontFamily],
+    [seriesId, setFontFamily, runOptimisticUpdate],
   );
 
   const handleLineHeightChange = useCallback(
     (height: number) => {
-      setLineHeight(height);
-      void settingAPI.update("epub_line_height", { value: String(height) }).catch((error) => {
-        console.warn("[EpubViewerRoute] Failed to save epub_line_height:", error);
-      });
+      runOptimisticUpdate(
+        "lineHeight",
+        height,
+        setLineHeight,
+        () => !seriesId
+          ? settingAPI.update("epub_line_height", { value: String(height) })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_line_height: height })
+      );
     },
-    [setLineHeight],
+    [seriesId, setLineHeight, runOptimisticUpdate],
   );
 
   const handleThemeChange = useCallback(
-    (theme: "light" | "dark" | "sepia") => {
-      setTheme(theme);
-      if (!seriesId) {
-        void settingAPI.update("epub_theme", { value: theme }).catch((error) => {
-          console.warn("[EpubViewerRoute] Failed to save global epub_theme:", error);
-        });
-        return;
-      }
-      void seriesAPI.updateViewerSettings(seriesId, { epub_theme: theme }).catch((error) => {
-        console.warn("[EpubViewerRoute] Failed to save series epub_theme:", error);
-      });
+    (themeVal: "light" | "dark" | "sepia") => {
+      runOptimisticUpdate(
+        "theme",
+        themeVal,
+        setTheme,
+        () => !seriesId
+          ? settingAPI.update("epub_theme", { value: themeVal })
+          : seriesAPI.updateViewerSettings(seriesId, { epub_theme: themeVal })
+      );
     },
-    [seriesId, setTheme],
+    [seriesId, setTheme, runOptimisticUpdate],
   );
 
   const handleSpreadChange = useCallback(

--- a/web/src/pages/ImageViewerRoute.tsx
+++ b/web/src/pages/ImageViewerRoute.tsx
@@ -392,6 +392,7 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
     currentChapterId: chapterId,
     isCurrentChapterLoaded: !!isCurrentChapterLoaded,
     preloadCount: 5,
+    seriesId,
   });
 
   // 웹소켓 실시간 동기화 및 중복 세션 제어

--- a/web/src/stores/epubViewerStore.test.ts
+++ b/web/src/stores/epubViewerStore.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { normalizeEpubLineHeightScale } from "./epubViewerStore";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useEpubViewerStore, normalizeEpubLineHeightScale } from "./epubViewerStore";
 
 describe("normalizeEpubLineHeightScale", () => {
   it("새 배율 범위 내의 값은 그대로 유지한다", () => {
@@ -12,5 +12,92 @@ describe("normalizeEpubLineHeightScale", () => {
   it("기존 절대 줄 간격(> 1.25 및 <= 2.0)을 새 배율 범위로 변환한다", () => {
     expect(normalizeEpubLineHeightScale(1.6)).toBe(1.0);
     expect(normalizeEpubLineHeightScale(2.0)).toBe(1.25);
+  });
+});
+
+describe("epubViewerStore series settings", () => {
+  beforeEach(() => {
+    useEpubViewerStore.getState().reset();
+    useEpubViewerStore.setState({ seriesSettings: {}, currentSeriesId: null });
+  });
+
+  it("currentSeriesId가 설정되지 않으면 seriesSettings에 저장하지 않는다", () => {
+    const store = useEpubViewerStore.getState();
+    store.setTheme("dark");
+    expect(useEpubViewerStore.getState().seriesSettings).toEqual({});
+  });
+
+  it("currentSeriesId가 설정된 경우 설정 변경 시 seriesSettings에 저장한다", () => {
+    const store = useEpubViewerStore.getState();
+    store.setCurrentSeriesId("series-1");
+    store.setTheme("dark");
+    expect(useEpubViewerStore.getState().seriesSettings["series-1"]).toMatchObject({
+      theme: "dark",
+    });
+  });
+
+  it("같은 시리즈에서 여러 설정을 변경하면 누적된다", () => {
+    const store = useEpubViewerStore.getState();
+    store.setCurrentSeriesId("series-2");
+    store.setTheme("sepia");
+    store.setFontSize(120);
+    store.setFlow("scrolled");
+    expect(useEpubViewerStore.getState().seriesSettings["series-2"]).toEqual({
+      theme: "sepia",
+      fontSize: 120,
+      flow: "scrolled",
+    });
+  });
+
+  it("다른 시리즈의 설정은 서로 격리된다", () => {
+    const store = useEpubViewerStore.getState();
+    store.setCurrentSeriesId("series-a");
+    store.setTheme("dark");
+    store.setCurrentSeriesId("series-b");
+    store.setTheme("light");
+    expect(useEpubViewerStore.getState().seriesSettings["series-a"]).toEqual({ theme: "dark" });
+    expect(useEpubViewerStore.getState().seriesSettings["series-b"]).toEqual({ theme: "light" });
+  });
+
+  it("updateSeriesSetting으로 직접 시리즈 설정을 업데이트할 수 있다", () => {
+    const store = useEpubViewerStore.getState();
+    store.updateSeriesSetting("series-3", { fontFamily: "serif", lineHeight: 1.1 });
+    expect(useEpubViewerStore.getState().seriesSettings["series-3"]).toEqual({
+      fontFamily: "serif",
+      lineHeight: 1.1,
+    });
+  });
+
+  it("reset은 seriesSettings를 초기화하지 않는다", () => {
+    const store = useEpubViewerStore.getState();
+    store.setCurrentSeriesId("series-1");
+    store.setTheme("dark");
+    store.reset();
+    expect(useEpubViewerStore.getState().seriesSettings["series-1"]).toEqual({ theme: "dark" });
+  });
+
+  it("seriesSettings 개수가 50개를 초과하면 가장 오래된(처음 추가된) 설정을 삭제한다", () => {
+    const store = useEpubViewerStore.getState();
+    for (let i = 1; i <= 51; i++) {
+      store.updateSeriesSetting(`series-${i}`, { theme: "dark" });
+    }
+    const settings = useEpubViewerStore.getState().seriesSettings;
+    expect(Object.keys(settings).length).toBe(50);
+    expect(settings["series-1"]).toBeUndefined();
+    expect(settings["series-51"]).toEqual({ theme: "dark" });
+  });
+
+  it("buildSettingUpdate (setter 호출) 시에도 seriesSettings 개수가 50개를 초과하면 eviction이 작동한다", () => {
+    const store = useEpubViewerStore.getState();
+    for (let i = 1; i <= 50; i++) {
+      store.updateSeriesSetting(`series-${i}`, { theme: "light" });
+    }
+    store.setCurrentSeriesId("series-51");
+    store.setTheme("dark");
+
+    const settings = useEpubViewerStore.getState().seriesSettings;
+    expect(Object.keys(settings).length).toBe(50);
+    expect(settings["series-1"]).toBeUndefined();
+    expect(settings["series-51"]).toEqual({ theme: "dark" });
   });
 });

--- a/web/src/stores/epubViewerStore.ts
+++ b/web/src/stores/epubViewerStore.ts
@@ -58,8 +58,12 @@ interface EpubViewerState {
 
   // 설정
   settings: EpubViewerSettings;
+  seriesSettings: Record<string, Partial<EpubViewerSettings>>; // 시리즈별 개별 설정 저장
+  currentSeriesId: string | null;
 
   // 액션
+  setCurrentSeriesId: (id: string | null) => void;
+  updateSeriesSetting: (seriesId: string, newSettings: Partial<EpubViewerSettings>) => void;
   setCurrentCFI: (cfi: string | null) => void;
   setCurrentPage: (page: number) => void;
   setTotalPages: (total: number) => void;
@@ -103,6 +107,40 @@ const defaultSettings: EpubViewerSettings = {
   keyboardDirection: "right",
   clickDirection: "right",
 };
+const MAX_SERIES_SETTINGS = 50;
+
+const enforceSeriesSettingsLimit = (
+  settings: Record<string, Partial<EpubViewerSettings>>,
+): Record<string, Partial<EpubViewerSettings>> => {
+  const keys = Object.keys(settings);
+  if (keys.length <= MAX_SERIES_SETTINGS) {
+    return settings;
+  }
+  const rest = { ...settings };
+  delete rest[keys[0]];
+  return rest;
+};
+
+const buildSettingUpdate = <K extends keyof EpubViewerSettings>(
+  state: EpubViewerState,
+  key: K,
+  value: EpubViewerSettings[K],
+): Partial<EpubViewerState> => {
+  const updates: Partial<EpubViewerState> = {
+    settings: { ...state.settings, [key]: value },
+  };
+  if (state.currentSeriesId) {
+    const nextSettings = {
+      ...state.seriesSettings,
+      [state.currentSeriesId]: {
+        ...(state.seriesSettings[state.currentSeriesId] || {}),
+        [key]: value,
+      },
+    };
+    updates.seriesSettings = enforceSeriesSettingsLimit(nextSettings);
+  }
+  return updates;
+};
 
 export const useEpubViewerStore = create<EpubViewerState>()(
   devtools(
@@ -119,6 +157,21 @@ export const useEpubViewerStore = create<EpubViewerState>()(
       isAtFirstPage: false,
       isAtLastPage: false,
       settings: defaultSettings,
+      seriesSettings: {},
+      currentSeriesId: null,
+
+      setCurrentSeriesId: (id) => set({ currentSeriesId: id }),
+      updateSeriesSetting: (seriesId, newSettings) =>
+        set((state) => {
+          const nextSettings = {
+            ...state.seriesSettings,
+            [seriesId]: {
+              ...(state.seriesSettings[seriesId] || {}),
+              ...newSettings,
+            },
+          };
+          return { seriesSettings: enforceSeriesSettingsLimit(nextSettings) };
+        }),
 
       setCurrentCFI: (cfi) => set({ currentCFI: cfi }),
       setCurrentPage: (page) => set({ currentPage: page }),
@@ -171,57 +224,38 @@ export const useEpubViewerStore = create<EpubViewerState>()(
           isAtFirstPage: false,
           isAtLastPage: false,
           settings: defaultSettings,
+          currentSeriesId: null,
         }),
 
       setFontSize: (size) =>
-        set((state) => ({
-          settings: { ...state.settings, fontSize: size },
-        })),
+        set((state) => buildSettingUpdate(state, "fontSize", size)),
 
       setFontFamily: (family) =>
-        set((state) => ({
-          settings: { ...state.settings, fontFamily: family },
-        })),
+        set((state) => buildSettingUpdate(state, "fontFamily", family)),
 
       setLineHeight: (height) =>
-        set((state) => ({
-          settings: { ...state.settings, lineHeight: height },
-        })),
+        set((state) => buildSettingUpdate(state, "lineHeight", height)),
 
       setTheme: (theme) =>
-        set((state) => ({
-          settings: { ...state.settings, theme },
-        })),
+        set((state) => buildSettingUpdate(state, "theme", theme)),
 
       setRenderMode: (mode) =>
-        set((state) => ({
-          settings: { ...state.settings, renderMode: mode },
-        })),
+        set((state) => buildSettingUpdate(state, "renderMode", mode)),
 
       setFlow: (flow) =>
-        set((state) => ({
-          settings: { ...state.settings, flow },
-        })),
+        set((state) => buildSettingUpdate(state, "flow", flow)),
 
       setSpread: (spread) =>
-        set((state) => ({
-          settings: { ...state.settings, spread },
-        })),
+        set((state) => buildSettingUpdate(state, "spread", spread)),
 
       setWheelDirection: (direction) =>
-        set((state) => ({
-          settings: { ...state.settings, wheelDirection: direction },
-        })),
+        set((state) => buildSettingUpdate(state, "wheelDirection", direction)),
 
       setKeyboardDirection: (direction) =>
-        set((state) => ({
-          settings: { ...state.settings, keyboardDirection: direction },
-        })),
+        set((state) => buildSettingUpdate(state, "keyboardDirection", direction)),
 
       setClickDirection: (direction) =>
-        set((state) => ({
-          settings: { ...state.settings, clickDirection: direction },
-        })),
+        set((state) => buildSettingUpdate(state, "clickDirection", direction)),
     }),
     {
       name: "kumiho-epub-viewer-settings",

--- a/web/src/stores/epubViewerStore.ts
+++ b/web/src/stores/epubViewerStore.ts
@@ -95,7 +95,7 @@ interface EpubViewerState {
   setClickDirection: (direction: "right" | "left") => void;
 }
 
-const defaultSettings: EpubViewerSettings = {
+const defaultSettings: EpubViewerSettings = Object.freeze({
   fontSize: EPUB_FONT_SIZE_DEFAULT,
   fontFamily: "original",
   lineHeight: EPUB_LINE_HEIGHT_SCALE_DEFAULT,
@@ -106,9 +106,10 @@ const defaultSettings: EpubViewerSettings = {
   wheelDirection: "down",
   keyboardDirection: "right",
   clickDirection: "right",
-};
+});
 const MAX_SERIES_SETTINGS = 50;
 
+// Write-LRU: 저장/갱신 시점만 추적하여 evict 순서를 결정한다.
 const enforceSeriesSettingsLimit = (
   settings: Record<string, Partial<EpubViewerSettings>>,
 ): Record<string, Partial<EpubViewerSettings>> => {

--- a/web/src/stores/epubViewerStore.ts
+++ b/web/src/stores/epubViewerStore.ts
@@ -130,12 +130,13 @@ const buildSettingUpdate = <K extends keyof EpubViewerSettings>(
     settings: { ...state.settings, [key]: value },
   };
   if (state.currentSeriesId) {
-    const nextSettings = {
-      ...state.seriesSettings,
-      [state.currentSeriesId]: {
-        ...(state.seriesSettings[state.currentSeriesId] || {}),
-        [key]: value,
-      },
+    const nextSettings = { ...state.seriesSettings };
+    const existing = nextSettings[state.currentSeriesId] || {};
+    // delete and re-insert to move key to the end of insertion order (LRU)
+    delete nextSettings[state.currentSeriesId];
+    nextSettings[state.currentSeriesId] = {
+      ...existing,
+      [key]: value,
     };
     updates.seriesSettings = enforceSeriesSettingsLimit(nextSettings);
   }
@@ -163,12 +164,13 @@ export const useEpubViewerStore = create<EpubViewerState>()(
       setCurrentSeriesId: (id) => set({ currentSeriesId: id }),
       updateSeriesSetting: (seriesId, newSettings) =>
         set((state) => {
-          const nextSettings = {
-            ...state.seriesSettings,
-            [seriesId]: {
-              ...(state.seriesSettings[seriesId] || {}),
-              ...newSettings,
-            },
+          const nextSettings = { ...state.seriesSettings };
+          const existing = nextSettings[seriesId] || {};
+          // delete and re-insert to move key to the end of insertion order (LRU)
+          delete nextSettings[seriesId];
+          nextSettings[seriesId] = {
+            ...existing,
+            ...newSettings,
           };
           return { seriesSettings: enforceSeriesSettingsLimit(nextSettings) };
         }),

--- a/web/src/stores/viewerStore.ts
+++ b/web/src/stores/viewerStore.ts
@@ -104,8 +104,9 @@ interface ViewerState {
     chapterId: string;
     chapter: Chapter;
     pages: Page[];
+    seriesId?: string | null;
   } | null;
-  setNextChapterData: (data: { chapterId: string; chapter: Chapter; pages: Page[] } | null) => void;
+  setNextChapterData: (data: { chapterId: string; chapter: Chapter; pages: Page[]; seriesId?: string | null } | null) => void;
 }
 
 const defaultSettings: ViewerSettings = {

--- a/web/src/types/series.ts
+++ b/web/src/types/series.ts
@@ -175,6 +175,9 @@ export interface UserSeriesSetting {
   epub_wheel_direction?: string;
   epub_keyboard_direction?: string;
   epub_click_direction?: string;
+  epub_font_size?: number;
+  epub_font_family?: string;
+  epub_line_height?: number;
   reading_direction?: string;
   wheel_direction?: string;
   swipe_direction?: string;


### PR DESCRIPTION
## 변경 사항
- EPUB/TXT 뷰어의 글자 크기, 글꼴, 줄 간격 옵션을 시리즈별 개별 저장(`user_series_settings`)할 수 있도록 DB 스키마(마이그레이션 #45) 및 백엔드/프론트엔드 통신 로직 확장
- 뷰어 내 폰트/줄간격/글꼴 변경 핸들러를 공통 제네릭 낙관적 업데이트 헬퍼(`runOptimisticUpdate`)를 통해 리팩토링 및 실패 시 자동 롤백 적용
- 설정 > 뷰어 탭의 EPUB/TXT 전역 기본값 섹션 내에서 '레이아웃' 옵션과 '기본 테마' 옵션의 표시 순서를 스왑하여 사용자 가독성 향상
- 브라우저 기본 range input의 padding/border 오차로 인해 슬라이더 핸들이 끝까지 당겨지지 않던 Webkit 렌더링 버그 해결을 위해 pseudo-elements를 포함한 프리미엄 커스텀 슬라이더 스타일 적용
- 슬라이더의 가로 너비를 200px로 제한하여 우측의 다른 선택 상자(Select Box)들과 정렬선을 통일하고, 슬라이더 바의 진행 영역이 실시간 수치에 따라 동적으로 `#667eea` 색상으로 채워지도록 그라데이션 적용
- eslint의 미사용 변수(`no-unused-vars`) 경고를 객체 복사 후 delete 연산자 적용 방식으로 리팩토링하여 빌드/린트 에러 완전 차단

## 테스트
- [x] 백엔드 유닛 테스트 빌드 및 `go vet ./...` 수행 결과 정상 완료
- [x] 프론트엔드 Vitest 전체 검증(총 42개 테스트 파일, 294개 테스트 케이스) 100% 통과 완료
- [x] `npm run build` 및 `npm run lint` 수행 결과 에러 없음 확인
