### PR TITLE
fix: 누락 회차 안내 기본 접힘 상태로 변경

### DIFF
--- a/web/src/components/SeriesInfoCard.test.tsx
+++ b/web/src/components/SeriesInfoCard.test.tsx
@@ -53,7 +53,7 @@ describe("SeriesInfoCard description", () => {
     expect(screen.queryByRole("button", { name: /series\.missing_/ })).not.toBeInTheDocument();
   });
 
-  it("누락 회차 안내를 클릭하면 아이콘만 남기고 다시 클릭하면 펼친다", () => {
+  it("누락 회차 안내는 기본으로 접혀 있고 클릭하면 내용을 펼친다", () => {
     render(
       <SeriesInfoCard
         series={{ ...series, display_unit: "volume" }}
@@ -66,15 +66,16 @@ describe("SeriesInfoCard description", () => {
     );
 
     const notice = screen.getByRole("button", { name: "series.missing_volumes:9권, 12권" });
-    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
-
-    fireEvent.click(notice);
-
     expect(notice).toHaveAttribute("aria-pressed", "true");
     expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
 
     fireEvent.click(notice);
+
     expect(notice).toHaveAttribute("aria-pressed", "false");
     expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+    expect(notice).toHaveAttribute("aria-pressed", "true");
+    expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
   });
 });

--- a/web/src/components/SeriesInfoCard.tsx
+++ b/web/src/components/SeriesInfoCard.tsx
@@ -54,7 +54,7 @@ export function SeriesInfoCard({
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
-  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(false);
+  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(true);
   const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -180,7 +180,7 @@ export function SeriesInfoCard({
   }, [displayDescription]);
 
   useEffect(() => {
-    setIsMissingNumberNoticeCollapsed(false);
+    setIsMissingNumberNoticeCollapsed(true);
   }, [missingNumberNoticeLabel]);
 
   useEffect(() => {


### PR DESCRIPTION
## 변경 사항
- 시리즈 정보 카드의 누락 회차/권 안내 버튼 기본 상태를 펼침에서 접힘으로 변경
- `isMissingNumberNoticeCollapsed` 초기값을 `false`에서 `true`로 변경
- `missingNumberNoticeLabel` 변경 시 리셋값도 `true`로 일치
- `useState` 선언 위치를 컴포넌트 상단 hooks 그룹으로 유지하여 React Hooks 규칙 준수

## 테스트
- [x] Vitest 46 files / 330 tests passed
- [x] ESLint 통과
- [x] TypeScript 빌드 통과
- [x] 기본 접힘 → 펼침 → 접힘 3단계 토글 동작 테스트