### PR TITLE
feat: 상세 페이지 복귀 시 직전에 열었던 카드로 스크롤 복구

### DIFF
--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -42,6 +42,7 @@ export interface SeriesCardProps {
   extensionBadgeText?: string | null;
   extensionBadgePlacement?: "thumbnail" | "meta";
   navigateTo?: string;
+  onBeforeNavigate?: () => void;
 }
 
 export function SeriesCard({
@@ -59,6 +60,7 @@ export function SeriesCard({
   extensionBadgeText = null,
   extensionBadgePlacement = "thumbnail",
   navigateTo,
+  onBeforeNavigate,
 }: SeriesCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -158,6 +160,8 @@ export function SeriesCard({
 
   const handleCardClick = (e: React.MouseEvent) => {
     if (e.defaultPrevented || window.getSelection()?.toString()) return;
+
+    onBeforeNavigate?.();
 
     if (navigateTo) {
       navigate(navigateTo);

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { Series } from "../types/series";
 import { LibraryPage } from "./Library";
 import styles from "./Library.module.css";
+import { rememberReturnFocus } from "../utils/returnFocus";
 
 const { mocks, libraryStoreState, authStoreState } = vi.hoisted(() => {
   const libraryGetMock = vi.fn();
@@ -138,6 +139,7 @@ vi.mock("../components/common/LoadingSpinner", () => ({
 }));
 
 const originalResizeObserver = globalThis.ResizeObserver;
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, "matchMedia");
 const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
   window.HTMLElement.prototype,
   "scrollIntoView",
@@ -272,6 +274,11 @@ describe("LibraryPage series index", () => {
   afterEach(() => {
     defaultRectSpy.mockRestore();
     globalThis.ResizeObserver = originalResizeObserver;
+    if (originalMatchMediaDescriptor) {
+      Object.defineProperty(window, "matchMedia", originalMatchMediaDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
     if (originalScrollIntoViewDescriptor) {
       Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
     } else {
@@ -287,6 +294,38 @@ describe("LibraryPage series index", () => {
     } else {
       Reflect.deleteProperty(window.Element.prototype, "scrollTo");
     }
+  });
+
+  it("복귀한 라이브러리에서 직전에 열었던 시리즈 카드를 중앙에 맞춘다", async () => {
+    rememberReturnFocus("library", "library-1", "series-b");
+
+    renderLibraryPage();
+
+    await screen.findByText("Beta");
+    await waitFor(() => {
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
+      });
+    });
+  });
+
+  it("동작 줄이기 설정에서는 복귀 카드를 즉시 중앙에 맞춘다", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+    rememberReturnFocus("library", "library-1", "series-b");
+
+    renderLibraryPage();
+
+    await screen.findByText("Beta");
+    await waitFor(() => {
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "auto",
+        block: "center",
+      });
+    });
   });
 
   it("활성 목차 항목이 스크롤 영역 중앙에 오도록 이동한다", async () => {

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -21,6 +21,8 @@ import {
   getSeriesDisplayName,
   getSeriesGroupKey,
 } from "../utils/librarySeries";
+import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
+import { prefersReducedMotion } from "../utils/reducedMotion";
 import styles from "./Library.module.css";
 
 const POLL_INTERVAL_MS = 3000;
@@ -56,6 +58,7 @@ export function LibraryPage() {
   const loadSequenceRef = useRef(0);
   const lastFetchedIdRef = useRef<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const seriesCardRefs = useRef<Record<string, HTMLDivElement>>({});
   const indexButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const scrollingToGroupRef = useRef<string | null>(null);
   const scrollReleaseTimeoutRef = useRef<number | null>(null);
@@ -138,6 +141,22 @@ export function LibraryPage() {
       };
     }
   }, [id, refreshKey, loadData, fetchLibraries]);
+
+  useEffect(() => {
+    if (!id || isLoading) return;
+
+    // App의 전역 scroll-to-top effect가 끝난 다음 프레임에 복귀 스크롤을 적용한다.
+    // StrictMode의 effect 재실행에서도 취소된 프레임은 storage를 소비하지 않는다.
+    const frameId = window.requestAnimationFrame(() => {
+      const seriesId = takeReturnFocus("library", id);
+      const target = seriesId ? seriesCardRefs.current[seriesId] : null;
+      if (!target) return;
+
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [id, isLoading, seriesList]);
 
   // 스캔 중일 때 시리즈 목록 실시간 폴링
   // - isScanning: 이 페이지에서 직접 스캔 버튼을 눌렀을 때 (libraryAPI.scan은 동기 블로킹이므로 스토어 갱신 없음)
@@ -265,15 +284,12 @@ export function LibraryPage() {
     }
     const target = sectionRefs.current[groupKey];
     if (target) {
-      const prefersReducedMotion =
-        typeof window !== "undefined" &&
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      target.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+      const reducedMotion = prefersReducedMotion();
+      target.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "start" });
       scrollReleaseTimeoutRef.current = window.setTimeout(() => {
         scrollingToGroupRef.current = null;
         scrollReleaseTimeoutRef.current = null;
-      }, prefersReducedMotion ? 0 : INDEX_SCROLL_LOCK_MS);
+      }, reducedMotion ? 0 : INDEX_SCROLL_LOCK_MS);
     } else {
       scrollingToGroupRef.current = null;
     }
@@ -668,6 +684,11 @@ export function LibraryPage() {
                         <div
                           key={series.id}
                           ref={(node) => {
+                            if (node) {
+                              seriesCardRefs.current[series.id] = node;
+                            } else {
+                              delete seriesCardRefs.current[series.id];
+                            }
                             if (index === 0) {
                               sectionRefs.current[group.key] = node;
                             }
@@ -681,6 +702,9 @@ export function LibraryPage() {
                             progressStyle="overlay"
                             showExtensionBadge
                             onStatusChange={loadData}
+                            onBeforeNavigate={() => {
+                              if (id) rememberReturnFocus("library", id, series.id);
+                            }}
                           />
                         </div>
                       );

--- a/web/src/pages/Series.module.css
+++ b/web/src/pages/Series.module.css
@@ -24,101 +24,16 @@
   gap: 1rem;
 }
 
-.volumeCard {
+/* ref 콜백을 위한 래퍼. grid item으로 동작하며 내부 SeriesCard가 너비를 채운다. */
+.volumeCardAnchor {
   display: flex;
   flex-direction: column;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  overflow: hidden;
-  text-decoration: none;
-  color: inherit;
-  transition: all 0.2s;
+  min-width: 0;
 }
 
-.volumeCard:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(102, 126, 234, 0.4);
-  transform: translateY(-2px);
-}
-
-.volumeCover {
-  aspect-ratio: 5/8; /* 시리즈 카드와 동일하게 1:1.6 비율 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #1e3a5f 0%, #2d3748 100%);
-  color: #667eea;
-  overflow: hidden;
-  position: relative;
-}
-
-.volumeThumbnail {
+.volumeCardAnchor > * {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-}
-
-.volumeCard:hover .volumeThumbnail {
-  transform: scale(1.05);
-}
-
-/* 볼륨 카드 클릭 스타일 */
-.volumeCard {
-  cursor: pointer;
-}
-
-.volumeCard.loading {
-  pointer-events: none;
-  opacity: 0.7;
-}
-
-/* 재생 오버레이 */
-.volumePlayOverlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.4);
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-.volumeCard:hover .volumePlayOverlay {
-  opacity: 1;
-}
-
-.volumePlayOverlay .loadingSpinner.small {
-  width: 24px;
-  height: 24px;
-  border-width: 2px;
-}
-
-.volumeInfo {
-  padding: 0.75rem;
-}
-
-.volumeTitle {
-  font-size: 0.9rem;
-  font-weight: 500;
-  margin: 0 0 0.25rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.volumeNumber {
-  font-size: 0.8rem;
-  color: #718096;
-  margin: 0;
+  flex: 1 1 auto;
 }
 
 /* 로딩 & 에러 */
@@ -156,18 +71,5 @@
   .volumeGrid {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     gap: 0.75rem;
-  }
-
-  .volumeInfo {
-    padding: 0.5rem;
-  }
-
-  .volumeTitle {
-    font-size: 0.8rem;
-    margin-bottom: 0.1rem;
-  }
-
-  .volumeNumber {
-    font-size: 0.7rem;
   }
 }

--- a/web/src/pages/Series.test.tsx
+++ b/web/src/pages/Series.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type { ReactNode } from "react";
+import { rememberReturnFocus } from "../utils/returnFocus";
 import { SeriesPage } from "./Series";
 
 const { mocks } = vi.hoisted(() => {
@@ -85,7 +86,7 @@ vi.mock("../components/Sidebar", () => ({
 }));
 
 vi.mock("../components/SeriesCard", () => ({
-  SeriesCard: () => <div data-testid="series-card" />,
+  SeriesCard: ({ item }: { item: { id: string; title: string } }) => <div data-testid={`series-card-${item.id}`}>{item.title}</div>,
 }));
 
 vi.mock("../components/SeriesInfoCard", () => ({
@@ -107,6 +108,84 @@ vi.mock("../components/modals/AlertModal", () => ({
 vi.mock("../components/common/LoadingSpinner", () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner" />,
 }));
+
+const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "scrollIntoView");
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/series/series-1"]}>
+      <Routes>
+        <Route
+          path="/series/:id"
+          element={<SeriesPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+function mockSeriesPageData(volumes: unknown[] = []) {
+  mocks.apiGetMock.mockImplementation((url: string) => {
+    if (url === "/series/series-1") {
+      return Promise.resolve({
+        data: {
+          id: "series-1",
+          library_id: "library-1",
+          title: "테스트 시리즈",
+          path: "/books/series",
+          library_type: "book",
+          created_at: "2026-03-21T00:00:00Z",
+          updated_at: "2026-03-21T00:00:00Z",
+        },
+      });
+    }
+    if (url === "/series/series-1/volumes?parent_id=root") return Promise.resolve({ data: { volumes } });
+    if (url === "/series/series-1/progress") return Promise.resolve({ data: { progress: null, summary: null } });
+    if (url === "/libraries/library-1") return Promise.resolve({ data: { id: "library-1", name: "서재" } });
+    throw new Error(`Unhandled api.get(${url})`);
+  });
+}
+
+describe("SeriesPage return focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    if (originalScrollIntoViewDescriptor) {
+      Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
+    } else {
+      Reflect.deleteProperty(window.HTMLElement.prototype, "scrollIntoView");
+    }
+  });
+
+  it("복귀한 시리즈에서 직전에 열었던 볼륨 카드를 중앙에 맞춘다", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    rememberReturnFocus("series", "series-1", "volume-7");
+    mockSeriesPageData([
+      {
+        id: "volume-7",
+        series_id: "series-1",
+        title: "7권",
+        volume_number: 7,
+        path: "/books/volume-7.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+    ]);
+
+    renderPage();
+
+    await screen.findByTestId("series-card-volume-7");
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    });
+  });
+});
 
 describe("SeriesPage audiobook bootstrap guard", () => {
   beforeEach(() => {

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -12,6 +12,8 @@ import { initiateDownload } from "../utils/download";
 import { useAuthStore } from "../stores/authStore";
 import { useAudioPlayerStore } from "../stores/audioPlayerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
+import { prefersReducedMotion } from "../utils/reducedMotion";
 import styles from "./Series.module.css";
 
 import type { Series, Volume, Library, ReadingProgress, SeriesProgressSummary, Chapter, SeriesCharacter } from "../types/series";
@@ -50,6 +52,7 @@ export function SeriesPage() {
     }
   };
   const [volumes, setVolumes] = useState<Volume[]>([]);
+  const volumeCardRefs = useRef<Record<string, HTMLDivElement>>({});
   const [library, setLibrary] = useState<Library | null>(null);
   const [progress, setProgress] = useState<ReadingProgress | undefined>(undefined);
   const [summary, setSummary] = useState<SeriesProgressSummary | undefined>(undefined);
@@ -180,6 +183,22 @@ export function SeriesPage() {
   useEffect(() => {
     if (id) loadData();
   }, [id, loadData]);
+
+  useEffect(() => {
+    if (!id || isLoading) return;
+
+    // App의 전역 scroll-to-top effect가 끝난 다음 프레임에 복귀 스크롤을 적용한다.
+    // StrictMode의 effect 재실행에서도 취소된 프레임은 storage를 소비하지 않는다.
+    const frameId = window.requestAnimationFrame(() => {
+      const volumeId = takeReturnFocus("series", id);
+      const target = volumeId ? volumeCardRefs.current[volumeId] : null;
+      if (!target) return;
+
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [id, isLoading, volumes]);
 
   // 시리즈 데이터가 변경될 때마다 오디오 플레이어 스토어 동기화
   useEffect(() => {
@@ -492,15 +511,29 @@ export function SeriesPage() {
             ) : (
               <div className={styles.volumeGrid}>
                 {volumes.map((volume) => (
-                  <SeriesCard
+                  <div
                     key={volume.id}
-                    item={volume}
-                    type="volume"
-                    progressStyle="overlay"
-                    extensionBadgePlacement="meta"
-                    onStatusChange={loadData}
-                    onDownload={canDownload ? () => handleDownloadVolume(volume) : undefined}
-                  />
+                    ref={(node) => {
+                      if (node) {
+                        volumeCardRefs.current[volume.id] = node;
+                      } else {
+                        delete volumeCardRefs.current[volume.id];
+                      }
+                    }}
+                    className={styles.volumeCardAnchor}
+                  >
+                    <SeriesCard
+                      item={volume}
+                      type="volume"
+                      progressStyle="overlay"
+                      extensionBadgePlacement="meta"
+                      onStatusChange={loadData}
+                      onBeforeNavigate={() => {
+                        if (id) rememberReturnFocus("series", id, volume.id);
+                      }}
+                      onDownload={canDownload ? () => handleDownloadVolume(volume) : undefined}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/web/src/utils/reducedMotion.test.ts
+++ b/web/src/utils/reducedMotion.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prefersReducedMotion } from "./reducedMotion";
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  it("returns false when matchMedia is unavailable", () => {
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: undefined });
+
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it("returns the reduced-motion media-query result", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+
+    expect(prefersReducedMotion()).toBe(true);
+  });
+});

--- a/web/src/utils/reducedMotion.ts
+++ b/web/src/utils/reducedMotion.ts
@@ -1,0 +1,6 @@
+/** Returns whether the user requests reduced motion, with safe defaults for non-browser environments. */
+export function prefersReducedMotion() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+}

--- a/web/src/utils/returnFocus.test.ts
+++ b/web/src/utils/returnFocus.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rememberReturnFocus, takeReturnFocus } from "./returnFocus";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.sessionStorage.clear();
+});
+
+describe("returnFocus", () => {
+  it("stores and consumes the focused item only for its matching parent route", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+
+    expect(takeReturnFocus("library", "library-2")).toBeNull();
+    expect(takeReturnFocus("library", "library-1")).toBe("series-42");
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("does not throw when session storage writes fail", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(() => rememberReturnFocus("library", "library-1", "series-42")).not.toThrow();
+  });
+
+  it("returns null when session storage reads fail", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("returns null when clearing a consumed focus target fails", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("keeps library and series return targets isolated", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+    rememberReturnFocus("series", "series-42", "volume-7");
+
+    expect(takeReturnFocus("series", "series-42")).toBe("volume-7");
+    expect(takeReturnFocus("library", "library-1")).toBe("series-42");
+  });
+});

--- a/web/src/utils/returnFocus.ts
+++ b/web/src/utils/returnFocus.ts
@@ -1,0 +1,31 @@
+export type ReturnFocusScope = "library" | "series";
+
+const STORAGE_PREFIX = "kumiho:return-focus";
+
+function getStorageKey(scope: ReturnFocusScope, parentId: string) {
+  return `${STORAGE_PREFIX}:${scope}:${parentId}`;
+}
+
+/**
+ * Remembers the card that initiated a detail-page navigation so that returning
+ * to its parent collection can put that card back in view exactly once.
+ */
+export function rememberReturnFocus(scope: ReturnFocusScope, parentId: string, itemId: string) {
+  try {
+    window.sessionStorage.setItem(getStorageKey(scope, parentId), itemId);
+  } catch {
+    // Browsers may block storage in private or restrictive contexts.
+  }
+}
+
+/** Returns and clears a pending focus target for this exact parent route. */
+export function takeReturnFocus(scope: ReturnFocusScope, parentId: string) {
+  try {
+    const key = getStorageKey(scope, parentId);
+    const itemId = window.sessionStorage.getItem(key);
+    window.sessionStorage.removeItem(key);
+    return itemId;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 변경 사항

### 배경
시리즈/볼륨 상세 페이지에서 뒤로 가기 시, 직전에 클릭했던 카드의 스크롤 위치가 복원되지 않아 목록 상단으로 이동하는 문제가 있었습니다. 대규모 라이브러리에서는 원래 보고 있던 위치를 다시 찾기 위해 스크롤을 조작해야 하는 UX 문제가 발생합니다.

### 구현 내용

**신규 유틸**
- `web/src/utils/returnFocus.ts`: sessionStorage 기반으로 상세 진입 카드를 기억/복구하는 유틸. `rememberReturnFocus(scope, parentId, itemId)`로 저장하고 `takeReturnFocus(scope, parentId)`로 one-shot 소비. private 모드 등 storage 접근 실패 시 try/catch로 안전하게 처리
- `web/src/utils/reducedMotion.ts`: `prefersReducedMotion()` 유틸. Library.tsx에 3곳, Series.tsx에 1곳에서 반복되던 `window.matchMedia("(prefers-reduced-motion: reduce)")` 판별 로직을 통합

**SeriesCard**
- `onBeforeNavigate?: () => void` prop 추가. 카드 클릭 시 navigate 호출 직전에 호출되어 상위 페이지에서 복귀 포커스를 기억할 수 있도록 지원

**Library 페이지**
- `seriesCardRefs` ref 맵을 통해 각 시리즈 카드 DOM 노드를 추적
- `useEffect` + `requestAnimationFrame`으로 복귀 스크롤 적용. App의 전역 scroll-to-top effect가 끝난 다음 프레임에 실행되어 충돌을 방지
- StrictMode의 effect 재실행에서도 취소된 rAF는 storage를 소비하지 않도록 cleanup에서 `cancelAnimationFrame` 처리
- ref 콜백에서 unmount 시 `delete` 처리로 stale entry 제거
- 기존 `scrollToGroup`의 인라인 `prefersReducedMotion` 판별을 유틸 호출로 교체

**Series 페이지**
- 볼륨 카드를 `div` 래퍼로 감싸 `volumeCardRefs` 수집. 래퍼에는 `.volumeCardAnchor` 클래스 부여(`display: flex; min-width: 0;` + 자식 `width: 100%`)하여 grid 레이아웃이 `SeriesCard`에 그대로 적용되도록 유지
- Library와 동일한 rAF 기반 복귀 스크롤 적용
- ref cleanup 처리

**CSS 정리**
- `Series.module.css`에서 사용되지 않던 `.volumeCard`, `.volumeCover`, `.volumeThumbnail`, `.volumePlayOverlay`, `.volumeInfo`, `.volumeTitle`, `.volumeNumber` 등 dead CSS 제거

### 주요 구현 결정사항
- **rAF + cleanup 패턴**: `takeReturnFocus`가 부작용(storage 제거)을 가지므로, target이 없을 때 storage가 비워지는 것을 방지하기 위해 `requestAnimationFrame` 콜백 내부에서 `takeReturnFocus`를 호출. StrictMode 재실행 시 cleanup이 rAF를 취소하므로 storage 소비 방지
- **`display: contents` 미사용**: `scrollIntoView`가 동작하지 않으므로 래퍼 div를 정상 grid item으로 유지하고 자식이 너비를 채우도록 처리
- **sessionStorage 선택**: 탭 종료 시 자동 만료되어 stale 데이터가 남지 않으며, 라이브러리/시리즈 스코프 분리로 충돌 방지

## 테스트

### 단위 테스트
- [x] `returnFocus.test.ts`: 스코프별 저장/소비, storage 접근 실패(setItem/getItem/removeItem 각각) 시 안전 처리, library/series 격리 (5개)
- [x] `reducedMotion.test.ts`: matchMedia 미지원 시 false, reduced-motion 설정 시 true (2개)

### 통합 테스트
- [x] `Library.test.tsx`: 복귀 시 직전 시리즈 카드를 중앙에 맞춤(smooth), reduced-motion에서 auto로 즉시 이동 (2개)
- [x] `Series.test.tsx`: 복귀 시 직전 볼륨 카드를 중앙에 맞춤 (1개)

### 검증 결과
- [x] TypeScript `tsc --noEmit` 통과
- [x] ESLint 통과
- [x] Vite build 통과
- [x] 전체 테스트 317/317 통과 (기존 310 + 신규 7)

## 관련 이�어
N/A