### PR TITLE
feat: 마지막 읽은 볼륨으로 시리즈 복귀

### DIFF
--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useViewerNavigation } from "./useViewerNavigation";
+import { takeReturnFocus } from "../../../utils/returnFocus";
 import type { PageMeta } from "../types";
 
 const { mocks } = vi.hoisted(() => {
@@ -48,6 +49,7 @@ vi.mock("../../../utils/fullscreen", async (importOriginal) => {
 describe("useViewerNavigation fullscreen switching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("sets chapter switching before navigating to next chapter", async () => {
@@ -109,6 +111,8 @@ describe("useViewerNavigation fullscreen switching", () => {
         closeSettings: vi.fn(),
         handleToggleFullscreen: vi.fn(),
         currentChapterId: "chapter-1",
+        seriesId: "series-1",
+        volumeId: "volume-150",
       }),
     );
 
@@ -118,12 +122,14 @@ describe("useViewerNavigation fullscreen switching", () => {
 
     expect(mocks.saveProgressMock).toHaveBeenCalledTimes(1);
     expect(mocks.navigateMock).toHaveBeenCalledWith("/series/1", { replace: true });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
   });
 });
 
 describe("useViewerNavigation fullscreen shortcut", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("toggles fullscreen on f, F, and ㄹ", () => {
@@ -194,6 +200,7 @@ describe("useViewerNavigation fullscreen shortcut", () => {
 describe("useViewerNavigation split-page flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   const createWidePageMetaMap = (page: number): Map<number, PageMeta> =>
@@ -349,6 +356,7 @@ describe("useViewerNavigation split-page flow", () => {
 describe("useViewerNavigation chapter boundary flags", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   const wideMeta = (page: number): Map<number, PageMeta> =>

--- a/web/src/features/viewer/hooks/useViewerNavigation.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.ts
@@ -6,6 +6,7 @@ import { useViewerStore } from "../../../stores/viewerStore";
 import { isFullscreen as isDocumentFullscreen, isFullscreenToggleShortcut } from "../../../utils/fullscreen";
 import { startChapterSwitching } from "../../../stores/fullscreenSwitchStore";
 import { buildViewerRouteState } from "../../../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../../../utils/returnFocus";
 import type { PageMeta } from "../types";
 import type { ReadingDirection, ReadingMode, SubPage } from "../../../stores/viewerStore";
 import { getNextNavState, getPrevNavState } from "../../../utils/pageCalculator";
@@ -30,6 +31,8 @@ interface UseViewerNavigationParams {
   handleToggleFullscreen: () => void;
   animationRef?: RefObject<ViewerAnimationHandles>;
   currentChapterId: string | undefined;
+  seriesId?: string | null;
+  volumeId?: string | null;
   onReachedSeriesEnd?: () => void;
 }
 
@@ -70,6 +73,8 @@ export function useViewerNavigation({
   handleToggleFullscreen,
   animationRef,
   currentChapterId,
+  seriesId,
+  volumeId,
   onReachedSeriesEnd,
 }: UseViewerNavigationParams): UseViewerNavigationReturn {
   const navigate = useNavigate();
@@ -280,12 +285,13 @@ export function useViewerNavigation({
   // 뒤로가기
   const handleBack = useCallback(() => {
     saveProgress();
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
     } else {
       navigate(-1);
     }
-  }, [saveProgress, navigate, viewerFrom]);
+  }, [saveProgress, navigate, viewerFrom, seriesId, volumeId]);
 
   // 클릭 핸들러
 

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from "react-router-dom";
 import { EpubViewerRoute } from "./EpubViewerRoute";
 import { isMobile } from "../utils/device";
+import { takeReturnFocus } from "../utils/returnFocus";
 
 const epubProgressGetMock = vi.fn();
 const apiGetMock = vi.fn();
@@ -1215,6 +1216,55 @@ describe("EpubViewerRoute", () => {
     });
   });
 
+  it("나가기 버튼은 마지막으로 보고 있던 볼륨을 시리즈 복귀 대상으로 갱신한다", async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/viewer/:chapterId",
+          element: (
+            <EpubViewerRoute
+              loaderData={{
+                chapter: {
+                  id: "chapter-150",
+                  volume_id: "volume-150",
+                  title: "EPUB 챕터 150",
+                  chapter_number: 1,
+                  page_count: 1,
+                },
+                isLoading: false,
+                error: null,
+                seriesId: "series-1",
+                volumeId: "volume-150",
+                pageMeta: [],
+                pageMetaMap: new Map(),
+                isInitialScrollingRef: { current: false },
+                setViewStatus: vi.fn(),
+              }}
+            />
+          ),
+        },
+        {
+          path: "/volumes/volume-1",
+          element: <div data-testid="volume-page">volume page</div>,
+        },
+      ],
+      {
+        initialEntries: [{ pathname: "/viewer/chapter-150", state: { from: "/volumes/volume-1" } }],
+      },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(latestViewerProps?.onBack).toBeDefined());
+
+    act(() => {
+      latestViewerProps?.onBack?.();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("volume-page")).toBeInTheDocument());
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
+  });
+
   it("이전 챕터 이동 시 viewerFrom과 isIncognito 상태를 유지한다", async () => {
     useAdjacentChaptersMock.mockReturnValue({
       nextChapterId: null,
@@ -1341,6 +1391,7 @@ describe("EpubViewerRoute", () => {
       expect(router.state.location.pathname).toBe("/series/1");
       expect(router.state.historyAction).toBe("REPLACE");
     });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-1");
   });
 
   it("isMobile()이 true일 때 모바일 전용 설정 키를 우선 로딩한다", async () => {

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -30,6 +30,7 @@ import {
 import { usePreventBrowserZoom } from "../features/viewer/hooks/usePreventBrowserZoom";
 import { useViewerSync } from "../hooks/useViewerSync";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 interface EpubViewerRouteProps {
   loaderData: UseChapterLoaderReturn;
@@ -1058,12 +1059,13 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   );
 
   const handleBack = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
     } else {
       navigate(-1);
     }
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   const handleReachedSeriesEnd = useCallback(() => {
     if (isAdjacentResolved) {
@@ -1092,12 +1094,13 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   }, [prevChapterId, navigate, viewerFrom, routeIsIncognito]);
 
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   const handleToggleFullscreen = useCallback(() => {
     try {

--- a/web/src/pages/ImageViewerRoute.tsx
+++ b/web/src/pages/ImageViewerRoute.tsx
@@ -9,6 +9,7 @@ import { enterFullscreen, exitFullscreen, isFullscreen as isDocumentFullscreen }
 import { ViewerSettings as ViewerSettingsModal } from "../components/viewer/ViewerSettings";
 
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 // Feature imports
 import {
@@ -377,6 +378,8 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
     handleToggleFullscreen,
     animationRef: animationRef as React.RefObject<ViewerAnimationHandles>,
     currentChapterId: chapterId,
+    seriesId,
+    volumeId,
     onReachedSeriesEnd: handleReachedSeriesEnd,
   });
 
@@ -406,12 +409,13 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
 
   // 세션 종료 핸들러
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   // 읽기 시간 측정 (활성화)
   useReadingTime(seriesId || undefined, !isLoading && !error, chapterId);

--- a/web/src/pages/PdfViewerRoute.test.tsx
+++ b/web/src/pages/PdfViewerRoute.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from "react-router-dom";
 import { PdfViewerRoute } from "./PdfViewerRoute";
 import { useViewerStore } from "../stores/viewerStore";
+import { takeReturnFocus } from "../utils/returnFocus";
 
 const useProgressSyncMock = vi.fn();
 const useViewerSyncMock = vi.fn();
@@ -209,15 +210,15 @@ describe("PdfViewerRoute", () => {
               loaderData={{
                 chapter: {
                   id: "chapter-7",
-                  volume_id: "volume-1",
-                  title: "PDF 챕터",
+                  volume_id: "volume-150",
+                  title: "PDF 챕터 150",
                   chapter_number: 1,
                   page_count: 20,
                 },
                 isLoading: false,
                 error: null,
                 seriesId: "series-1",
-                volumeId: "volume-1",
+                volumeId: "volume-150",
                 pageMeta: [],
                 pageMetaMap: new Map(),
                 isInitialScrollingRef: { current: false },
@@ -248,5 +249,6 @@ describe("PdfViewerRoute", () => {
       expect(router.state.location.pathname).toBe("/series/1");
       expect(router.state.historyAction).toBe("REPLACE");
     });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
   });
 });

--- a/web/src/pages/PdfViewerRoute.tsx
+++ b/web/src/pages/PdfViewerRoute.tsx
@@ -25,6 +25,7 @@ import { PdfViewer } from "./PdfViewer";
 import { usePreventBrowserZoom } from "../features/viewer/hooks/usePreventBrowserZoom";
 import type { SubPage } from "../stores/viewerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 interface PdfViewerRouteProps {
   loaderData: UseChapterLoaderReturn;
@@ -160,6 +161,8 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
     handleToggleFullscreen,
     animationRef: animationRef as React.RefObject<ViewerAnimationHandles>,
     currentChapterId: chapterId,
+    seriesId,
+    volumeId,
     onReachedSeriesEnd: handleReachedSeriesEnd,
   });
 
@@ -177,12 +180,13 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
 
   // 세션 종료 핸들러
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   // 읽기 시간 측정 (활성화)
   useReadingTime(seriesId || undefined, true, chapterId as string);

--- a/web/src/utils/returnFocus.test.ts
+++ b/web/src/utils/returnFocus.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { rememberReturnFocus, takeReturnFocus } from "./returnFocus";
+import { rememberReturnFocus, rememberViewerReturnFocus, takeReturnFocus } from "./returnFocus";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -38,6 +38,18 @@ describe("returnFocus", () => {
     });
 
     expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("updates a series return target from the last viewed volume", () => {
+    rememberViewerReturnFocus("/volumes/volume-1", "series-1", "volume-150");
+
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
+  });
+
+  it("does not create a return target for unrelated viewer origins", () => {
+    rememberViewerReturnFocus("/settings", "series-1", "volume-150");
+
+    expect(takeReturnFocus("series", "series-1")).toBeNull();
   });
 
   it("keeps library and series return targets isolated", () => {

--- a/web/src/utils/returnFocus.ts
+++ b/web/src/utils/returnFocus.ts
@@ -29,3 +29,18 @@ export function takeReturnFocus(scope: ReturnFocusScope, parentId: string) {
     return null;
   }
 }
+
+/**
+ * 뷰어에서 시리즈 또는 볼륨 경로로 나갈 때 시리즈 페이지의
+ * 복귀 스크롤 대상을 마지막으로 읽은 볼륨으로 갱신합니다.
+ */
+export function rememberViewerReturnFocus(
+  viewerFrom: string | undefined,
+  seriesId: string | null | undefined,
+  volumeId: string | null | undefined,
+) {
+  if (!viewerFrom || !seriesId || !volumeId) return;
+  if (!/^\/(?:series|volumes)\/[^/?#]+(?:[/?#]|$)/.test(viewerFrom)) return;
+
+  rememberReturnFocus("series", seriesId, volumeId);
+}


### PR DESCRIPTION
## Summary
- 뷰어 종료 시 현재 마지막으로 읽은 볼륨을 시리즈 복귀 스크롤 대상으로 갱신합니다.
- Image/PDF/EPUB 뷰어의 일반 종료와 세션 종료 경로를 반영합니다.
- 기존 Library/Series 복귀 스크롤 동작과 홈페이지는 변경하지 않습니다.

## Test plan
- [x] Focused Vitest: 49 passed
- [x] Full Vitest: 44 files / 320 tests passed
- [x] npm run lint
- [x] npm run build
- [x] git diff --check

## Review follow-up
- EPUB/PDF 세션 종료 시 복귀 대상 갱신 회귀 테스트를 보강했습니다.
- 공통 종료 훅 추출은 각 뷰어의 종료 흐름 차이로 이번 범위에서는 보류했습니다.