### PR TITLE
feat: 누락 회차 표시 기능 추가

### DIFF
--- a/web/src/components/SeriesInfoCard.module.css
+++ b/web/src/components/SeriesInfoCard.module.css
@@ -309,7 +309,9 @@
   color: rgba(255, 255, 255, 0.6);
   cursor: pointer;
   font-family: inherit;
-  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), background 0.15s;
+  transition:
+    transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    background 0.15s;
 }
 
 .characterAvatarMore:hover {
@@ -330,8 +332,12 @@
 }
 
 @keyframes backdropFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .characterModalBox {
@@ -349,8 +355,14 @@
 }
 
 @keyframes modalSlideIn {
-  from { opacity: 0; transform: scale(0.9) translateY(10px); }
-  to { opacity: 1; transform: scale(1) translateY(0); }
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 .characterModalHeader {
@@ -624,6 +636,46 @@
 
 .btnMore:focus {
   outline: none; /* Ensure focus outline is removed */
+}
+
+.missingNumberNotice {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 0.4rem;
+  max-width: 100%;
+  min-height: 28px;
+  /* seriesContent의 8px gap을 상쇄해 줄거리 아래 실거리 5px를 유지 */
+  margin-top: -3px;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(251, 191, 36, 0.92);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.missingNumberNotice:hover {
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.missingNumberNotice span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.missingNumberNotice:focus-visible {
+  outline: 2px solid rgba(251, 191, 36, 0.9);
+  outline-offset: 2px;
+}
+
+.missingNumberNoticeCollapsed {
+  justify-content: center;
+  width: 28px;
+  padding: 4px;
 }
 
 .seriesActions {

--- a/web/src/components/SeriesInfoCard.test.tsx
+++ b/web/src/components/SeriesInfoCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Series } from "../types/series";
+import { SeriesInfoCard } from "./SeriesInfoCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { numbers?: string }) => {
+      if (options?.numbers) return `${key}:${options.numbers}`;
+      if (key === "series.action.more") return "더보기";
+      if (key === "series.action.less") return "접기";
+      if (key === "series.missing_number_unit.volume") return "권";
+      return key;
+    },
+    i18n: { language: "ko" },
+  }),
+}));
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: () => ({ role: "USER" }),
+}));
+
+vi.mock("../api/client", () => ({
+  seriesAPI: {},
+  volumeAPI: {},
+}));
+
+const series: Series = {
+  id: "series-1",
+  library_id: "library-1",
+  title: "테스트 시리즈",
+  description: "가".repeat(151),
+  created_at: "2026-07-18T00:00:00Z",
+  updated_at: "2026-07-18T00:00:00Z",
+};
+
+describe("SeriesInfoCard description", () => {
+  it("세 줄 안에 표시되는 설명에는 더보기 버튼을 표시하지 않는다", () => {
+    render(<SeriesInfoCard series={series} onPlay={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
+  });
+
+  it("display_unit이 없으면 누락 번호를 권으로 표시한다", () => {
+    render(<SeriesInfoCard series={series} missingNumberRanges={[{ start: 2, end: 2 }]} onPlay={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "series.missing_volumes:2권" })).toBeInTheDocument();
+  });
+
+  it("표시할 수 없는 빈 누락 범위는 안내를 렌더링하지 않는다", () => {
+    render(<SeriesInfoCard series={series} missingNumberRanges={[{ start: 3, end: 2 }]} onPlay={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /series\.missing_/ })).not.toBeInTheDocument();
+  });
+
+  it("누락 회차 안내를 클릭하면 아이콘만 남기고 다시 클릭하면 펼친다", () => {
+    render(
+      <SeriesInfoCard
+        series={{ ...series, display_unit: "volume" }}
+        missingNumberRanges={[
+          { start: 9, end: 9 },
+          { start: 12, end: 12 },
+        ]}
+        onPlay={vi.fn()}
+      />,
+    );
+
+    const notice = screen.getByRole("button", { name: "series.missing_volumes:9권, 12권" });
+    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+
+    expect(notice).toHaveAttribute("aria-pressed", "true");
+    expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+    expect(notice).toHaveAttribute("aria-pressed", "false");
+    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+  });
+});

--- a/web/src/components/SeriesInfoCard.tsx
+++ b/web/src/components/SeriesInfoCard.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { Play, Edit2, Heart, Shield, BookCheck, BookX, ChevronDown, Download, FileText, BookOpen } from "lucide-react";
+import { Play, Edit2, Heart, Shield, BookCheck, BookX, ChevronDown, Download, FileText, BookOpen, CircleAlert } from "lucide-react";
 import type { Series, Volume, ReadingProgress, SeriesProgressSummary, SeriesCharacter, Library } from "../types/series";
+import { formatMissingNumberRanges, type NumberRange } from "../utils/missingNumbers";
 import { EditSeriesModal } from "./modals/EditSeriesModal";
 import { EditVolumeModal } from "./modals/EditVolumeModal";
 import { AlertModal, type AlertType } from "./modals/AlertModal";
@@ -22,6 +23,7 @@ interface SeriesInfoCardProps {
   progress?: ReadingProgress;
   summary?: SeriesProgressSummary;
   preferPercentLabel?: boolean;
+  missingNumberRanges?: NumberRange[];
   characters?: SeriesCharacter[];
   onUpdate?: (updated: Series | Volume) => void;
   onPlay: (incognito?: boolean) => void | Promise<void>;
@@ -38,6 +40,7 @@ export function SeriesInfoCard({
   progress,
   summary,
   preferPercentLabel = false,
+  missingNumberRanges = [],
   characters,
   onUpdate,
   onPlay,
@@ -50,6 +53,9 @@ export function SeriesInfoCard({
   const characterModalTitleId = useId();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isCharacterModalOpen, setIsCharacterModalOpen] = useState(false);
@@ -156,6 +162,49 @@ export function SeriesInfoCard({
   const lowerDisplayPath = displayPath.toLowerCase();
   const isTextFile = lowerDisplayPath.endsWith(".txt") || (!isVolumeType && series.extension === "TXT");
   const isAudiobook = series.library_type === "audiobook";
+  const shouldUseSeriesDescriptionFallback = isVolumeType && !volume?.description?.trim();
+  const rawDescription = isVolumeType && !shouldUseSeriesDescriptionFallback ? volume?.description ?? "" : series.description;
+  const translatedDescription = !isVolumeType || shouldUseSeriesDescriptionFallback ? series.metadata?.description_translated : undefined;
+  const displayDescription = translatedDescription || rawDescription;
+  const isChapterUnit = series.display_unit === "chapter";
+  const missingNumberUnit = isChapterUnit
+    ? t("series.missing_number_unit.chapter")
+    : t("series.missing_number_unit.volume");
+  const missingNumberLabel = formatMissingNumberRanges(missingNumberRanges, missingNumberUnit);
+  const missingNumberNoticeLabel = isChapterUnit
+    ? t("series.missing_chapters", { numbers: missingNumberLabel })
+    : t("series.missing_volumes", { numbers: missingNumberLabel });
+
+  useEffect(() => {
+    setIsDescriptionExpanded(false);
+  }, [displayDescription]);
+
+  useEffect(() => {
+    setIsMissingNumberNoticeCollapsed(false);
+  }, [missingNumberNoticeLabel]);
+
+  useEffect(() => {
+    const descriptionElement = descriptionRef.current;
+    if (!descriptionElement || !displayDescription || isDescriptionExpanded) {
+      if (!displayDescription) {
+        setIsDescriptionTruncated(false);
+      }
+      return undefined;
+    }
+
+    const updateTruncation = () => {
+      setIsDescriptionTruncated(descriptionElement.scrollHeight > descriptionElement.clientHeight + 1);
+    };
+
+    updateTruncation();
+    if (typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+
+    const resizeObserver = new ResizeObserver(updateTruncation);
+    resizeObserver.observe(descriptionElement);
+    return () => resizeObserver.disconnect();
+  }, [displayDescription, isDescriptionExpanded]);
 
   // 시리즈 완독 처리 실행
   const executeMarkComplete = async () => {
@@ -534,42 +583,44 @@ export function SeriesInfoCard({
         </div>
 
         {/* 줄거리 */}
-        {(() => {
-          const shouldUseSeriesDescriptionFallback = isVolumeType && !volume?.description?.trim();
-          const rawDescription =
-            isVolumeType && !shouldUseSeriesDescriptionFallback ? volume?.description ?? "" : series.description;
-          const translatedDescription =
-            !isVolumeType || shouldUseSeriesDescriptionFallback
-              ? series.metadata?.description_translated
-              : undefined;
-          const displayDescription = translatedDescription || rawDescription;
-
-          if (!displayDescription) return null;
-
-          return (
-            <div className={styles.seriesDescription}>
-              <p
-                style={{
-                  margin: 0,
-                  display: "-webkit-box",
-                  WebkitLineClamp: isDescriptionExpanded ? "unset" : 3,
-                  WebkitBoxOrient: "vertical",
-                  overflow: "hidden",
-                }}
+        {displayDescription && (
+          <div className={styles.seriesDescription}>
+            <p
+              ref={descriptionRef}
+              style={{
+                margin: 0,
+                display: "-webkit-box",
+                WebkitLineClamp: isDescriptionExpanded ? "unset" : 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {displayDescription}
+            </p>
+            {isDescriptionTruncated && (
+              <button
+                onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                className={styles.btnMore}
               >
-                {displayDescription}
-              </p>
-              {displayDescription.length > 150 && (
-                <button
-                  onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-                  className={styles.btnMore}
-                >
-                  {isDescriptionExpanded ? t("series.action.less") : t("series.action.more")}
-                </button>
-              )}
-            </div>
-          );
-        })()}
+                {isDescriptionExpanded ? t("series.action.less") : t("series.action.more")}
+              </button>
+            )}
+          </div>
+        )}
+
+        {missingNumberRanges.length > 0 && missingNumberLabel && (
+          <button
+            type="button"
+            className={`${styles.missingNumberNotice} ${isMissingNumberNoticeCollapsed ? styles.missingNumberNoticeCollapsed : ""}`}
+            aria-label={missingNumberNoticeLabel}
+            aria-pressed={isMissingNumberNoticeCollapsed}
+            title={isMissingNumberNoticeCollapsed ? missingNumberNoticeLabel : undefined}
+            onClick={() => setIsMissingNumberNoticeCollapsed((collapsed) => !collapsed)}
+          >
+            <CircleAlert size={16} aria-hidden="true" />
+            {!isMissingNumberNoticeCollapsed && <span>{missingNumberNoticeLabel}</span>}
+          </button>
+        )}
 
         {/* 액션 버튼 */}
         <div className={styles.seriesActions}>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -752,6 +752,12 @@
     "empty_volumes": "No volumes found",
     "empty_chapters": "No chapters found",
     "not_found": "Series not found",
+    "missing_volumes": "Missing volumes: {{numbers}}",
+    "missing_chapters": "Missing chapters: {{numbers}}",
+    "missing_number_unit": {
+      "volume": " vol.",
+      "chapter": " ch."
+    },
     "unit": {
       "volume": "Vol. {{count}}",
       "total_volume": "Total {{count}} volumes",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -752,6 +752,12 @@
     "empty_volumes": "スキャンされた巻がありません",
     "empty_chapters": "スキャンされた話がありません",
     "not_found": "シリーズが見つかりません",
+    "missing_volumes": "欠巻: {{numbers}}",
+    "missing_chapters": "欠番の話: {{numbers}}",
+    "missing_number_unit": {
+      "volume": "巻",
+      "chapter": "話"
+    },
     "unit": {
       "volume": "{{count}}巻",
       "total_volume": "全 {{count}} 巻",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -752,6 +752,12 @@
     "empty_volumes": "스캔된 볼륨이 없습니다",
     "empty_chapters": "스캔된 챕터가 없습니다",
     "not_found": "시리즈를 찾을 수 없습니다",
+    "missing_volumes": "누락 권: {{numbers}}",
+    "missing_chapters": "누락 회차: {{numbers}}",
+    "missing_number_unit": {
+      "volume": "권",
+      "chapter": "화"
+    },
     "unit": {
       "volume": "{{count}}권",
       "total_volume": "총 {{count}}권",

--- a/web/src/pages/Series.test.tsx
+++ b/web/src/pages/Series.test.tsx
@@ -90,14 +90,27 @@ vi.mock("../components/SeriesCard", () => ({
 }));
 
 vi.mock("../components/SeriesInfoCard", () => ({
-  SeriesInfoCard: ({ onPlay }: { onPlay: () => void | Promise<void> }) => (
-    <button
-      type="button"
-      data-testid="series-info-play"
-      onClick={() => void onPlay()}
-    >
-      play
-    </button>
+  SeriesInfoCard: ({
+    onPlay,
+    missingNumberRanges,
+  }: {
+    onPlay: () => void | Promise<void>;
+    missingNumberRanges?: Array<{ start: number; end: number }>;
+  }) => (
+    <>
+      <button
+        type="button"
+        data-testid="series-info-play"
+        onClick={() => void onPlay()}
+      >
+        play
+      </button>
+      {missingNumberRanges?.map((range) => (
+        <div key={`${range.start}-${range.end}`} data-testid="missing-number-range">
+          {range.start}-{range.end}
+        </div>
+      ))}
+    </>
   ),
 }));
 
@@ -184,6 +197,37 @@ describe("SeriesPage return focus", () => {
     await waitFor(() => {
       expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
     });
+  });
+});
+
+describe("SeriesPage missing number indicator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("최상위 권 번호 사이의 빈 번호를 시리즈 정보 카드에 전달한다", async () => {
+    mockSeriesPageData([
+      {
+        id: "volume-1",
+        series_id: "series-1",
+        title: "1화",
+        volume_number: 1,
+        path: "/books/1.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+      {
+        id: "volume-3",
+        series_id: "series-1",
+        title: "3화",
+        volume_number: 3,
+        path: "/books/3.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByTestId("missing-number-range")).toHaveTextContent("2-2");
   });
 });
 

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { Folder } from "lucide-react";
@@ -14,6 +14,7 @@ import { useAudioPlayerStore } from "../stores/audioPlayerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
 import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
 import { prefersReducedMotion } from "../utils/reducedMotion";
+import { findMissingNumberRanges } from "../utils/missingNumbers";
 import styles from "./Series.module.css";
 
 import type { Series, Volume, Library, ReadingProgress, SeriesProgressSummary, Chapter, SeriesCharacter } from "../types/series";
@@ -76,6 +77,10 @@ export function SeriesPage() {
   const user = useAuthStore((state) => state.user);
   const canDownload = user?.role === "MASTER" || user?.can_download;
   const seriesTitle = series?.display_title || series?.title || "";
+  const missingNumberRanges = useMemo(
+    () => findMissingNumberRanges(volumes.map((volume) => volume.volume_number)),
+    [volumes],
+  );
   const preferPercentLabel =
     volumes.length > 0 &&
     volumes.every((volume) => {
@@ -420,6 +425,7 @@ export function SeriesPage() {
               progress={progress}
               summary={summary}
               preferPercentLabel={preferPercentLabel}
+              missingNumberRanges={missingNumberRanges}
               onUpdate={handleUpdate}
               onRefresh={loadData}
               onAlert={showAlert}

--- a/web/src/utils/missingNumbers.test.ts
+++ b/web/src/utils/missingNumbers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { findMissingNumberRanges, formatMissingNumberRanges } from "./missingNumbers";
+
+describe("findMissingNumberRanges", () => {
+  it("등록된 회차 번호 사이의 빈 번호를 범위로 반환한다", () => {
+    expect(findMissingNumberRanges([1, 3, 4, 5, 7, 9, 10])).toEqual([
+      { start: 2, end: 2 },
+      { start: 6, end: 6 },
+      { start: 8, end: 8 },
+    ]);
+  });
+
+  it("연속된 누락 번호를 하나의 범위로 묶는다", () => {
+    expect(findMissingNumberRanges([1, 5])).toEqual([{ start: 2, end: 4 }]);
+  });
+
+  it("중복, 0 이하, 소수 번호는 누락 계산에서 제외한다", () => {
+    expect(findMissingNumberRanges([0, 1, 1, 1.5, 3, -2, 5])).toEqual([
+      { start: 2, end: 2 },
+      { start: 4, end: 4 },
+    ]);
+  });
+
+  it("처음 번호 앞이나 마지막 번호 뒤의 번호는 추정하지 않는다", () => {
+    expect(findMissingNumberRanges([3, 4, 5])).toEqual([]);
+  });
+
+  it("누락 번호는 화면에서 각각의 화 또는 권으로 표시할 수 있게 펼친다", () => {
+    expect(formatMissingNumberRanges([{ start: 2, end: 4 }, { start: 7, end: 7 }], "화")).toBe("2화, 3화, 4화, 7화");
+  });
+});

--- a/web/src/utils/missingNumbers.ts
+++ b/web/src/utils/missingNumbers.ts
@@ -1,0 +1,31 @@
+export interface NumberRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * 등록된 양의 정수 번호 사이에서 비어 있는 번호를 연속 범위로 찾습니다.
+ * 첫 등록 번호 앞이나 마지막 등록 번호 뒤의 번호는 추정하지 않습니다.
+ */
+export function findMissingNumberRanges(numbers: number[]): NumberRange[] {
+  const sorted = [...new Set(numbers.filter((number) => Number.isInteger(number) && number > 0))].sort((a, b) => a - b);
+  const ranges: NumberRange[] = [];
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const previous = sorted[index - 1];
+    const current = sorted[index];
+
+    if (current - previous > 1) {
+      ranges.push({ start: previous + 1, end: current - 1 });
+    }
+  }
+
+  return ranges;
+}
+
+/** 누락 범위를 각 번호의 단위 표기로 펼쳐 반환합니다. */
+export function formatMissingNumberRanges(ranges: NumberRange[], unit: string): string {
+  return ranges
+    .flatMap(({ start, end }) => Array.from({ length: end - start + 1 }, (_, index) => `${start + index}${unit}`))
+    .join(", ");
+}


### PR DESCRIPTION
## 변경 사항
- 시리즈 정보 카드에 누락된 회차/권 번호 안내 버튼 추가
- `missingNumbers.ts` 유틸: 최상위 볼륨 번호 사이의 빈 구간을 계산하고 단위(권/화)를 붙여 포맷
- `Series.tsx`에서 `volumes[].volume_number`로 누락 범위를 계산해 `SeriesInfoCard`에 전달 (`useMemo` 적용)
- `SeriesInfoCard.tsx`에서 누락 안내 버튼 렌더링, 클릭 시 접기/펼치기 토글
- `display_unit === "chapter"`인 시리즈는 회차 문구, 그 외는 권 문구 사용 (백엔드 `assignDisplayUnit` 규칙과 일치)
- 설명 더보기 판단을 기존 `length > 150` 하드코딩에서 `ResizeObserver` 기반 실제 truncation 감지로 개선
- 빈 라벨 방어 처리 및 긴 누락 목록 레이아웃 보호 (`max-width`, `overflow-wrap`)
- 한국어/영어/일본어 i18n 키 추가

## 테스트
- [x] Vitest 46 files / 330 tests passed
- [x] ESLint 통과
- [x] TypeScript 빌드 통과
- [x] `git diff --check` 통과
- [x] `display_unit` 없을 때 권으로 표시하는 케이스 테스트
- [x] 빈 누락 범위는 렌더링하지 않는 케이스 테스트
- [x] 접기/펼치기 토글 동작 테스트

## 관련 이슈
Closes #301