### PR TITLE
release: v0.17.0

### DIFF
--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.16.5"
+const Version = "v0.16.6-beta.1"

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.16.6-beta.5"
+const Version = "v0.17.0"

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.16.6-beta.3"
+const Version = "v0.16.6-beta.5"

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.16.6-beta.1"
+const Version = "v0.16.6-beta.2"

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version 프로젝트의 현재 버전 (Git tag 형식, v 접두사 포함)
-const Version = "v0.16.6-beta.2"
+const Version = "v0.16.6-beta.3"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.6-beta.1",
+  "version": "0.16.6-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.6-beta.1",
+      "version": "0.16.6-beta.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.6-beta.5",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.6-beta.5",
+      "version": "0.17.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.6-beta.3",
+  "version": "0.16.6-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.6-beta.3",
+      "version": "0.16.6-beta.4",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.5",
+  "version": "0.16.6-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.5",
+      "version": "0.16.6-beta.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.6-beta.4",
+  "version": "0.16.6-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.6-beta.4",
+      "version": "0.16.6-beta.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.6-beta.2",
+  "version": "0.16.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.6-beta.2",
+      "version": "0.16.6-beta.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.6-beta.3",
+  "version": "0.16.6-beta.4",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.6-beta.5",
+  "version": "0.17.0",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.6-beta.2",
+  "version": "0.16.6-beta.3",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.5",
+  "version": "0.16.6-beta.1",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.6-beta.1",
+  "version": "0.16.6-beta.2",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.6-beta.4",
+  "version": "0.16.6-beta.5",
   "type": "module",
   "engines": {
     "node": ">=20.16.0"

--- a/web/src/components/SeriesCard.tsx
+++ b/web/src/components/SeriesCard.tsx
@@ -42,6 +42,7 @@ export interface SeriesCardProps {
   extensionBadgeText?: string | null;
   extensionBadgePlacement?: "thumbnail" | "meta";
   navigateTo?: string;
+  onBeforeNavigate?: () => void;
 }
 
 export function SeriesCard({
@@ -59,6 +60,7 @@ export function SeriesCard({
   extensionBadgeText = null,
   extensionBadgePlacement = "thumbnail",
   navigateTo,
+  onBeforeNavigate,
 }: SeriesCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -158,6 +160,8 @@ export function SeriesCard({
 
   const handleCardClick = (e: React.MouseEvent) => {
     if (e.defaultPrevented || window.getSelection()?.toString()) return;
+
+    onBeforeNavigate?.();
 
     if (navigateTo) {
       navigate(navigateTo);

--- a/web/src/components/SeriesCharactersDrawer.module.css
+++ b/web/src/components/SeriesCharactersDrawer.module.css
@@ -104,6 +104,23 @@
 .imageBlock {
   display: flex;
   gap: 0.75rem;
+  align-items: flex-start;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.editRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.editRow .inlineActions {
+  margin-left: auto;
+  align-self: flex-start;
+  justify-content: flex-start;
 }
 
 .summaryRow {

--- a/web/src/components/SeriesCharactersDrawer.tsx
+++ b/web/src/components/SeriesCharactersDrawer.tsx
@@ -309,41 +309,43 @@ function CharacterCard({
         </div>
       ) : (
         <>
-          {!isNew && (
-            <div className={styles.inlineActions}>
-              <button type="button" className={styles.headerAction} onClick={onToggleEdit}>
-                <Settings2 size={14} />
-              </button>
-              <button type="button" className={`${styles.headerAction} ${styles.deleteAction}`} onClick={onDelete}>
-                <Trash2 size={14} />
-              </button>
+          <div className={styles.editRow}>
+            <div className={styles.imageBlock}>
+              {item.image_url ? <img src={item.image_url} alt={item.name} className={styles.image} /> : <div className={styles.imagePlaceholder}><Users size={20} /></div>}
+              <div className={styles.imageActions}>
+                <button type="button" className={styles.smallButton} onClick={() => document.getElementById(`file-${item.id}`)?.click()}>
+                  <Upload size={12} />
+                  <span>{t("series.characters.upload")}</span>
+                </button>
+                <button type="button" className={styles.smallButton} onClick={onResetImage}>
+                  <RotateCcw size={12} />
+                  <span>{t("series.characters.reset_image")}</span>
+                </button>
+                <input
+                  id={`file-${item.id}`}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      onUpload(file);
+                      event.target.value = "";
+                    }
+                  }}
+                />
+              </div>
             </div>
-          )}
-          <div className={styles.imageBlock}>
-            {item.image_url ? <img src={item.image_url} alt={item.name} className={styles.image} /> : <div className={styles.imagePlaceholder}><Users size={20} /></div>}
-            <div className={styles.imageActions}>
-              <button type="button" className={styles.smallButton} onClick={() => document.getElementById(`file-${item.id}`)?.click()}>
-                <Upload size={12} />
-                <span>{t("series.characters.upload")}</span>
-              </button>
-              <button type="button" className={styles.smallButton} onClick={onResetImage}>
-                <RotateCcw size={12} />
-                <span>{t("series.characters.reset_image")}</span>
-              </button>
-              <input
-                id={`file-${item.id}`}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    onUpload(file);
-                    event.target.value = "";
-                  }
-                }}
-              />
-            </div>
+            {!isNew && (
+              <div className={styles.inlineActions}>
+                <button type="button" className={styles.headerAction} onClick={onToggleEdit}>
+                  <Settings2 size={14} />
+                </button>
+                <button type="button" className={`${styles.headerAction} ${styles.deleteAction}`} onClick={onDelete}>
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            )}
           </div>
           <div className={styles.field}>
             <label>{t("series.characters.fields.name")}</label>

--- a/web/src/components/SeriesInfoCard.module.css
+++ b/web/src/components/SeriesInfoCard.module.css
@@ -309,7 +309,9 @@
   color: rgba(255, 255, 255, 0.6);
   cursor: pointer;
   font-family: inherit;
-  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), background 0.15s;
+  transition:
+    transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    background 0.15s;
 }
 
 .characterAvatarMore:hover {
@@ -330,8 +332,12 @@
 }
 
 @keyframes backdropFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .characterModalBox {
@@ -349,8 +355,14 @@
 }
 
 @keyframes modalSlideIn {
-  from { opacity: 0; transform: scale(0.9) translateY(10px); }
-  to { opacity: 1; transform: scale(1) translateY(0); }
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 .characterModalHeader {
@@ -624,6 +636,46 @@
 
 .btnMore:focus {
   outline: none; /* Ensure focus outline is removed */
+}
+
+.missingNumberNotice {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 0.4rem;
+  max-width: 100%;
+  min-height: 28px;
+  /* seriesContent의 8px gap을 상쇄해 줄거리 아래 실거리 5px를 유지 */
+  margin-top: -3px;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(251, 191, 36, 0.92);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.missingNumberNotice:hover {
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.missingNumberNotice span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.missingNumberNotice:focus-visible {
+  outline: 2px solid rgba(251, 191, 36, 0.9);
+  outline-offset: 2px;
+}
+
+.missingNumberNoticeCollapsed {
+  justify-content: center;
+  width: 28px;
+  padding: 4px;
 }
 
 .seriesActions {

--- a/web/src/components/SeriesInfoCard.test.tsx
+++ b/web/src/components/SeriesInfoCard.test.tsx
@@ -53,7 +53,7 @@ describe("SeriesInfoCard description", () => {
     expect(screen.queryByRole("button", { name: /series\.missing_/ })).not.toBeInTheDocument();
   });
 
-  it("누락 회차 안내를 클릭하면 아이콘만 남기고 다시 클릭하면 펼친다", () => {
+  it("누락 회차 안내는 기본으로 접혀 있고 클릭하면 내용을 펼친다", () => {
     render(
       <SeriesInfoCard
         series={{ ...series, display_unit: "volume" }}
@@ -66,15 +66,16 @@ describe("SeriesInfoCard description", () => {
     );
 
     const notice = screen.getByRole("button", { name: "series.missing_volumes:9권, 12권" });
-    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
-
-    fireEvent.click(notice);
-
     expect(notice).toHaveAttribute("aria-pressed", "true");
     expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
 
     fireEvent.click(notice);
+
     expect(notice).toHaveAttribute("aria-pressed", "false");
     expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+    expect(notice).toHaveAttribute("aria-pressed", "true");
+    expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
   });
 });

--- a/web/src/components/SeriesInfoCard.test.tsx
+++ b/web/src/components/SeriesInfoCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Series } from "../types/series";
+import { SeriesInfoCard } from "./SeriesInfoCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { numbers?: string }) => {
+      if (options?.numbers) return `${key}:${options.numbers}`;
+      if (key === "series.action.more") return "더보기";
+      if (key === "series.action.less") return "접기";
+      if (key === "series.missing_number_unit.volume") return "권";
+      return key;
+    },
+    i18n: { language: "ko" },
+  }),
+}));
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: () => ({ role: "USER" }),
+}));
+
+vi.mock("../api/client", () => ({
+  seriesAPI: {},
+  volumeAPI: {},
+}));
+
+const series: Series = {
+  id: "series-1",
+  library_id: "library-1",
+  title: "테스트 시리즈",
+  description: "가".repeat(151),
+  created_at: "2026-07-18T00:00:00Z",
+  updated_at: "2026-07-18T00:00:00Z",
+};
+
+describe("SeriesInfoCard description", () => {
+  it("세 줄 안에 표시되는 설명에는 더보기 버튼을 표시하지 않는다", () => {
+    render(<SeriesInfoCard series={series} onPlay={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
+  });
+
+  it("display_unit이 없으면 누락 번호를 권으로 표시한다", () => {
+    render(<SeriesInfoCard series={series} missingNumberRanges={[{ start: 2, end: 2 }]} onPlay={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "series.missing_volumes:2권" })).toBeInTheDocument();
+  });
+
+  it("표시할 수 없는 빈 누락 범위는 안내를 렌더링하지 않는다", () => {
+    render(<SeriesInfoCard series={series} missingNumberRanges={[{ start: 3, end: 2 }]} onPlay={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /series\.missing_/ })).not.toBeInTheDocument();
+  });
+
+  it("누락 회차 안내를 클릭하면 아이콘만 남기고 다시 클릭하면 펼친다", () => {
+    render(
+      <SeriesInfoCard
+        series={{ ...series, display_unit: "volume" }}
+        missingNumberRanges={[
+          { start: 9, end: 9 },
+          { start: 12, end: 12 },
+        ]}
+        onPlay={vi.fn()}
+      />,
+    );
+
+    const notice = screen.getByRole("button", { name: "series.missing_volumes:9권, 12권" });
+    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+
+    expect(notice).toHaveAttribute("aria-pressed", "true");
+    expect(notice).not.toHaveTextContent("series.missing_volumes:9권, 12권");
+
+    fireEvent.click(notice);
+    expect(notice).toHaveAttribute("aria-pressed", "false");
+    expect(notice).toHaveTextContent("series.missing_volumes:9권, 12권");
+  });
+});

--- a/web/src/components/SeriesInfoCard.tsx
+++ b/web/src/components/SeriesInfoCard.tsx
@@ -54,7 +54,7 @@ export function SeriesInfoCard({
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
-  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(false);
+  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(true);
   const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -180,7 +180,7 @@ export function SeriesInfoCard({
   }, [displayDescription]);
 
   useEffect(() => {
-    setIsMissingNumberNoticeCollapsed(false);
+    setIsMissingNumberNoticeCollapsed(true);
   }, [missingNumberNoticeLabel]);
 
   useEffect(() => {

--- a/web/src/components/SeriesInfoCard.tsx
+++ b/web/src/components/SeriesInfoCard.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { Play, Edit2, Heart, Shield, BookCheck, BookX, ChevronDown, Download, FileText, BookOpen } from "lucide-react";
+import { Play, Edit2, Heart, Shield, BookCheck, BookX, ChevronDown, Download, FileText, BookOpen, CircleAlert } from "lucide-react";
 import type { Series, Volume, ReadingProgress, SeriesProgressSummary, SeriesCharacter, Library } from "../types/series";
+import { formatMissingNumberRanges, type NumberRange } from "../utils/missingNumbers";
 import { EditSeriesModal } from "./modals/EditSeriesModal";
 import { EditVolumeModal } from "./modals/EditVolumeModal";
 import { AlertModal, type AlertType } from "./modals/AlertModal";
@@ -22,6 +23,7 @@ interface SeriesInfoCardProps {
   progress?: ReadingProgress;
   summary?: SeriesProgressSummary;
   preferPercentLabel?: boolean;
+  missingNumberRanges?: NumberRange[];
   characters?: SeriesCharacter[];
   onUpdate?: (updated: Series | Volume) => void;
   onPlay: (incognito?: boolean) => void | Promise<void>;
@@ -38,6 +40,7 @@ export function SeriesInfoCard({
   progress,
   summary,
   preferPercentLabel = false,
+  missingNumberRanges = [],
   characters,
   onUpdate,
   onPlay,
@@ -50,6 +53,9 @@ export function SeriesInfoCard({
   const characterModalTitleId = useId();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+  const [isMissingNumberNoticeCollapsed, setIsMissingNumberNoticeCollapsed] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isCharacterModalOpen, setIsCharacterModalOpen] = useState(false);
@@ -156,6 +162,49 @@ export function SeriesInfoCard({
   const lowerDisplayPath = displayPath.toLowerCase();
   const isTextFile = lowerDisplayPath.endsWith(".txt") || (!isVolumeType && series.extension === "TXT");
   const isAudiobook = series.library_type === "audiobook";
+  const shouldUseSeriesDescriptionFallback = isVolumeType && !volume?.description?.trim();
+  const rawDescription = isVolumeType && !shouldUseSeriesDescriptionFallback ? volume?.description ?? "" : series.description;
+  const translatedDescription = !isVolumeType || shouldUseSeriesDescriptionFallback ? series.metadata?.description_translated : undefined;
+  const displayDescription = translatedDescription || rawDescription;
+  const isChapterUnit = series.display_unit === "chapter";
+  const missingNumberUnit = isChapterUnit
+    ? t("series.missing_number_unit.chapter")
+    : t("series.missing_number_unit.volume");
+  const missingNumberLabel = formatMissingNumberRanges(missingNumberRanges, missingNumberUnit);
+  const missingNumberNoticeLabel = isChapterUnit
+    ? t("series.missing_chapters", { numbers: missingNumberLabel })
+    : t("series.missing_volumes", { numbers: missingNumberLabel });
+
+  useEffect(() => {
+    setIsDescriptionExpanded(false);
+  }, [displayDescription]);
+
+  useEffect(() => {
+    setIsMissingNumberNoticeCollapsed(false);
+  }, [missingNumberNoticeLabel]);
+
+  useEffect(() => {
+    const descriptionElement = descriptionRef.current;
+    if (!descriptionElement || !displayDescription || isDescriptionExpanded) {
+      if (!displayDescription) {
+        setIsDescriptionTruncated(false);
+      }
+      return undefined;
+    }
+
+    const updateTruncation = () => {
+      setIsDescriptionTruncated(descriptionElement.scrollHeight > descriptionElement.clientHeight + 1);
+    };
+
+    updateTruncation();
+    if (typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+
+    const resizeObserver = new ResizeObserver(updateTruncation);
+    resizeObserver.observe(descriptionElement);
+    return () => resizeObserver.disconnect();
+  }, [displayDescription, isDescriptionExpanded]);
 
   // 시리즈 완독 처리 실행
   const executeMarkComplete = async () => {
@@ -534,42 +583,44 @@ export function SeriesInfoCard({
         </div>
 
         {/* 줄거리 */}
-        {(() => {
-          const shouldUseSeriesDescriptionFallback = isVolumeType && !volume?.description?.trim();
-          const rawDescription =
-            isVolumeType && !shouldUseSeriesDescriptionFallback ? volume?.description ?? "" : series.description;
-          const translatedDescription =
-            !isVolumeType || shouldUseSeriesDescriptionFallback
-              ? series.metadata?.description_translated
-              : undefined;
-          const displayDescription = translatedDescription || rawDescription;
-
-          if (!displayDescription) return null;
-
-          return (
-            <div className={styles.seriesDescription}>
-              <p
-                style={{
-                  margin: 0,
-                  display: "-webkit-box",
-                  WebkitLineClamp: isDescriptionExpanded ? "unset" : 3,
-                  WebkitBoxOrient: "vertical",
-                  overflow: "hidden",
-                }}
+        {displayDescription && (
+          <div className={styles.seriesDescription}>
+            <p
+              ref={descriptionRef}
+              style={{
+                margin: 0,
+                display: "-webkit-box",
+                WebkitLineClamp: isDescriptionExpanded ? "unset" : 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {displayDescription}
+            </p>
+            {isDescriptionTruncated && (
+              <button
+                onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                className={styles.btnMore}
               >
-                {displayDescription}
-              </p>
-              {displayDescription.length > 150 && (
-                <button
-                  onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-                  className={styles.btnMore}
-                >
-                  {isDescriptionExpanded ? t("series.action.less") : t("series.action.more")}
-                </button>
-              )}
-            </div>
-          );
-        })()}
+                {isDescriptionExpanded ? t("series.action.less") : t("series.action.more")}
+              </button>
+            )}
+          </div>
+        )}
+
+        {missingNumberRanges.length > 0 && missingNumberLabel && (
+          <button
+            type="button"
+            className={`${styles.missingNumberNotice} ${isMissingNumberNoticeCollapsed ? styles.missingNumberNoticeCollapsed : ""}`}
+            aria-label={missingNumberNoticeLabel}
+            aria-pressed={isMissingNumberNoticeCollapsed}
+            title={isMissingNumberNoticeCollapsed ? missingNumberNoticeLabel : undefined}
+            onClick={() => setIsMissingNumberNoticeCollapsed((collapsed) => !collapsed)}
+          >
+            <CircleAlert size={16} aria-hidden="true" />
+            {!isMissingNumberNoticeCollapsed && <span>{missingNumberNoticeLabel}</span>}
+          </button>
+        )}
 
         {/* 액션 버튼 */}
         <div className={styles.seriesActions}>

--- a/web/src/features/viewer/components/PdfChapterViewer/index.tsx
+++ b/web/src/features/viewer/components/PdfChapterViewer/index.tsx
@@ -198,6 +198,10 @@ interface PdfChapterViewerProps {
   onPrev: (delta?: number | React.MouseEvent) => void;
   onOutlineLoad?: (outline: PDFOutlineItem[]) => void;
   transitionType: PageTransitionType;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
   onZoomChange?: (scale: number) => void;
   onPageChange?: (page: number) => void;
 }
@@ -218,6 +222,8 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
       onPrev,
       onOutlineLoad,
       transitionType,
+      canGoNextChapter = false,
+      canGoPrevChapter = false,
       onZoomChange,
       onPageChange,
     },
@@ -256,14 +262,24 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
     const animatePrevRef = useRef<(() => void) | null>(null);
 
     const handleAnimatedNext = useCallback(() => {
-      if (animateNextRef.current) animateNextRef.current();
-      else onNext(readingMode === "double" ? 2 : 1);
-    }, [onNext, readingMode]);
+      if (canGoNextChapter) {
+        onNext(readingMode === "double" ? 2 : 1);
+      } else if (animateNextRef.current) {
+        animateNextRef.current();
+      } else {
+        onNext(readingMode === "double" ? 2 : 1);
+      }
+    }, [canGoNextChapter, onNext, readingMode]);
 
     const handleAnimatedPrev = useCallback(() => {
-      if (animatePrevRef.current) animatePrevRef.current();
-      else onPrev(readingMode === "double" ? 2 : 1);
-    }, [onPrev, readingMode]);
+      if (canGoPrevChapter) {
+        onPrev(readingMode === "double" ? 2 : 1);
+      } else if (animatePrevRef.current) {
+        animatePrevRef.current();
+      } else {
+        onPrev(readingMode === "double" ? 2 : 1);
+      }
+    }, [canGoPrevChapter, onPrev, readingMode]);
     const getVerticalScrollContainer = () => {
       const parent = containerRef.current?.parentElement;
       return parent instanceof HTMLElement ? parent : null;
@@ -1035,6 +1051,8 @@ export const PdfChapterViewer = forwardRef<ViewerAnimationHandles, PdfChapterVie
       containerRef,
       gap: 20,
       duration: 300,
+      skipNextAnimation: canGoNextChapter,
+      skipPrevAnimation: canGoPrevChapter,
     });
 
     // Keep refs in sync with useSwipe's animation functions

--- a/web/src/features/viewer/components/ViewerContent/index.tsx
+++ b/web/src/features/viewer/components/ViewerContent/index.tsx
@@ -43,6 +43,10 @@ interface ViewerContentProps {
   isInitialScrolling?: boolean; // Boolean으로 회복
   estimatedPageHeights?: Map<number, number>;
   viewStatus?: ViewStatus;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (다음 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (이전 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
 }
 
 export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentProps>(
@@ -73,6 +77,8 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
       isInitialScrolling = false,
       estimatedPageHeights,
       viewStatus = "ready",
+      canGoNextChapter = false,
+      canGoPrevChapter = false,
     },
     ref,
   ) => {
@@ -83,14 +89,24 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
     const animatePrevRef = useRef<(() => void) | null>(null);
 
     const handleAnimatedNext = useCallback(() => {
-      if (animateNextRef.current) animateNextRef.current();
-      else onNext();
-    }, [onNext]);
+      if (canGoNextChapter) {
+        onNext();
+      } else if (animateNextRef.current) {
+        animateNextRef.current();
+      } else {
+        onNext();
+      }
+    }, [canGoNextChapter, onNext]);
 
     const handleAnimatedPrev = useCallback(() => {
-      if (animatePrevRef.current) animatePrevRef.current();
-      else onPrev();
-    }, [onPrev]);
+      if (canGoPrevChapter) {
+        onPrev();
+      } else if (animatePrevRef.current) {
+        animatePrevRef.current();
+      } else {
+        onPrev();
+      }
+    }, [canGoPrevChapter, onPrev]);
     const { transformComponentRef, isZoomed, setIsZoomed, handleContentClick, handleMouseDown, handleMouseMove } =
       useViewerZoom({
         clickDirection,
@@ -116,6 +132,8 @@ export const ViewerContent = forwardRef<ViewerAnimationHandles, ViewerContentPro
       containerRef,
       gap: PAGE_GAP,
       duration: 300,
+      skipNextAnimation: canGoNextChapter,
+      skipPrevAnimation: canGoPrevChapter,
     });
 
     // Vertical 모드일 때는 이벤트 핸들러를 null로 처리하여 스와이프 방지

--- a/web/src/features/viewer/hooks/useSwipe.ts
+++ b/web/src/features/viewer/hooks/useSwipe.ts
@@ -11,6 +11,10 @@ interface UseSwipeParams {
   containerRef?: React.RefObject<HTMLDivElement | null>;
   gap?: number;
   duration?: number;
+  /** true면 다음 페이지로의 스와이프 임계값 도달 시 애니메이션 없이 즉시 onNext 호출 */
+  skipNextAnimation?: boolean;
+  /** true면 이전 페이지로의 스와이프 임계값 도달 시 애니메이션 없이 즉시 onPrev 호출 */
+  skipPrevAnimation?: boolean;
 }
 
 export function useSwipe({
@@ -23,6 +27,8 @@ export function useSwipe({
   containerRef,
   gap = 20,
   duration = 300,
+  skipNextAnimation = false,
+  skipPrevAnimation = false,
 }: UseSwipeParams) {
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
@@ -112,6 +118,18 @@ export function useSwipe({
       isNext = isRTL;
     }
 
+    // 방향별로 애니메이션 억제 여부 확인
+    if (isNext && skipNextAnimation) {
+      setSwipeOffset(0);
+      onNext();
+      return;
+    }
+    if (!isNext && skipPrevAnimation) {
+      setSwipeOffset(0);
+      onPrev();
+      return;
+    }
+
     const targetOffset = finalOffset < 0 ? -(containerWidth + gap) : containerWidth + gap;
 
     setIsAnimating(true);
@@ -140,11 +158,23 @@ export function useSwipe({
     containerRef,
     gap,
     duration,
+    skipNextAnimation,
+    skipPrevAnimation,
   ]);
 
   const animateTransition = useCallback(
     (direction: "next" | "prev") => {
       if (isAnimating) return;
+
+      // 방향별 애니메이션 억제
+      if (direction === "next" && skipNextAnimation) {
+        onNext();
+        return;
+      }
+      if (direction === "prev" && skipPrevAnimation) {
+        onPrev();
+        return;
+      }
 
       const containerWidth = containerRef?.current?.clientWidth || window.innerWidth;
       // 클릭/키보드 등 명시적 next/prev 전환은 읽기 방향 기준으로 애니메이션한다.
@@ -173,7 +203,7 @@ export function useSwipe({
         setIsAnimating(false);
       }, duration);
     },
-    [isAnimating, containerRef, readingDirection, gap, duration, onNext, onPrev],
+    [isAnimating, containerRef, readingDirection, gap, duration, onNext, onPrev, skipNextAnimation, skipPrevAnimation],
   );
 
   const animateNext = useCallback(() => animateTransition("next"), [animateTransition]);

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -345,3 +345,298 @@ describe("useViewerNavigation split-page flow", () => {
     expect(setSubPage).toHaveBeenCalledWith(null);
   });
 });
+
+describe("useViewerNavigation chapter boundary flags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wideMeta = (page: number): Map<number, PageMeta> =>
+    new Map([
+      [
+        page,
+        {
+          pageNumber: page,
+          width: 2600,
+          height: 1600,
+          isWide: true,
+        },
+      ],
+    ]);
+
+  it("마지막 일반 페이지 + nextChapterId 존재 → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("마지막 페이지 + nextChapterId 없음 → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 첫 번째 subPage (LTR) → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 마지막 subPage (LTR) → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+
+  it("single 모드 마지막 wide 이미지의 첫 번째 subPage (RTL) → canGoNextChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(false);
+  });
+
+  it("single 모드 마지막 wide 이미지의 마지막 subPage (RTL) → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(10),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+
+  it("single 모드 첫 wide 이미지의 마지막 subPage (LTR) → canGoPrevChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("single 모드 첫 wide 이미지의 첫 번째 subPage (LTR) → canGoPrevChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(true);
+  });
+
+  it("single 모드 첫 wide 이미지의 마지막 subPage (RTL) → canGoPrevChapter === false", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "left",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(false);
+  });
+
+  it("single 모드 첫 wide 이미지의 첫 번째 subPage (RTL) → canGoPrevChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 1,
+        totalPages: 10,
+        readingMode: "single",
+        readingDirection: "rtl",
+        keyboardDirection: "rtl",
+        pageOffset: 0,
+        pageMetaMap: wideMeta(1),
+        subPage: "right",
+        setSubPage: vi.fn(),
+        nextChapterId: null,
+        prevChapterId: "prev-chapter",
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoPrevChapter).toBe(true);
+  });
+
+  it("double 모드 마지막 페이지 + nextChapterId 존재 → canGoNextChapter === true", () => {
+    const { result } = renderHook(() =>
+      useViewerNavigation({
+        currentPage: 10,
+        totalPages: 10,
+        readingMode: "double",
+        readingDirection: "ltr",
+        keyboardDirection: "ltr",
+        pageOffset: 0,
+        pageMetaMap: new Map(),
+        subPage: null,
+        setSubPage: vi.fn(),
+        nextChapterId: "next-chapter",
+        prevChapterId: null,
+        saveProgress: mocks.saveProgressMock,
+        isSettingsOpen: false,
+        closeSettings: vi.fn(),
+        handleToggleFullscreen: vi.fn(),
+        currentChapterId: "chapter-1",
+      }),
+    );
+
+    expect(result.current.canGoNextChapter).toBe(true);
+  });
+});

--- a/web/src/features/viewer/hooks/useViewerNavigation.test.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useViewerNavigation } from "./useViewerNavigation";
+import { takeReturnFocus } from "../../../utils/returnFocus";
 import type { PageMeta } from "../types";
 
 const { mocks } = vi.hoisted(() => {
@@ -48,6 +49,7 @@ vi.mock("../../../utils/fullscreen", async (importOriginal) => {
 describe("useViewerNavigation fullscreen switching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("sets chapter switching before navigating to next chapter", async () => {
@@ -109,6 +111,8 @@ describe("useViewerNavigation fullscreen switching", () => {
         closeSettings: vi.fn(),
         handleToggleFullscreen: vi.fn(),
         currentChapterId: "chapter-1",
+        seriesId: "series-1",
+        volumeId: "volume-150",
       }),
     );
 
@@ -118,12 +122,14 @@ describe("useViewerNavigation fullscreen switching", () => {
 
     expect(mocks.saveProgressMock).toHaveBeenCalledTimes(1);
     expect(mocks.navigateMock).toHaveBeenCalledWith("/series/1", { replace: true });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
   });
 });
 
 describe("useViewerNavigation fullscreen shortcut", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("toggles fullscreen on f, F, and ㄹ", () => {
@@ -194,6 +200,7 @@ describe("useViewerNavigation fullscreen shortcut", () => {
 describe("useViewerNavigation split-page flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   const createWidePageMetaMap = (page: number): Map<number, PageMeta> =>
@@ -349,6 +356,7 @@ describe("useViewerNavigation split-page flow", () => {
 describe("useViewerNavigation chapter boundary flags", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   const wideMeta = (page: number): Map<number, PageMeta> =>

--- a/web/src/features/viewer/hooks/useViewerNavigation.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.ts
@@ -6,6 +6,7 @@ import { useViewerStore } from "../../../stores/viewerStore";
 import { isFullscreen as isDocumentFullscreen, isFullscreenToggleShortcut } from "../../../utils/fullscreen";
 import { startChapterSwitching } from "../../../stores/fullscreenSwitchStore";
 import { buildViewerRouteState } from "../../../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../../../utils/returnFocus";
 import type { PageMeta } from "../types";
 import type { ReadingDirection, ReadingMode, SubPage } from "../../../stores/viewerStore";
 import { getNextNavState, getPrevNavState } from "../../../utils/pageCalculator";
@@ -30,6 +31,8 @@ interface UseViewerNavigationParams {
   handleToggleFullscreen: () => void;
   animationRef?: RefObject<ViewerAnimationHandles>;
   currentChapterId: string | undefined;
+  seriesId?: string | null;
+  volumeId?: string | null;
   onReachedSeriesEnd?: () => void;
 }
 
@@ -70,6 +73,8 @@ export function useViewerNavigation({
   handleToggleFullscreen,
   animationRef,
   currentChapterId,
+  seriesId,
+  volumeId,
   onReachedSeriesEnd,
 }: UseViewerNavigationParams): UseViewerNavigationReturn {
   const navigate = useNavigate();
@@ -280,12 +285,13 @@ export function useViewerNavigation({
   // 뒤로가기
   const handleBack = useCallback(() => {
     saveProgress();
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
     } else {
       navigate(-1);
     }
-  }, [saveProgress, navigate, viewerFrom]);
+  }, [saveProgress, navigate, viewerFrom, seriesId, volumeId]);
 
   // 클릭 핸들러
 

--- a/web/src/features/viewer/hooks/useViewerNavigation.ts
+++ b/web/src/features/viewer/hooks/useViewerNavigation.ts
@@ -1,6 +1,6 @@
 // 뷰어 네비게이션 훅 (키보드, 클릭, 페이지 이동)
 
-import { useEffect, useCallback, useState, useRef, type RefObject } from "react";
+import { useEffect, useCallback, useState, useRef, useMemo, type RefObject } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useViewerStore } from "../../../stores/viewerStore";
 import { isFullscreen as isDocumentFullscreen, isFullscreenToggleShortcut } from "../../../utils/fullscreen";
@@ -39,6 +39,10 @@ interface UseViewerNavigationReturn {
   handleBack: () => void;
   showNextHint: boolean;
   showPrevHint: boolean;
+  /** 마지막 페이지에서 다음 챕터로 넘어갈 수 있는 상태 */
+  canGoNextChapter: boolean;
+  /** 첫 페이지에서 이전 챕터로 넘어갈 수 있는 상태 */
+  canGoPrevChapter: boolean;
 }
 
 /**
@@ -95,6 +99,27 @@ export function useViewerNavigation({
       }
     };
   }, []);
+
+  // 현재 챕터의 페이지/챕터 경계 여부 (애니메이션 억제용)
+  // single 모드에서는 wide 이미지의 subPage 이동이 남아 있을 수 있으므로
+  // getNextNavState / getPrevNavState 결과를 함께 고려한다.
+  const canGoNextChapter = useMemo(() => {
+    if (totalPages <= 0 || !nextChapterId) return false;
+    if (readingMode === "single") {
+      const navState = getNextNavState(currentPage, totalPages, subPage, pageMetaMap, readingDirection);
+      return navState === null;
+    }
+    return currentPage >= totalPages;
+  }, [currentPage, totalPages, readingMode, readingDirection, pageMetaMap, subPage, nextChapterId]);
+
+  const canGoPrevChapter = useMemo(() => {
+    if (totalPages <= 0 || !prevChapterId) return false;
+    if (readingMode === "single") {
+      const navState = getPrevNavState(currentPage, subPage, pageMetaMap, readingDirection);
+      return navState === null;
+    }
+    return currentPage <= 1;
+  }, [currentPage, totalPages, readingMode, readingDirection, pageMetaMap, subPage, prevChapterId]);
 
   // 다음 페이지/챕터 핸들러
   const handleNext = useCallback(async () => {
@@ -286,13 +311,19 @@ export function useViewerNavigation({
         case "ArrowLeft":
           e.preventDefault();
           if (isRTL) {
-            if (animationRef?.current) {
+            // RTL: 왼쪽 화살표 = 다음
+            if (canGoNextChapter) {
+              void handleNext();
+            } else if (animationRef?.current) {
               animationRef.current.animateNext();
             } else {
               handleNext();
             }
           } else {
-            if (animationRef?.current) {
+            // LTR: 왼쪽 화살표 = 이전
+            if (canGoPrevChapter) {
+              void handlePrev();
+            } else if (animationRef?.current) {
               animationRef.current.animatePrev();
             } else {
               handlePrev();
@@ -302,13 +333,19 @@ export function useViewerNavigation({
         case "ArrowRight":
           e.preventDefault();
           if (isRTL) {
-            if (animationRef?.current) {
+            // RTL: 오른쪽 화살표 = 이전
+            if (canGoPrevChapter) {
+              void handlePrev();
+            } else if (animationRef?.current) {
               animationRef.current.animatePrev();
             } else {
               handlePrev();
             }
           } else {
-            if (animationRef?.current) {
+            // LTR: 오른쪽 화살표 = 다음
+            if (canGoNextChapter) {
+              void handleNext();
+            } else if (animationRef?.current) {
               animationRef.current.animateNext();
             } else {
               handleNext();
@@ -317,7 +354,9 @@ export function useViewerNavigation({
           break;
         case " ":
           e.preventDefault();
-          if (animationRef?.current) {
+          if (canGoNextChapter) {
+            void handleNext();
+          } else if (animationRef?.current) {
             animationRef.current.animateNext();
           } else {
             handleNext();
@@ -356,6 +395,8 @@ export function useViewerNavigation({
     handleToggleFullscreen,
     handleBack,
     animationRef,
+    canGoNextChapter,
+    canGoPrevChapter,
   ]);
 
   return {
@@ -364,5 +405,7 @@ export function useViewerNavigation({
     handleBack,
     showNextHint,
     showPrevHint,
+    canGoNextChapter,
+    canGoPrevChapter,
   };
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -752,6 +752,12 @@
     "empty_volumes": "No volumes found",
     "empty_chapters": "No chapters found",
     "not_found": "Series not found",
+    "missing_volumes": "Missing volumes: {{numbers}}",
+    "missing_chapters": "Missing chapters: {{numbers}}",
+    "missing_number_unit": {
+      "volume": " vol.",
+      "chapter": " ch."
+    },
     "unit": {
       "volume": "Vol. {{count}}",
       "total_volume": "Total {{count}} volumes",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -752,6 +752,12 @@
     "empty_volumes": "スキャンされた巻がありません",
     "empty_chapters": "スキャンされた話がありません",
     "not_found": "シリーズが見つかりません",
+    "missing_volumes": "欠巻: {{numbers}}",
+    "missing_chapters": "欠番の話: {{numbers}}",
+    "missing_number_unit": {
+      "volume": "巻",
+      "chapter": "話"
+    },
     "unit": {
       "volume": "{{count}}巻",
       "total_volume": "全 {{count}} 巻",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -752,6 +752,12 @@
     "empty_volumes": "스캔된 볼륨이 없습니다",
     "empty_chapters": "스캔된 챕터가 없습니다",
     "not_found": "시리즈를 찾을 수 없습니다",
+    "missing_volumes": "누락 권: {{numbers}}",
+    "missing_chapters": "누락 회차: {{numbers}}",
+    "missing_number_unit": {
+      "volume": "권",
+      "chapter": "화"
+    },
     "unit": {
       "volume": "{{count}}권",
       "total_volume": "총 {{count}}권",

--- a/web/src/pages/EpubViewerRoute.test.tsx
+++ b/web/src/pages/EpubViewerRoute.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from "react-router-dom";
 import { EpubViewerRoute } from "./EpubViewerRoute";
 import { isMobile } from "../utils/device";
+import { takeReturnFocus } from "../utils/returnFocus";
 
 const epubProgressGetMock = vi.fn();
 const apiGetMock = vi.fn();
@@ -1215,6 +1216,55 @@ describe("EpubViewerRoute", () => {
     });
   });
 
+  it("나가기 버튼은 마지막으로 보고 있던 볼륨을 시리즈 복귀 대상으로 갱신한다", async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/viewer/:chapterId",
+          element: (
+            <EpubViewerRoute
+              loaderData={{
+                chapter: {
+                  id: "chapter-150",
+                  volume_id: "volume-150",
+                  title: "EPUB 챕터 150",
+                  chapter_number: 1,
+                  page_count: 1,
+                },
+                isLoading: false,
+                error: null,
+                seriesId: "series-1",
+                volumeId: "volume-150",
+                pageMeta: [],
+                pageMetaMap: new Map(),
+                isInitialScrollingRef: { current: false },
+                setViewStatus: vi.fn(),
+              }}
+            />
+          ),
+        },
+        {
+          path: "/volumes/volume-1",
+          element: <div data-testid="volume-page">volume page</div>,
+        },
+      ],
+      {
+        initialEntries: [{ pathname: "/viewer/chapter-150", state: { from: "/volumes/volume-1" } }],
+      },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(latestViewerProps?.onBack).toBeDefined());
+
+    act(() => {
+      latestViewerProps?.onBack?.();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("volume-page")).toBeInTheDocument());
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
+  });
+
   it("이전 챕터 이동 시 viewerFrom과 isIncognito 상태를 유지한다", async () => {
     useAdjacentChaptersMock.mockReturnValue({
       nextChapterId: null,
@@ -1341,6 +1391,7 @@ describe("EpubViewerRoute", () => {
       expect(router.state.location.pathname).toBe("/series/1");
       expect(router.state.historyAction).toBe("REPLACE");
     });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-1");
   });
 
   it("isMobile()이 true일 때 모바일 전용 설정 키를 우선 로딩한다", async () => {

--- a/web/src/pages/EpubViewerRoute.tsx
+++ b/web/src/pages/EpubViewerRoute.tsx
@@ -30,6 +30,7 @@ import {
 import { usePreventBrowserZoom } from "../features/viewer/hooks/usePreventBrowserZoom";
 import { useViewerSync } from "../hooks/useViewerSync";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 interface EpubViewerRouteProps {
   loaderData: UseChapterLoaderReturn;
@@ -1058,12 +1059,13 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   );
 
   const handleBack = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
     } else {
       navigate(-1);
     }
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   const handleReachedSeriesEnd = useCallback(() => {
     if (isAdjacentResolved) {
@@ -1092,12 +1094,13 @@ export function EpubViewerRoute({ loaderData }: EpubViewerRouteProps) {
   }, [prevChapterId, navigate, viewerFrom, routeIsIncognito]);
 
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   const handleToggleFullscreen = useCallback(() => {
     try {

--- a/web/src/pages/ImageViewerRoute.tsx
+++ b/web/src/pages/ImageViewerRoute.tsx
@@ -9,6 +9,7 @@ import { enterFullscreen, exitFullscreen, isFullscreen as isDocumentFullscreen }
 import { ViewerSettings as ViewerSettingsModal } from "../components/viewer/ViewerSettings";
 
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 // Feature imports
 import {
@@ -377,6 +378,8 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
     handleToggleFullscreen,
     animationRef: animationRef as React.RefObject<ViewerAnimationHandles>,
     currentChapterId: chapterId,
+    seriesId,
+    volumeId,
     onReachedSeriesEnd: handleReachedSeriesEnd,
   });
 
@@ -406,12 +409,13 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
 
   // 세션 종료 핸들러
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   // 읽기 시간 측정 (활성화)
   useReadingTime(seriesId || undefined, !isLoading && !error, chapterId);

--- a/web/src/pages/ImageViewerRoute.tsx
+++ b/web/src/pages/ImageViewerRoute.tsx
@@ -359,7 +359,7 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
   }, [isAdjacentResolved]);
 
   // 네비게이션
-  const { handleNext, handlePrev, handleBack, showNextHint, showPrevHint } = useViewerNavigation({
+  const { handleNext, handlePrev, handleBack, showNextHint, showPrevHint, canGoNextChapter, canGoPrevChapter } = useViewerNavigation({
     currentPage,
     totalPages,
     readingMode: settings.readingMode,
@@ -656,6 +656,8 @@ export function ImageViewerRoute({ loaderData }: { loaderData: UseChapterLoaderR
               isInitialScrolling={viewStatus !== "ready"}
               estimatedPageHeights={estimatedHeights}
               viewStatus={viewStatus}
+              canGoNextChapter={canGoNextChapter}
+              canGoPrevChapter={canGoPrevChapter}
             />
           </div>
 

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { Series } from "../types/series";
 import { LibraryPage } from "./Library";
 import styles from "./Library.module.css";
+import { rememberReturnFocus } from "../utils/returnFocus";
 
 const { mocks, libraryStoreState, authStoreState } = vi.hoisted(() => {
   const libraryGetMock = vi.fn();
@@ -138,6 +139,7 @@ vi.mock("../components/common/LoadingSpinner", () => ({
 }));
 
 const originalResizeObserver = globalThis.ResizeObserver;
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, "matchMedia");
 const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
   window.HTMLElement.prototype,
   "scrollIntoView",
@@ -272,6 +274,11 @@ describe("LibraryPage series index", () => {
   afterEach(() => {
     defaultRectSpy.mockRestore();
     globalThis.ResizeObserver = originalResizeObserver;
+    if (originalMatchMediaDescriptor) {
+      Object.defineProperty(window, "matchMedia", originalMatchMediaDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
     if (originalScrollIntoViewDescriptor) {
       Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
     } else {
@@ -287,6 +294,38 @@ describe("LibraryPage series index", () => {
     } else {
       Reflect.deleteProperty(window.Element.prototype, "scrollTo");
     }
+  });
+
+  it("복귀한 라이브러리에서 직전에 열었던 시리즈 카드를 중앙에 맞춘다", async () => {
+    rememberReturnFocus("library", "library-1", "series-b");
+
+    renderLibraryPage();
+
+    await screen.findByText("Beta");
+    await waitFor(() => {
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
+      });
+    });
+  });
+
+  it("동작 줄이기 설정에서는 복귀 카드를 즉시 중앙에 맞춘다", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+    rememberReturnFocus("library", "library-1", "series-b");
+
+    renderLibraryPage();
+
+    await screen.findByText("Beta");
+    await waitFor(() => {
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "auto",
+        block: "center",
+      });
+    });
   });
 
   it("활성 목차 항목이 스크롤 영역 중앙에 오도록 이동한다", async () => {

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -21,6 +21,8 @@ import {
   getSeriesDisplayName,
   getSeriesGroupKey,
 } from "../utils/librarySeries";
+import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
+import { prefersReducedMotion } from "../utils/reducedMotion";
 import styles from "./Library.module.css";
 
 const POLL_INTERVAL_MS = 3000;
@@ -56,6 +58,7 @@ export function LibraryPage() {
   const loadSequenceRef = useRef(0);
   const lastFetchedIdRef = useRef<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const seriesCardRefs = useRef<Record<string, HTMLDivElement>>({});
   const indexButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const scrollingToGroupRef = useRef<string | null>(null);
   const scrollReleaseTimeoutRef = useRef<number | null>(null);
@@ -138,6 +141,22 @@ export function LibraryPage() {
       };
     }
   }, [id, refreshKey, loadData, fetchLibraries]);
+
+  useEffect(() => {
+    if (!id || isLoading) return;
+
+    // App의 전역 scroll-to-top effect가 끝난 다음 프레임에 복귀 스크롤을 적용한다.
+    // StrictMode의 effect 재실행에서도 취소된 프레임은 storage를 소비하지 않는다.
+    const frameId = window.requestAnimationFrame(() => {
+      const seriesId = takeReturnFocus("library", id);
+      const target = seriesId ? seriesCardRefs.current[seriesId] : null;
+      if (!target) return;
+
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [id, isLoading, seriesList]);
 
   // 스캔 중일 때 시리즈 목록 실시간 폴링
   // - isScanning: 이 페이지에서 직접 스캔 버튼을 눌렀을 때 (libraryAPI.scan은 동기 블로킹이므로 스토어 갱신 없음)
@@ -265,15 +284,12 @@ export function LibraryPage() {
     }
     const target = sectionRefs.current[groupKey];
     if (target) {
-      const prefersReducedMotion =
-        typeof window !== "undefined" &&
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      target.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+      const reducedMotion = prefersReducedMotion();
+      target.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "start" });
       scrollReleaseTimeoutRef.current = window.setTimeout(() => {
         scrollingToGroupRef.current = null;
         scrollReleaseTimeoutRef.current = null;
-      }, prefersReducedMotion ? 0 : INDEX_SCROLL_LOCK_MS);
+      }, reducedMotion ? 0 : INDEX_SCROLL_LOCK_MS);
     } else {
       scrollingToGroupRef.current = null;
     }
@@ -668,6 +684,11 @@ export function LibraryPage() {
                         <div
                           key={series.id}
                           ref={(node) => {
+                            if (node) {
+                              seriesCardRefs.current[series.id] = node;
+                            } else {
+                              delete seriesCardRefs.current[series.id];
+                            }
                             if (index === 0) {
                               sectionRefs.current[group.key] = node;
                             }
@@ -681,6 +702,9 @@ export function LibraryPage() {
                             progressStyle="overlay"
                             showExtensionBadge
                             onStatusChange={loadData}
+                            onBeforeNavigate={() => {
+                              if (id) rememberReturnFocus("library", id, series.id);
+                            }}
                           />
                         </div>
                       );

--- a/web/src/pages/PdfViewer.tsx
+++ b/web/src/pages/PdfViewer.tsx
@@ -59,6 +59,10 @@ interface PdfViewerProps {
   onOutlineLoad: (outline: PDFOutlineItem[]) => void;
   onNext: (delta?: number | React.MouseEvent) => void;
   onPrev: (delta?: number | React.MouseEvent) => void;
+  /** 마지막 페이지에서 다음 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoNextChapter?: boolean;
+  /** 첫 페이지에서 이전 챕터 이동 가능 여부 (PDF 슬라이드 애니메이션 억제용) */
+  canGoPrevChapter?: boolean;
   onPageChange?: (page: number) => void;
   onGoToPage: (page: number) => void;
   onZoomChange?: (scale: number) => void;
@@ -135,6 +139,8 @@ export function PdfViewer({
   onZoomOut,
   onZoomReset,
   onZoomChange,
+  canGoNextChapter = false,
+  canGoPrevChapter = false,
 }: PdfViewerProps) {
   const backgroundClassName = getBackgroundClassName(settings.backgroundColor);
   const tocMarkers = useMemo(() => {
@@ -229,6 +235,8 @@ export function PdfViewer({
           onOutlineLoad={onOutlineLoad}
           onNext={onNext}
           onPrev={onPrev}
+          canGoNextChapter={canGoNextChapter}
+          canGoPrevChapter={canGoPrevChapter}
           onPageChange={onPageChange}
           transitionType={settings.pageTransition}
           onZoomChange={onZoomChange}

--- a/web/src/pages/PdfViewerRoute.test.tsx
+++ b/web/src/pages/PdfViewerRoute.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from "react-router-dom";
 import { PdfViewerRoute } from "./PdfViewerRoute";
 import { useViewerStore } from "../stores/viewerStore";
+import { takeReturnFocus } from "../utils/returnFocus";
 
 const useProgressSyncMock = vi.fn();
 const useViewerSyncMock = vi.fn();
@@ -209,15 +210,15 @@ describe("PdfViewerRoute", () => {
               loaderData={{
                 chapter: {
                   id: "chapter-7",
-                  volume_id: "volume-1",
-                  title: "PDF 챕터",
+                  volume_id: "volume-150",
+                  title: "PDF 챕터 150",
                   chapter_number: 1,
                   page_count: 20,
                 },
                 isLoading: false,
                 error: null,
                 seriesId: "series-1",
-                volumeId: "volume-1",
+                volumeId: "volume-150",
                 pageMeta: [],
                 pageMetaMap: new Map(),
                 isInitialScrollingRef: { current: false },
@@ -248,5 +249,6 @@ describe("PdfViewerRoute", () => {
       expect(router.state.location.pathname).toBe("/series/1");
       expect(router.state.historyAction).toBe("REPLACE");
     });
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
   });
 });

--- a/web/src/pages/PdfViewerRoute.tsx
+++ b/web/src/pages/PdfViewerRoute.tsx
@@ -142,7 +142,7 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
   }, []);
 
   // 네비게이션 제어
-  const { handleNext, handlePrev, handleBack } = useViewerNavigation({
+  const { handleNext, handlePrev, handleBack, canGoNextChapter, canGoPrevChapter } = useViewerNavigation({
     currentPage,
     totalPages,
     readingMode: settings.readingMode,
@@ -377,6 +377,8 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
         onOutlineLoad={handleOutlineLoad}
         onNext={handleNext}
         onPrev={handlePrev}
+        canGoNextChapter={canGoNextChapter}
+        canGoPrevChapter={canGoPrevChapter}
         onPageChange={handlePageChange}
         onGoToPage={goToPage}
         onPageJumpClick={() => setShowPageJump(true)}

--- a/web/src/pages/PdfViewerRoute.tsx
+++ b/web/src/pages/PdfViewerRoute.tsx
@@ -25,6 +25,7 @@ import { PdfViewer } from "./PdfViewer";
 import { usePreventBrowserZoom } from "../features/viewer/hooks/usePreventBrowserZoom";
 import type { SubPage } from "../stores/viewerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberViewerReturnFocus } from "../utils/returnFocus";
 
 interface PdfViewerRouteProps {
   loaderData: UseChapterLoaderReturn;
@@ -160,6 +161,8 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
     handleToggleFullscreen,
     animationRef: animationRef as React.RefObject<ViewerAnimationHandles>,
     currentChapterId: chapterId,
+    seriesId,
+    volumeId,
     onReachedSeriesEnd: handleReachedSeriesEnd,
   });
 
@@ -177,12 +180,13 @@ export function PdfViewerRoute({ loaderData }: PdfViewerRouteProps) {
 
   // 세션 종료 핸들러
   const handleTerminatedConfirm = useCallback(() => {
+    rememberViewerReturnFocus(viewerFrom, seriesId, volumeId);
     if (viewerFrom) {
       navigate(viewerFrom, { replace: true });
       return;
     }
     navigate("/");
-  }, [navigate, viewerFrom]);
+  }, [navigate, viewerFrom, seriesId, volumeId]);
 
   // 읽기 시간 측정 (활성화)
   useReadingTime(seriesId || undefined, true, chapterId as string);

--- a/web/src/pages/Series.module.css
+++ b/web/src/pages/Series.module.css
@@ -24,101 +24,16 @@
   gap: 1rem;
 }
 
-.volumeCard {
+/* ref 콜백을 위한 래퍼. grid item으로 동작하며 내부 SeriesCard가 너비를 채운다. */
+.volumeCardAnchor {
   display: flex;
   flex-direction: column;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  overflow: hidden;
-  text-decoration: none;
-  color: inherit;
-  transition: all 0.2s;
+  min-width: 0;
 }
 
-.volumeCard:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(102, 126, 234, 0.4);
-  transform: translateY(-2px);
-}
-
-.volumeCover {
-  aspect-ratio: 5/8; /* 시리즈 카드와 동일하게 1:1.6 비율 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #1e3a5f 0%, #2d3748 100%);
-  color: #667eea;
-  overflow: hidden;
-  position: relative;
-}
-
-.volumeThumbnail {
+.volumeCardAnchor > * {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-}
-
-.volumeCard:hover .volumeThumbnail {
-  transform: scale(1.05);
-}
-
-/* 볼륨 카드 클릭 스타일 */
-.volumeCard {
-  cursor: pointer;
-}
-
-.volumeCard.loading {
-  pointer-events: none;
-  opacity: 0.7;
-}
-
-/* 재생 오버레이 */
-.volumePlayOverlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.4);
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-.volumeCard:hover .volumePlayOverlay {
-  opacity: 1;
-}
-
-.volumePlayOverlay .loadingSpinner.small {
-  width: 24px;
-  height: 24px;
-  border-width: 2px;
-}
-
-.volumeInfo {
-  padding: 0.75rem;
-}
-
-.volumeTitle {
-  font-size: 0.9rem;
-  font-weight: 500;
-  margin: 0 0 0.25rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.volumeNumber {
-  font-size: 0.8rem;
-  color: #718096;
-  margin: 0;
+  flex: 1 1 auto;
 }
 
 /* 로딩 & 에러 */
@@ -156,18 +71,5 @@
   .volumeGrid {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     gap: 0.75rem;
-  }
-
-  .volumeInfo {
-    padding: 0.5rem;
-  }
-
-  .volumeTitle {
-    font-size: 0.8rem;
-    margin-bottom: 0.1rem;
-  }
-
-  .volumeNumber {
-    font-size: 0.7rem;
   }
 }

--- a/web/src/pages/Series.test.tsx
+++ b/web/src/pages/Series.test.tsx
@@ -90,14 +90,27 @@ vi.mock("../components/SeriesCard", () => ({
 }));
 
 vi.mock("../components/SeriesInfoCard", () => ({
-  SeriesInfoCard: ({ onPlay }: { onPlay: () => void | Promise<void> }) => (
-    <button
-      type="button"
-      data-testid="series-info-play"
-      onClick={() => void onPlay()}
-    >
-      play
-    </button>
+  SeriesInfoCard: ({
+    onPlay,
+    missingNumberRanges,
+  }: {
+    onPlay: () => void | Promise<void>;
+    missingNumberRanges?: Array<{ start: number; end: number }>;
+  }) => (
+    <>
+      <button
+        type="button"
+        data-testid="series-info-play"
+        onClick={() => void onPlay()}
+      >
+        play
+      </button>
+      {missingNumberRanges?.map((range) => (
+        <div key={`${range.start}-${range.end}`} data-testid="missing-number-range">
+          {range.start}-{range.end}
+        </div>
+      ))}
+    </>
   ),
 }));
 
@@ -184,6 +197,37 @@ describe("SeriesPage return focus", () => {
     await waitFor(() => {
       expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
     });
+  });
+});
+
+describe("SeriesPage missing number indicator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("최상위 권 번호 사이의 빈 번호를 시리즈 정보 카드에 전달한다", async () => {
+    mockSeriesPageData([
+      {
+        id: "volume-1",
+        series_id: "series-1",
+        title: "1화",
+        volume_number: 1,
+        path: "/books/1.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+      {
+        id: "volume-3",
+        series_id: "series-1",
+        title: "3화",
+        volume_number: 3,
+        path: "/books/3.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByTestId("missing-number-range")).toHaveTextContent("2-2");
   });
 });
 

--- a/web/src/pages/Series.test.tsx
+++ b/web/src/pages/Series.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type { ReactNode } from "react";
+import { rememberReturnFocus } from "../utils/returnFocus";
 import { SeriesPage } from "./Series";
 
 const { mocks } = vi.hoisted(() => {
@@ -85,7 +86,7 @@ vi.mock("../components/Sidebar", () => ({
 }));
 
 vi.mock("../components/SeriesCard", () => ({
-  SeriesCard: () => <div data-testid="series-card" />,
+  SeriesCard: ({ item }: { item: { id: string; title: string } }) => <div data-testid={`series-card-${item.id}`}>{item.title}</div>,
 }));
 
 vi.mock("../components/SeriesInfoCard", () => ({
@@ -107,6 +108,84 @@ vi.mock("../components/modals/AlertModal", () => ({
 vi.mock("../components/common/LoadingSpinner", () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner" />,
 }));
+
+const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "scrollIntoView");
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/series/series-1"]}>
+      <Routes>
+        <Route
+          path="/series/:id"
+          element={<SeriesPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+function mockSeriesPageData(volumes: unknown[] = []) {
+  mocks.apiGetMock.mockImplementation((url: string) => {
+    if (url === "/series/series-1") {
+      return Promise.resolve({
+        data: {
+          id: "series-1",
+          library_id: "library-1",
+          title: "테스트 시리즈",
+          path: "/books/series",
+          library_type: "book",
+          created_at: "2026-03-21T00:00:00Z",
+          updated_at: "2026-03-21T00:00:00Z",
+        },
+      });
+    }
+    if (url === "/series/series-1/volumes?parent_id=root") return Promise.resolve({ data: { volumes } });
+    if (url === "/series/series-1/progress") return Promise.resolve({ data: { progress: null, summary: null } });
+    if (url === "/libraries/library-1") return Promise.resolve({ data: { id: "library-1", name: "서재" } });
+    throw new Error(`Unhandled api.get(${url})`);
+  });
+}
+
+describe("SeriesPage return focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    if (originalScrollIntoViewDescriptor) {
+      Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", originalScrollIntoViewDescriptor);
+    } else {
+      Reflect.deleteProperty(window.HTMLElement.prototype, "scrollIntoView");
+    }
+  });
+
+  it("복귀한 시리즈에서 직전에 열었던 볼륨 카드를 중앙에 맞춘다", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    rememberReturnFocus("series", "series-1", "volume-7");
+    mockSeriesPageData([
+      {
+        id: "volume-7",
+        series_id: "series-1",
+        title: "7권",
+        volume_number: 7,
+        path: "/books/volume-7.zip",
+        created_at: "2026-03-21T00:00:00Z",
+      },
+    ]);
+
+    renderPage();
+
+    await screen.findByTestId("series-card-volume-7");
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    });
+  });
+});
 
 describe("SeriesPage audiobook bootstrap guard", () => {
   beforeEach(() => {

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -12,6 +12,8 @@ import { initiateDownload } from "../utils/download";
 import { useAuthStore } from "../stores/authStore";
 import { useAudioPlayerStore } from "../stores/audioPlayerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
+import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
+import { prefersReducedMotion } from "../utils/reducedMotion";
 import styles from "./Series.module.css";
 
 import type { Series, Volume, Library, ReadingProgress, SeriesProgressSummary, Chapter, SeriesCharacter } from "../types/series";
@@ -50,6 +52,7 @@ export function SeriesPage() {
     }
   };
   const [volumes, setVolumes] = useState<Volume[]>([]);
+  const volumeCardRefs = useRef<Record<string, HTMLDivElement>>({});
   const [library, setLibrary] = useState<Library | null>(null);
   const [progress, setProgress] = useState<ReadingProgress | undefined>(undefined);
   const [summary, setSummary] = useState<SeriesProgressSummary | undefined>(undefined);
@@ -180,6 +183,22 @@ export function SeriesPage() {
   useEffect(() => {
     if (id) loadData();
   }, [id, loadData]);
+
+  useEffect(() => {
+    if (!id || isLoading) return;
+
+    // App의 전역 scroll-to-top effect가 끝난 다음 프레임에 복귀 스크롤을 적용한다.
+    // StrictMode의 effect 재실행에서도 취소된 프레임은 storage를 소비하지 않는다.
+    const frameId = window.requestAnimationFrame(() => {
+      const volumeId = takeReturnFocus("series", id);
+      const target = volumeId ? volumeCardRefs.current[volumeId] : null;
+      if (!target) return;
+
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [id, isLoading, volumes]);
 
   // 시리즈 데이터가 변경될 때마다 오디오 플레이어 스토어 동기화
   useEffect(() => {
@@ -492,15 +511,29 @@ export function SeriesPage() {
             ) : (
               <div className={styles.volumeGrid}>
                 {volumes.map((volume) => (
-                  <SeriesCard
+                  <div
                     key={volume.id}
-                    item={volume}
-                    type="volume"
-                    progressStyle="overlay"
-                    extensionBadgePlacement="meta"
-                    onStatusChange={loadData}
-                    onDownload={canDownload ? () => handleDownloadVolume(volume) : undefined}
-                  />
+                    ref={(node) => {
+                      if (node) {
+                        volumeCardRefs.current[volume.id] = node;
+                      } else {
+                        delete volumeCardRefs.current[volume.id];
+                      }
+                    }}
+                    className={styles.volumeCardAnchor}
+                  >
+                    <SeriesCard
+                      item={volume}
+                      type="volume"
+                      progressStyle="overlay"
+                      extensionBadgePlacement="meta"
+                      onStatusChange={loadData}
+                      onBeforeNavigate={() => {
+                        if (id) rememberReturnFocus("series", id, volume.id);
+                      }}
+                      onDownload={canDownload ? () => handleDownloadVolume(volume) : undefined}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { Folder } from "lucide-react";
@@ -14,6 +14,7 @@ import { useAudioPlayerStore } from "../stores/audioPlayerStore";
 import { buildViewerRouteState } from "../utils/viewerRouteState";
 import { rememberReturnFocus, takeReturnFocus } from "../utils/returnFocus";
 import { prefersReducedMotion } from "../utils/reducedMotion";
+import { findMissingNumberRanges } from "../utils/missingNumbers";
 import styles from "./Series.module.css";
 
 import type { Series, Volume, Library, ReadingProgress, SeriesProgressSummary, Chapter, SeriesCharacter } from "../types/series";
@@ -76,6 +77,10 @@ export function SeriesPage() {
   const user = useAuthStore((state) => state.user);
   const canDownload = user?.role === "MASTER" || user?.can_download;
   const seriesTitle = series?.display_title || series?.title || "";
+  const missingNumberRanges = useMemo(
+    () => findMissingNumberRanges(volumes.map((volume) => volume.volume_number)),
+    [volumes],
+  );
   const preferPercentLabel =
     volumes.length > 0 &&
     volumes.every((volume) => {
@@ -420,6 +425,7 @@ export function SeriesPage() {
               progress={progress}
               summary={summary}
               preferPercentLabel={preferPercentLabel}
+              missingNumberRanges={missingNumberRanges}
               onUpdate={handleUpdate}
               onRefresh={loadData}
               onAlert={showAlert}

--- a/web/src/utils/missingNumbers.test.ts
+++ b/web/src/utils/missingNumbers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { findMissingNumberRanges, formatMissingNumberRanges } from "./missingNumbers";
+
+describe("findMissingNumberRanges", () => {
+  it("등록된 회차 번호 사이의 빈 번호를 범위로 반환한다", () => {
+    expect(findMissingNumberRanges([1, 3, 4, 5, 7, 9, 10])).toEqual([
+      { start: 2, end: 2 },
+      { start: 6, end: 6 },
+      { start: 8, end: 8 },
+    ]);
+  });
+
+  it("연속된 누락 번호를 하나의 범위로 묶는다", () => {
+    expect(findMissingNumberRanges([1, 5])).toEqual([{ start: 2, end: 4 }]);
+  });
+
+  it("중복, 0 이하, 소수 번호는 누락 계산에서 제외한다", () => {
+    expect(findMissingNumberRanges([0, 1, 1, 1.5, 3, -2, 5])).toEqual([
+      { start: 2, end: 2 },
+      { start: 4, end: 4 },
+    ]);
+  });
+
+  it("처음 번호 앞이나 마지막 번호 뒤의 번호는 추정하지 않는다", () => {
+    expect(findMissingNumberRanges([3, 4, 5])).toEqual([]);
+  });
+
+  it("누락 번호는 화면에서 각각의 화 또는 권으로 표시할 수 있게 펼친다", () => {
+    expect(formatMissingNumberRanges([{ start: 2, end: 4 }, { start: 7, end: 7 }], "화")).toBe("2화, 3화, 4화, 7화");
+  });
+});

--- a/web/src/utils/missingNumbers.ts
+++ b/web/src/utils/missingNumbers.ts
@@ -1,0 +1,31 @@
+export interface NumberRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * 등록된 양의 정수 번호 사이에서 비어 있는 번호를 연속 범위로 찾습니다.
+ * 첫 등록 번호 앞이나 마지막 등록 번호 뒤의 번호는 추정하지 않습니다.
+ */
+export function findMissingNumberRanges(numbers: number[]): NumberRange[] {
+  const sorted = [...new Set(numbers.filter((number) => Number.isInteger(number) && number > 0))].sort((a, b) => a - b);
+  const ranges: NumberRange[] = [];
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const previous = sorted[index - 1];
+    const current = sorted[index];
+
+    if (current - previous > 1) {
+      ranges.push({ start: previous + 1, end: current - 1 });
+    }
+  }
+
+  return ranges;
+}
+
+/** 누락 범위를 각 번호의 단위 표기로 펼쳐 반환합니다. */
+export function formatMissingNumberRanges(ranges: NumberRange[], unit: string): string {
+  return ranges
+    .flatMap(({ start, end }) => Array.from({ length: end - start + 1 }, (_, index) => `${start + index}${unit}`))
+    .join(", ");
+}

--- a/web/src/utils/reducedMotion.test.ts
+++ b/web/src/utils/reducedMotion.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prefersReducedMotion } from "./reducedMotion";
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  it("returns false when matchMedia is unavailable", () => {
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: undefined });
+
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it("returns the reduced-motion media-query result", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+
+    expect(prefersReducedMotion()).toBe(true);
+  });
+});

--- a/web/src/utils/reducedMotion.ts
+++ b/web/src/utils/reducedMotion.ts
@@ -1,0 +1,6 @@
+/** Returns whether the user requests reduced motion, with safe defaults for non-browser environments. */
+export function prefersReducedMotion() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+}

--- a/web/src/utils/returnFocus.test.ts
+++ b/web/src/utils/returnFocus.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rememberReturnFocus, takeReturnFocus } from "./returnFocus";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.sessionStorage.clear();
+});
+
+describe("returnFocus", () => {
+  it("stores and consumes the focused item only for its matching parent route", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+
+    expect(takeReturnFocus("library", "library-2")).toBeNull();
+    expect(takeReturnFocus("library", "library-1")).toBe("series-42");
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("does not throw when session storage writes fail", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(() => rememberReturnFocus("library", "library-1", "series-42")).not.toThrow();
+  });
+
+  it("returns null when session storage reads fail", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("returns null when clearing a consumed focus target fails", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+
+    expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("keeps library and series return targets isolated", () => {
+    rememberReturnFocus("library", "library-1", "series-42");
+    rememberReturnFocus("series", "series-42", "volume-7");
+
+    expect(takeReturnFocus("series", "series-42")).toBe("volume-7");
+    expect(takeReturnFocus("library", "library-1")).toBe("series-42");
+  });
+});

--- a/web/src/utils/returnFocus.test.ts
+++ b/web/src/utils/returnFocus.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { rememberReturnFocus, takeReturnFocus } from "./returnFocus";
+import { rememberReturnFocus, rememberViewerReturnFocus, takeReturnFocus } from "./returnFocus";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -38,6 +38,18 @@ describe("returnFocus", () => {
     });
 
     expect(takeReturnFocus("library", "library-1")).toBeNull();
+  });
+
+  it("updates a series return target from the last viewed volume", () => {
+    rememberViewerReturnFocus("/volumes/volume-1", "series-1", "volume-150");
+
+    expect(takeReturnFocus("series", "series-1")).toBe("volume-150");
+  });
+
+  it("does not create a return target for unrelated viewer origins", () => {
+    rememberViewerReturnFocus("/settings", "series-1", "volume-150");
+
+    expect(takeReturnFocus("series", "series-1")).toBeNull();
   });
 
   it("keeps library and series return targets isolated", () => {

--- a/web/src/utils/returnFocus.ts
+++ b/web/src/utils/returnFocus.ts
@@ -1,0 +1,31 @@
+export type ReturnFocusScope = "library" | "series";
+
+const STORAGE_PREFIX = "kumiho:return-focus";
+
+function getStorageKey(scope: ReturnFocusScope, parentId: string) {
+  return `${STORAGE_PREFIX}:${scope}:${parentId}`;
+}
+
+/**
+ * Remembers the card that initiated a detail-page navigation so that returning
+ * to its parent collection can put that card back in view exactly once.
+ */
+export function rememberReturnFocus(scope: ReturnFocusScope, parentId: string, itemId: string) {
+  try {
+    window.sessionStorage.setItem(getStorageKey(scope, parentId), itemId);
+  } catch {
+    // Browsers may block storage in private or restrictive contexts.
+  }
+}
+
+/** Returns and clears a pending focus target for this exact parent route. */
+export function takeReturnFocus(scope: ReturnFocusScope, parentId: string) {
+  try {
+    const key = getStorageKey(scope, parentId);
+    const itemId = window.sessionStorage.getItem(key);
+    window.sessionStorage.removeItem(key);
+    return itemId;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/utils/returnFocus.ts
+++ b/web/src/utils/returnFocus.ts
@@ -29,3 +29,18 @@ export function takeReturnFocus(scope: ReturnFocusScope, parentId: string) {
     return null;
   }
 }
+
+/**
+ * 뷰어에서 시리즈 또는 볼륨 경로로 나갈 때 시리즈 페이지의
+ * 복귀 스크롤 대상을 마지막으로 읽은 볼륨으로 갱신합니다.
+ */
+export function rememberViewerReturnFocus(
+  viewerFrom: string | undefined,
+  seriesId: string | null | undefined,
+  volumeId: string | null | undefined,
+) {
+  if (!viewerFrom || !seriesId || !volumeId) return;
+  if (!/^\/(?:series|volumes)\/[^/?#]+(?:[/?#]|$)/.test(viewerFrom)) return;
+
+  rememberReturnFocus("series", seriesId, volumeId);
+}


### PR DESCRIPTION
## 변경 사항
- v0.17.0 정식 release 버전 범프
- `backend/internal/version/version.go`: `v0.16.6-beta.5` → `v0.17.0`
- `web/package.json` / `web/package-lock.json`: `0.16.6-beta.5` → `0.17.0`

## 포함된 기능 (v0.16.5 이후)
- feat(series): 누락 회차 표시 기능 (#330, #331)
- feat: 뷰어 나갈 때 마지막으로 읽은 볼륨을 시리즈 복귀 스크롤 대상으로 갱신
- feat: 상세 페이지 복귀 시 직전에 열었던 카드로 스크롤 복구
- feat(viewer): 등장인물 편집 카드 이미지 액션과 수정/삭제 버튼을 같은 행으로 배치
- fix(viewer): #324 뷰어 마지막 페이지에서 다음 권 이동 시 slide 애니메이션 억제

## 테스트
- [x] Vitest 46 files / 330 tests passed
- [x] ESLint 통과
- [x] TypeScript 빌드 통과