### PR TITLE
feat: 등장인물 편집 카드 이미지 액션과 수정/삭제 버튼을 같은 행으로 배치

### DIFF
--- a/web/src/components/SeriesCharactersDrawer.module.css
+++ b/web/src/components/SeriesCharactersDrawer.module.css
@@ -104,6 +104,23 @@
 .imageBlock {
   display: flex;
   gap: 0.75rem;
+  align-items: flex-start;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.editRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.editRow .inlineActions {
+  margin-left: auto;
+  align-self: flex-start;
+  justify-content: flex-start;
 }
 
 .summaryRow {

--- a/web/src/components/SeriesCharactersDrawer.tsx
+++ b/web/src/components/SeriesCharactersDrawer.tsx
@@ -309,41 +309,43 @@ function CharacterCard({
         </div>
       ) : (
         <>
-          {!isNew && (
-            <div className={styles.inlineActions}>
-              <button type="button" className={styles.headerAction} onClick={onToggleEdit}>
-                <Settings2 size={14} />
-              </button>
-              <button type="button" className={`${styles.headerAction} ${styles.deleteAction}`} onClick={onDelete}>
-                <Trash2 size={14} />
-              </button>
+          <div className={styles.editRow}>
+            <div className={styles.imageBlock}>
+              {item.image_url ? <img src={item.image_url} alt={item.name} className={styles.image} /> : <div className={styles.imagePlaceholder}><Users size={20} /></div>}
+              <div className={styles.imageActions}>
+                <button type="button" className={styles.smallButton} onClick={() => document.getElementById(`file-${item.id}`)?.click()}>
+                  <Upload size={12} />
+                  <span>{t("series.characters.upload")}</span>
+                </button>
+                <button type="button" className={styles.smallButton} onClick={onResetImage}>
+                  <RotateCcw size={12} />
+                  <span>{t("series.characters.reset_image")}</span>
+                </button>
+                <input
+                  id={`file-${item.id}`}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      onUpload(file);
+                      event.target.value = "";
+                    }
+                  }}
+                />
+              </div>
             </div>
-          )}
-          <div className={styles.imageBlock}>
-            {item.image_url ? <img src={item.image_url} alt={item.name} className={styles.image} /> : <div className={styles.imagePlaceholder}><Users size={20} /></div>}
-            <div className={styles.imageActions}>
-              <button type="button" className={styles.smallButton} onClick={() => document.getElementById(`file-${item.id}`)?.click()}>
-                <Upload size={12} />
-                <span>{t("series.characters.upload")}</span>
-              </button>
-              <button type="button" className={styles.smallButton} onClick={onResetImage}>
-                <RotateCcw size={12} />
-                <span>{t("series.characters.reset_image")}</span>
-              </button>
-              <input
-                id={`file-${item.id}`}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    onUpload(file);
-                    event.target.value = "";
-                  }
-                }}
-              />
-            </div>
+            {!isNew && (
+              <div className={styles.inlineActions}>
+                <button type="button" className={styles.headerAction} onClick={onToggleEdit}>
+                  <Settings2 size={14} />
+                </button>
+                <button type="button" className={`${styles.headerAction} ${styles.deleteAction}`} onClick={onDelete}>
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            )}
           </div>
           <div className={styles.field}>
             <label>{t("series.characters.fields.name")}</label>


### PR DESCRIPTION
## 변경 사항
- 등장인물 편집 모드에서 썸네일, 파일 업로드, 이미지 초기화를 수정/삭제 버튼과 같은 가로 행으로 배치
- 수정/삭제 버튼은 카드 우측 상단에 기존처럼 유지
- 이름, 역할, 이미지 URL 입력 및 저장 버튼은 이미지 액션 행 아래에 그대로 유지
- .editRow flex 컨테이너 추가, 좁은 화면에서 flex-wrap으로 자연스럽게 줄바꿈
- 접힌 일반 등장인물 카드의 수정/삭제 진입 UX는 변경하지 않음

## 테스트
- [x] npm run build 통과
- [x] npm run lint 통과
- [x] npm run test -- --run 307 tests passed

## 관련 이슈
없음