### PR TITLE
fix(viewer): #324 뷰어 마지막/첫 페이지 챕터 이동 시 slide 애니메이션 억제

### DIFF
--- a/web/src/features/viewer/components/PdfChapterViewer/index.tsx
+++ b/web/src/features/viewer/components/PdfChapterViewer/index.tsx
@@ -198,6 +198,10 @@ interface PdfChapterViewerProps {
   onPrev: (delta?: number | React.MouseEvent) => void;
   onOutlineLoad?: (outline: PDFOutlineItem[]) => void;
   transitionType: PageTransitionType;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
   onZoomChange?: (scale: number) => void;
   onPageChange?: (page: number) => void;
 }
@@ -218,6 +222,8 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
       onPrev,
       onOutlineLoad,
       transitionType,
+      canGoNextChapter = false,
+      canGoPrevChapter = false,
       onZoomChange,
       onPageChange,
     },
@@ -256,14 +262,24 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
     const animatePrevRef = useRef<(() => void) | null>(null);
 
     const handleAnimatedNext = useCallback(() => {
-      if (animateNextRef.current) animateNextRef.current();
-      else onNext(readingMode === "double" ? 2 : 1);
-    }, [onNext, readingMode]);
+      if (canGoNextChapter) {
+        onNext(readingMode === "double" ? 2 : 1);
+      } else if (animateNextRef.current) {
+        animateNextRef.current();
+      } else {
+        onNext(readingMode === "double" ? 2 : 1);
+      }
+    }, [canGoNextChapter, onNext, readingMode]);
 
     const handleAnimatedPrev = useCallback(() => {
-      if (animatePrevRef.current) animatePrevRef.current();
-      else onPrev(readingMode === "double" ? 2 : 1);
-    }, [onPrev, readingMode]);
+      if (canGoPrevChapter) {
+        onPrev(readingMode === "double" ? 2 : 1);
+      } else if (animatePrevRef.current) {
+        animatePrevRef.current();
+      } else {
+        onPrev(readingMode === "double" ? 2 : 1);
+      }
+    }, [canGoPrevChapter, onPrev, readingMode]);
     const getVerticalScrollContainer = () => {
       const parent = containerRef.current?.parentElement;
       return parent instanceof HTMLElement ? parent : null;
@@ -1035,6 +1051,8 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
       containerRef,
       gap: 20,
       duration: 300,
+      skipNextAnimation: canGoNextChapter,
+      skipPrevAnimation: canGoPrevChapter,
     });
 
     // Keep refs in sync with useSwipe's animation functions

--- a/web/src/features/viewer/components/ViewerContent/index.tsx
+++ b/web/src/features/viewer/components/ViewerContent/index.tsx
@@ -43,6 +43,10 @@ interface ViewerContentProps {
   isInitialScrolling?: boolean; // Boolean으로 회복
   estimatedPageHeights?: Map<number, number>;
   viewStatus?: ViewStatus;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (다음 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (이전 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
 }
 
 export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentProps>(
@@ -73,6 +77,8 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
       isInitialScrolling = false,
       estimatedPageHeights,
       viewStatus = "ready",
+      canGoNextChapter = false,
+      canGoPrevChapter = false,
     },
     ref,
   ) => {
@@ -83,14 +89,24 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
     const animatePrevRef = useRef<(() => void) | null>(null);
 
     const handleAnimatedNext = useCallback(() => {
-      if (animateNextRef.current) animateNextRef.current();
-      else onNext();
-    }, [onNext]);
+      if (canGoNextChapter) {
+        onNext();
+      } else if (animateNextRef.current) {
+        animateNextRef.current();
+      } else {
+        onNext();
+      }
+    }, [canGoNextChapter, onNext]);
 
     const handleAnimatedPrev = useCallback(() => {
-      if (animatePrevRef.current) animatePrevRef.current();
-      else onPrev();
-    }, [onPrev]);
+      if (canGoPrevChapter) {
+        onPrev();
+      } else if (animatePrevRef.current) {
+        animatePrevRef.current();
+      } else {
+        onPrev();
+      }
+    }, [canGoPrevChapter, onPrev]);
     const { transformComponentRef, isZoomed, setIsZoomed, handleContentClick, handleMouseDown, handleMouseMove } =
       useViewerZoom({
         clickDirection,
@@ -116,6 +132,8 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
       containerRef,
       gap: PAGE_GAP,
       duration: 300,
+      skipNextAnimation: canGoNextChapter,
+      skipPrevAnimation: canGoPrevChapter,
     });
 
     // Vertical 모드일 때는 이벤트 핸들러를 null로 처리하여 스와이프 방지

--- a/web/src/features/viewer/hooks/useSwipe.ts
+++ b/web/src/features/viewer/hooks/useSwipe.ts
@@ -11,6 +11,10 @@ interface UseSwipeParams {
   containerRef?: React.RefObject<HTMLDivElement | null>;
   gap?: number;
   duration?: number;
+  /** true면 다음 페이지로의 스와이프 임계값 도달 시 애니메이션 없이 즉시 onNext 호출 */
+  skipNextAnimation?: boolean;
+  /** true면 이전 페이지로의 스와이프 임계값 도달 시 애니메이션 없이 즉시 onPrev 호출 */
+  skipPrevAnimation?: boolean;
 }
 
 export function useSwipe({
@@ -23,6 +27,8 @@ export function useSwipe({
   containerRef,
   gap = 20,
   duration = 300,
+  skipNextAnimation = false,
+  skipPrevAnimation = false,
 }: UseSwipeParams) {
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
@@ -112,6 +118,18 @@ export function useSwipe({
       isNext = isRTL;
     }
 
+    // 방향별로 애니메이션 억제 여부 확인
+    if (isNext && skipNextAnimation) {
+      setSwipeOffset(0);
+      onNext();
+      return;
+    }
+    if (!isNext && skipPrevAnimation) {
+      setSwipeOffset(0);
+      onPrev();
+      return;
+    }
+
     const targetOffset = finalOffset < 0 ? -(containerWidth + gap) : containerWidth + gap;
 
     setIsAnimating(true);
@@ -140,11 +158,23 @@ export function useSwipe({
     containerRef,
     gap,
     duration,
+    skipNextAnimation,
+    skipPrevAnimation,
   ]);
 
   const animateTransition = useCallback(
     (direction: "next" | "prev") => {
       if (isAnimating) return;
+
+      // 방향별 애니메이션 억제
+      if (direction === "next" && skipNextAnimation) {
+        onNext();
+        return;
+      }
+      if (direction === "prev" && skipPrevAnimation) {
+        onPrev();
+        return;
+      }
 
       const containerWidth = containerRef?.current?.clientWidth || window.innerWidth;
       // 클릭/키보드 등 명시적 next/prev 전환은 읽기 방향 기준으로 애니메이션한다.
@@ -173,7 +203,7 @@ export function useSwipe({
         setIsAnimating(false);
       }, duration);
     },
-    [isAnimating, containerRef, readingDirection, gap, duration, onNext, onPrev],
+    [isAnimating, containerRef, readingDirection, gap, duration, onNext, onPrev, skipNextAnimation, skipPrevAnimation],
   );
 
   const animateNext = useCallback(() => animateTransition("next"), [animateTransition]);

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -345,3 +345,298 @@ describe("useViewerNavigation split-page flow", () => {
     expect(setSubPage).toHaveBeenCalledWith(null);
   });
 });
+
+describe("useViewerNavigation chapter boundary flags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wideMeta = (page: number): Map<number, PageMeta> =>
+    new Map([
+      [
+        page,
+        {
+          pageNumber: page,
+          width: 2600,
+          height: 1600,
+          isWide: true,
+        },
+      ],
+    ]);
+
+  it("마지막 일반 페이지 + nextChapterId 존재 → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("마지막 페이지 + nextChapterId 없음 → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 첫 번째 subPage (LTR) → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 마지막 subPage (LTR) → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+
+  it("single 모드 마지막 wide 이미지의 첫 번째 subPage (RTL) → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 마지막 subPage (RTL) → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+
+  it("single 모드 첫 wide 이미지의 마지막 subPage (LTR) → canGoPrevChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("single 모드 첫 wide 이미지의 첫 번째 subPage (LTR) → canGoPrevChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(true);
+  });
+
+  it("single 모드 첫 wide 이미지의 마지막 subPage (RTL) → canGoPrevChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("single 모드 첫 wide 이미지의 첫 번째 subPage (RTL) → canGoPrevChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(true);
+  });
+
+  it("double 모드 마지막 페이지 + nextChapterId 존재 → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "double",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+});

--- a/web/src/features/viewer/hooks/useViewerNavigation.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.ts
@@ -1,6 +1,6 @@
 // 뷰어 네비게이션 훅 (키보드, 클릭, 페이지 이동)
 
-import { useEffect, useCallback, useState, useRef, type RefObject } from "react";
+import { useEffect, useCallback, useState, useRef, useMemo, type RefObject } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useViewerStore } from "../../../stores/viewerStore";
 import { isFullscreen as isDocumentFullscreen, isFullscreenToggleShortcut } from "../../../utils/fullscreen";
@@ -39,6 +39,10 @@ interface UseViewerNavigationReturn {
   handleBack: () => void;
   showNextHint: boolean;
   showPrevHint: boolean;
+  /** 마지막 페이지에서 다음 챕터로 넘어갈 수 있는 상태 */
+  canGoNextChapter: boolean;
+  /** 첫 페이지에서 이전 챕터로 넘어갈 수 있는 상태 */
+  canGoPrevChapter: boolean;
 }
 
 /**
@@ -95,6 +99,27 @@ export function useViewerNavigation({
       }
     };
   }, []);
+
+  // 현재 챕터의 페이지/챕터 경계 여부 (애니메이션 억제용)
+  // single 모드에서는 wide 이미지의 subPage 이동이 남아 있을 수 있으므로
+  // getNextNavState / getPrevNavState 결과를 함께 고려한다.
+  const canGoNextChapter = useMemo(() => {
+    if (totalPages <= 0 || !nextChapterId) return false;
+    if (readingMode === "single") {
+      const navState = getNextNavState(currentPage, totalPages, subPage, pageMetaMap, readingDirection);
+      return navState === null;
+    }
+    return currentPage >= totalPages;
+  }, [currentPage, totalPages, readingMode, readingDirection, pageMetaMap, subPage, nextChapterId]);
+
+  const canGoPrevChapter = useMemo(() => {
+    if (totalPages <= 0 || !prevChapterId) return false;
+    if (readingMode === "single") {
+      const navState = getPrevNavState(currentPage, subPage, pageMetaMap, readingDirection);
+      return navState === null;
+    }
+    return currentPage <= 1;
+  }, [currentPage, totalPages, readingMode, readingDirection, pageMetaMap, subPage, prevChapterId]);
 
   // 다음 페이지/챕터 핸들러
   const handleNext = useCallback(async () => {
@@ -286,13 +311,19 @@ export function useViewerNavigation({
         case "ArrowLeft":
           e.preventDefault();
           if (isRTL) {
-            if (animationRef?.current) {
+            // RTL: 왼쪽 화살표 = 다음
+            if (canGoNextChapter) {
+              void handleNext();
+            } else if (animationRef?.current) {
               animationRef.current.animateNext();
             } else {
               handleNext();
             }
           } else {
-            if (animationRef?.current) {
+            // LTR: 왼쪽 화살표 = 이전
+            if (canGoPrevChapter) {
+              void handlePrev();
+            } else if (animationRef?.current) {
               animationRef.current.animatePrev();
             } else {
               handlePrev();
@@ -302,13 +333,19 @@ export function useViewerNavigation({
         case "ArrowRight":
           e.preventDefault();
           if (isRTL) {
-            if (animationRef?.current) {
+            // RTL: 오른쪽 화살표 = 이전
+            if (canGoPrevChapter) {
+              void handlePrev();
+            } else if (animationRef?.current) {
               animationRef.current.animatePrev();
             } else {
               handlePrev();
             }
           } else {
-            if (animationRef?.current) {
+            // LTR: 오른쪽 화살표 = 다음
+            if (canGoNextChapter) {
+              void handleNext();
+            } else if (animationRef?.current) {
               animationRef.current.animateNext();
             } else {
               handleNext();
@@ -317,7 +354,9 @@ export function useViewerNavigation({
           break;
         case " ":
           e.preventDefault();
-          if (animationRef?.current) {
+          if (canGoNextChapter) {
+            void handleNext();
+          } else if (animationRef?.current) {
             animationRef.current.animateNext();
           } else {
             handleNext();
@@ -356,6 +395,8 @@ export function useViewerNavigation({
     handleToggleFullscreen,
     handleBack,
     animationRef,
+    canGoNextChapter,
+    canGoPrevChapter,
   ]);
 
   return {
@@ -364,5 +405,7 @@ export function useViewerNavigation({
     handleBack,
     showNextHint,
     showPrevHint,
+    canGoNextChapter,
+    canGoPrevChapter,
   };
 }

--- a/web/src/pages/ImageViewerRoute.tsx
+++ b/web/src/pages/ImageViewerRoute.tsx
@@ -359,7 +359,7 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
   }, [isAdjacentResolved]);
 
   // 네비게이션
-  const { handleNext, handlePrev, handleBack, showNextHint, showPrevHint } = useViewerNavigation({
+  const { handleNext, handlePrev, handleBack, showNextHint, showPrevHint, canGoNextChapter, canGoPrevChapter } = useViewerNavigation({
     currentPage,
     totalPages,
     readingMode: settings.readingMode,
@@ -656,6 +656,8 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
               isInitialScrolling={viewStatus !== "ready"}
               estimatedPageHeights={estimatedHeights}
               viewStatus={viewStatus}
+              canGoNextChapter={canGoNextChapter}
+              canGoPrevChapter={canGoPrevChapter}
             />
           </div>
 

--- a/web/src/pages/PdfViewer.tsx
+++ b/web/src/pages/PdfViewer.tsx
@@ -59,6 +59,10 @@ interface PdfViewerProps {
   onOutlineLoad: (outline: PDFOutlineItem[]) => void;
   onNext: (delta?: number | React.MouseEvent) => void;
   onPrev: (delta?: number | React.MouseEvent) => void;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
   onPageChange?: (page: number) => void;
   onGoToPage: (page: number) => void;
   onZoomChange?: (scale: number) => void;
@@ -135,6 +139,8 @@ export function PdfViewer({
   onZoomOut,
   onZoomReset,
   onZoomChange,
+  canGoNextChapter = false,
+  canGoPrevChapter = false,
 }: PdfViewerProps) {
   const backgroundClassName = getBackgroundClassName(settings.backgroundColor);
   const tocMarkers = useMemo(() => {
@@ -229,6 +235,8 @@ export function PdfViewer({
           onOutlineLoad={onOutlineLoad}
           onNext={onNext}
           onPrev={onPrev}
+          canGoNextChapter={canGoNextChapter}
+          canGoPrevChapter={canGoPrevChapter}
           onPageChange={onPageChange}
           transitionType={settings.pageTransition}
           onZoomChange={onZoomChange}

--- a/web/src/pages/PdfViewerRoute.tsx
+++ b/web/src/pages/PdfViewerRoute.tsx
@@ -142,7 +142,7 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
   }, []);
 
   // 네비게이션 제어
-  const { handleNext, handlePrev, handleBack } = useViewerNavigation({
+  const { handleNext, handlePrev, handleBack, canGoNextChapter, canGoPrevChapter } = useViewerNavigation({
     currentPage,
     totalPages,
     readingMode: settings.readingMode,
@@ -377,6 +377,8 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
         onOutlineLoad={handleOutlineLoad}
         onNext={handleNext}
         onPrev={handlePrev}
+        canGoNextChapter={canGoNextChapter}
+        canGoPrevChapter={canGoPrevChapter}
         onPageChange={handlePageChange}
         onGoToPage={goToPage}
         onPageJumpClick={() => setShowPageJump(true)}


### PR DESCRIPTION
## 변경 요약

이슈 #324: 뷰어에서 마지막 페이지에서 다음 권(또는 첫 페이지에서 이전 권)으로 이동할 때, 챕터 이동 힌트가 표시되는 동안에도 slide 페이지 전환 애니메이션이 계속 작동하는 문제를 수정합니다.

## 핵심 변경

- `useViewerNavigation`에 `canGoNextChapter` / `canGoPrevChapter` 플래그를 추가
  - 실제 챕터 전환이 가능한 입력 상태일 때만 `true`
  - single 모드 wide 이미지는 `getNextNavState` / `getPrevNavState`를 이용해 subPage 이동이 남았는지 정확히 판단
  - 마지막 wide 이미지의 첫 subPage에서는 `false`, 마지막 subPage에서만 `true`
- `ViewerContent`, `PdfChapterViewer`에서 방향별로 슬라이드 애니메이션을 억제
  - `useSwipe`의 `skipNextAnimation` / `skipPrevAnimation` 옵션 사용
- `ImageViewerRoute`, `PdfViewerRoute`, `PdfViewer`에 플래그 전달 연결

## 테스트

- `useViewerNavigation.test.ts`에 chapter boundary 관련 회귀 테스트 12개 추가
  - 일반 마지막 페이지, nextChapterId 유무
  - single 모드 wide 이미지의 첫/마지막 subPage (LTR/RTL)
  - double 모드 마지막 페이지
- 전체 테스트 42 files / 307 tests 통과
- lint, tsc, build 통과

## 확인 사항

- 힌트 기반 2단계 UX는 유지 (첫 입력: 힌트 표시, 두 번째 입력: 이동)
- EPUB 뷰어는 별도 범위 (useViewerNavigation 미사용)
